### PR TITLE
refactor(bootstrap-theme): improve styles

### DIFF
--- a/src/components/button/button.bootstrap.scss
+++ b/src/components/button/button.bootstrap.scss
@@ -1,7 +1,10 @@
 @use '../../styles/utilities' as utils;
 
+$focus-outline: var(--igc-outline-size);
+
 @mixin theme() {
     igc-button::part(base) {
+        margin: $focus-outline;
         transition: all .15s ease-out;
 
         &::before {
@@ -50,7 +53,7 @@
         &:focus,
         &:active {
             color: #{utils.color(primary, 600)};
-            box-shadow: 0 0 0 utils.rem(4px) utils.color(primary, 200, .5);
+            box-shadow: 0 0 0 $focus-outline utils.color(primary, 200, .5);
         }
 
         &:hover::before {
@@ -74,7 +77,7 @@
         &:focus,
         &:active {
             color: #{utils.contrast-color(primary, 600)};
-            box-shadow: 0 0 0 utils.rem(4px) utils.color(primary, 200, .5);
+            box-shadow: 0 0 0 $focus-outline utils.color(primary, 200, .5);
         }
 
         &::before {
@@ -126,7 +129,7 @@
 
         &:focus::after,
         &:active::after {
-            box-shadow: 0 0 0 utils.rem(4px) utils.color(primary, 200, .5);
+            box-shadow: 0 0 0 $focus-outline utils.color(primary, 200, .5);
         }
     }
 
@@ -152,7 +155,7 @@
         &:focus,
         &:active {
             color: #{utils.contrast-color(primary, 600)};
-            box-shadow: 0 0 0 utils.rem(4px) utils.color(primary, 200, .5);
+            box-shadow: 0 0 0 $focus-outline utils.color(primary, 200, .5);
         }
 
         &::before {

--- a/src/components/button/icon-button.bootstrap.scss
+++ b/src/components/button/icon-button.bootstrap.scss
@@ -1,7 +1,10 @@
 @use '../../styles/utilities' as utils;
 
+$focus-outline: var(--igc-outline-size);
+
 @mixin theme() {
     igc-icon-button::part(base) {
+        margin: $focus-outline;
         border-radius: utils.rem(4px);
         transition: box-shadow .15s ease-out,
             color .15s ease-out,

--- a/src/components/checkbox/checkbox.bootstrap.scss
+++ b/src/components/checkbox/checkbox.bootstrap.scss
@@ -1,6 +1,20 @@
 @use '../../styles/utilities' as utils;
 
+$focus-outline: var(--igc-outline-size);
+
 @mixin theme() {
+    igc-checkbox::part(control) {
+        margin: $focus-outline;
+    }
+
+    igc-checkbox[label-position='after']::part(label) {
+        margin-inline-start: $focus-outline;
+    }
+
+    igc-checkbox[label-position='before']::part(label) {
+        margin-inline-end: $focus-outline;
+    }
+
     igc-checkbox::part(control) {
         $size: var(--size, utils.rem(16px));
         width: $size;
@@ -37,7 +51,7 @@
     }
 
     igc-checkbox:focus-within::part(control) {
-        box-shadow: 0 0 0 4px #{utils.color(primary, 100)};
+        box-shadow: 0 0 0 $focus-outline #{utils.color(primary, 100)};
 
         &::after {
             box-shadow: inset 0 0 0 1px #{utils.color(primary, 500)};
@@ -76,7 +90,7 @@
     igc-checkbox[invalid]:focus-within::part(control),
     igc-checkbox[invalid]:focus-within::part(control checked),
     igc-checkbox[invalid][indeterminate]:focus-within::part(control) {
-        box-shadow: 0 0 0 4px #{utils.color(error, 100)};
+        box-shadow: 0 0 0 $focus-outline #{utils.color(error, 100)};
     }
 
     igc-checkbox[disabled]::part(control),

--- a/src/components/checkbox/switch.bootstrap.scss
+++ b/src/components/checkbox/switch.bootstrap.scss
@@ -1,18 +1,22 @@
 @use '../../styles/utilities' as utils;
 
+$focus-outline: var(--igc-outline-size);
+
 @mixin theme() {
     igc-switch {
         --size: #{utils.rem(32px)};
-        --thumb-size: #{utils.rem(8px)};
-        --thumb-offset: calc(var(--thumb-size) / 2);
+        --thumb-size: #{utils.rem(10px)};
+        --thumb-offset: calc((var(--thumb-size) / 2) - #{utils.rem(2px)});
     }
 
     igc-switch::part(control) {
+        margin: $focus-outline;
         width: var(--size);
         height: utils.rem(16px);
         box-shadow: inset 0 0 0 1px #{utils.color(gray, 500)};
-        border-radius: utils.rem(4px);
+        border-radius: var(--size);
         background: transparent;
+        transition-duration: 0;
 
         &::after {
             content: '';
@@ -23,16 +27,24 @@
         }
     }
 
+    igc-switch[label-position='after']::part(label) {
+        margin-inline-start: $focus-outline;
+    }
+
+    igc-switch[label-position='before']::part(label) {
+        margin-inline-end: $focus-outline;
+    }
+
     igc-switch:focus-within::part(control) {
-        box-shadow: 0 0 0 2px #{utils.color(primary, 100)};
+        box-shadow: 0 0 0 $focus-outline #{utils.color(primary, 100)};
 
         &::after {
-            border: 1px solid #{utils.color(primary, 500)};
+            border: 1px solid #{utils.color(primary, 200)};
         }
     }
 
     igc-switch:focus-within::part(control checked) {
-        box-shadow: 0 0 0 2px #{utils.color(primary, 200)};
+        box-shadow: 0 0 0 $focus-outline #{utils.color(primary, 100)};
 
         &::after {
             border: 1px solid #{utils.color(primary, 500)};
@@ -55,7 +67,7 @@
     }
 
     igc-switch[invalid]:focus-within::part(control) {
-        box-shadow: 0 0 0 2px #{utils.color(error, 100)};
+        box-shadow: 0 0 0 $focus-outline #{utils.color(error, 100)};
 
         &::after {
             border: 1px solid #{utils.color(error, 500)};
@@ -63,7 +75,7 @@
     }
 
     igc-switch[invalid]:focus-within::part(control checked) {
-        box-shadow: 0 0 0 2px #{utils.color(error, 200)};
+        box-shadow: 0 0 0 $focus-outline #{utils.color(error, 100)};
 
         &::after {
             border: 1px solid #{utils.color(error, 500)};
@@ -87,8 +99,7 @@
         min-width: var(--thumb-size);
         animation-name: thumb-off;
         margin-inline-start: var(--thumb-offset);
-        background: #{utils.color(gray, 900)};
-        border-radius: utils.rem(2px);
+        background: #{utils.color(gray, 400)};
         box-shadow: none;
 
         &::after {
@@ -100,10 +111,18 @@
         }
     }
 
+    igc-switch:focus-within::part(thumb) {
+        background: #{utils.color(primary, 200)};
+    }
+
     igc-switch::part(thumb checked) {
         background: white;
         animation-name: thumb-on;
         margin-inline-start: calc(var(--size) - var(--thumb-size) - var(--thumb-offset));
+    }
+
+    igc-switch:focus-within::part(thumb checked) {
+        background: #{utils.contrast-color(primary, 600)};
     }
 
     igc-switch[disabled]::part(thumb),

--- a/src/components/input/input.bootstrap.scss
+++ b/src/components/input/input.bootstrap.scss
@@ -1,5 +1,7 @@
 @use '../../styles/utilities' as utils;
 
+$focus-outline: var(--igc-outline-size);
+
 @mixin theme() {
     igc-input,
     igc-input[outlined] {
@@ -41,7 +43,7 @@
 
         &::part(label) {
             line-height: utils.rem(24px);
-            margin-bottom: utils.rem(4px);
+            margin-inline-start: $focus-outline;
             color: utils.color(gray, 700);
             font-size: initial;
 
@@ -52,6 +54,7 @@
 
         &::part(container) {
             border: none;
+            margin: $focus-outline;
             grid-template-columns: auto 1fr auto;
 
             &::after {
@@ -63,14 +66,14 @@
         &::part(suffix) {
             position: relative;
             padding: rem(16px);
-            border-radius: none;
+            border-radius: 0;
             min-width: auto;
             color: utils.color(gray, 800);
             background: utils.color(gray, 300);
             transition: box-shadow .15s ease-out, border .15s ease-out;
 
             &:focus-within {
-                box-shadow: 0 0 0 utils.rem(4px) utils.color(gray, 300, .38);
+                box-shadow: 0 0 0 $focus-outline utils.color(gray, 300, .38);
             }
         }
 
@@ -163,14 +166,14 @@
 
     igc-input:focus-within {
         &::part(input) {
-            box-shadow: 0 0 0 utils.rem(4px) utils.color(primary, 500, .38);
+            box-shadow: 0 0 0 $focus-outline utils.color(primary, 500, .38);
             border-color: utils.color(primary, 500);
         }
     }
 
     igc-input[invalid]:focus-within {
         &::part(input) {
-            box-shadow: 0 0 0 utils.rem(4px) utils.color(error, 500, .38);
+            box-shadow: 0 0 0 $focus-outline utils.color(error, 500, .38);
             border-color: utils.color(error, 500);
         }
     }
@@ -196,7 +199,7 @@
 
     igc-input:focus-within[readonly] {
         &::part(input) {
-            box-shadow: 0 0 0 utils.rem(4px) utils.color(gray, 400, .38);
+            box-shadow: 0 0 0 $focus-outline utils.color(gray, 400, .38);
             border-color: utils.color(gray, 400);
         }
     }

--- a/src/components/radio/radio.bootstrap.scss
+++ b/src/components/radio/radio.bootstrap.scss
@@ -1,5 +1,7 @@
 @use '../../styles/utilities' as utils;
 
+$focus-outline: var(--igc-outline-size);
+
 @mixin theme() {
     igc-radio {
         &::part(base) {
@@ -9,6 +11,7 @@
 
     igc-radio::part(control) {
         $size: var(--size, utils.rem(16px));
+        margin: $focus-outline;
         width: $size;
         height: $size;
         min-width: $size;
@@ -31,6 +34,14 @@
             border-color: #{utils.color(gray, 400)};
             border-width: calc(var(--size, #{utils.rem(10px)}) / 10);
         }
+    }
+
+    igc-radio[label-position='after']::part(label) {
+        margin-inline-start: $focus-outline;
+    }
+
+    igc-radio[label-position='before']::part(label) {
+        margin-inline-end: $focus-outline;
     }
 
     igc-radio:focus-within::part(control) {

--- a/src/styles/themes/bootstrap.scss
+++ b/src/styles/themes/bootstrap.scss
@@ -179,6 +179,7 @@ $type-scale: utils.extend($_base-scale, (
     --igc-spacing-small: #{utils.rem(2px)};
     --igc-spacing-medium: #{utils.rem(4px)};
     --igc-spacing-large: #{utils.rem(8px)};
+    --igc-outline-size: #{utils.rem(4px)};
     @include utils.palette($palette);
     @include utils.elevations($elevations);
     @include utils.typography(


### PR DESCRIPTION
related to #134

1. Adding margin around all elements with outline border.
2. Fix the styles for switch element to match the bootstrap v5 styles

