### PR TITLE
add attributes to configure bidirational binding

### DIFF
--- a/src/components/checkbox/checkbox-base.ts
+++ b/src/components/checkbox/checkbox-base.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
 import { Constructor } from '../common/mixins/constructor.js';
-import { alternateName } from '../common/decorators/alternateName.js';
+import { alternateName, blazorTwoWayBind } from '../common/decorators';
 
 export interface IgcCheckboxEventMap {
   igcChange: CustomEvent<boolean>;
@@ -31,6 +31,7 @@ export class IgcCheckboxBaseComponent extends EventEmitterMixin<
 
   /** The checked state of the control. */
   @property({ type: Boolean })
+  @blazorTwoWayBind('igcChange', 'detail')
   public checked = false;
 
   /** Makes the control a required field. */

--- a/src/components/common/decorators/blazorTwoWayBind.ts
+++ b/src/components/common/decorators/blazorTwoWayBind.ts
@@ -1,0 +1,9 @@
+/**
+ * Indicates that a property will be updated from the inside, paired with an event, so can be used for bidirectional binding.
+ * @param _eventName the name of the event that will be fired when the value changes.
+ * @param _argsPath indicated the path to the updated value withing the event arguments.
+ * @returns a function that does nothing, given that this decorator is for static analysis only.
+ */
+export function blazorTwoWayBind(_eventName: string, _argsPath: string) {
+  return (_descriptor: any, _memberName: string): any => {};
+}

--- a/src/components/common/decorators/index.ts
+++ b/src/components/common/decorators/index.ts
@@ -1,3 +1,4 @@
 export * from './watch';
 export * from './alternateName';
 export * from './blazorSuppress';
+export * from './blazorTwoWayBind';

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -10,7 +10,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 import { styles } from './input.material.css';
 import { Constructor } from '../common/mixins/constructor.js';
-import { alternateName, watch } from '../common/decorators';
+import { alternateName, watch, blazorTwoWayBind } from '../common/decorators';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
 import { partNameMap } from '../common/util';
 import { SizableMixin } from '../common/mixins/sizable';
@@ -113,6 +113,7 @@ export default class IgcInputComponent extends SizableMixin(
 
   /** The value attribute of the control. */
   @property()
+  @blazorTwoWayBind('igcChange', 'detail')
   public value = '';
 
   /** The pattern attribute of the control. */

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -3,7 +3,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { styles } from './radio.material.css';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
 import { Constructor } from '../common/mixins/constructor.js';
-import { alternateName, watch } from '../common/decorators';
+import { alternateName, watch, blazorTwoWayBind } from '../common/decorators';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 import { partNameMap } from '../common/util.js';
@@ -56,6 +56,7 @@ export default class IgcRadioComponent extends EventEmitterMixin<
 
   /** The checked state of the control. */
   @property({ type: Boolean })
+  @blazorTwoWayBind('igcChange', 'detail')
   public checked = false;
 
   /** Disables the radio control. */


### PR DESCRIPTION
at the blazor level

This includes a new decorator and applies it in a few places. This has no runtime implications but serves as a hint for how to arrange the blazor wrapper in order to support bidirectional binding for the annotated property.