### PR TITLE
docs: Expose changelog command through npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint:styles": "stylelint \"src/**/*.scss\"",
     "format": "eslint --ext .ts . --fix --ignore-path .gitignore && prettier \"**/*.ts\" --write --ignore-path .gitignore",
     "format:stories": "prettier \"**/*.stories.ts\" --write --ignore-path .gitignore",
+    "release": "changelog",
     "test": "npm run build && wtr --coverage",
     "test:watch": "npm run build && concurrently -k -r \"npm:watch-scss\" \"npm:watch-ts\" \"wtr --watch\"",
     "storybook": "npm run build && concurrently -k -r \"npm:watch-scss\" \"npm:watch-ts\" \"npm:watch-meta\" \"wds -c .storybook/server.mjs\"",


### PR DESCRIPTION
Generate a keep a changelog release notes.
Run the command with
`npm run release -- --release [version]`