### PR TITLE
feat(a11y): fix a11y tests

### DIFF
--- a/src/components/avatar/avatar.spec.ts
+++ b/src/components/avatar/avatar.spec.ts
@@ -11,7 +11,7 @@ describe('Avatar', () => {
       html`<igc-avatar></igc-avatar>`
     );
 
-    expect(el).shadowDom.to.be.accessible();
+    await expect(el).shadowDom.to.be.accessible();
   });
 
   it('should initialize avatar component with default values', async () => {

--- a/src/components/badge/badge.spec.ts
+++ b/src/components/badge/badge.spec.ts
@@ -9,7 +9,7 @@ describe('Badge', () => {
   it('passes the a11y audit', async () => {
     const el = await fixture<IgcBadgeComponent>(html`<igc-badge></igc-badge>`);
 
-    expect(el).shadowDom.to.be.accessible();
+    await expect(el).shadowDom.to.be.accessible();
   });
 
   it('should initialize with default values', async () => {

--- a/src/components/button/button-base.ts
+++ b/src/components/button/button-base.ts
@@ -21,6 +21,8 @@ export abstract class IgcButtonBaseComponent extends SizableMixin(
   @query('[part="base"]', true)
   private nativeElement!: HTMLElement;
 
+  private _ariaLabel!: string;
+
   /**
    * The type of the button. Defaults to undefined.
    */
@@ -53,6 +55,24 @@ export abstract class IgcButtonBaseComponent extends SizableMixin(
   @property({ type: Boolean, reflect: true })
   public disabled = false;
 
+  public set ariaLabel(value: string) {
+    const oldVal = this._ariaLabel;
+    this._ariaLabel = value;
+
+    if (this.hasAttribute('aria-label')) {
+      this.removeAttribute('aria-label');
+    }
+    this.requestUpdate('ariaLabel', oldVal);
+  }
+
+  /**
+   * The aria label of the button.
+   */
+  @property({ attribute: 'aria-label' })
+  public get ariaLabel() {
+    return this._ariaLabel;
+  }
+
   /** Sets focus in the button. */
   @alternateName('focusComponent')
   public focus(options?: FocusOptions) {
@@ -81,6 +101,7 @@ export abstract class IgcButtonBaseComponent extends SizableMixin(
     return html`
       <button
         part="base"
+        aria-label=${ifDefined(this.ariaLabel)}
         .disabled=${this.disabled}
         class=${classMap(this.classes)}
         type=${ifDefined(this.type)}
@@ -102,6 +123,7 @@ export abstract class IgcButtonBaseComponent extends SizableMixin(
         download=${ifDefined(this.download)}
         rel=${ifDefined(this.rel)}
         aria-disabled=${this.disabled ? 'true' : 'false'}
+        aria-label=${ifDefined(this.ariaLabel)}
         class=${classMap(this.classes)}
         @focus=${this.handleFocus}
         @blur=${this.handleBlur}

--- a/src/components/button/button.spec.ts
+++ b/src/components/button/button.spec.ts
@@ -143,7 +143,7 @@ describe('Button component', () => {
     });
 
     it('renders a button element successfully', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
       expect(el).shadowDom.to.equal(`<button/>`, {
         ignoreChildren: ['button'],
         ignoreAttributes: ['class', 'part'],
@@ -239,7 +239,9 @@ describe('Button component', () => {
     );
   });
 
-  const createButtonComponent = (template = '<igc-button/>') => {
+  const createButtonComponent = (
+    template = '<igc-button>Click</igc-button>'
+  ) => {
     return fixture<IgcButtonComponent>(html`${unsafeStatic(template)}`);
   };
 });
@@ -257,7 +259,7 @@ describe('LinkButton component', () => {
     });
 
     it('renders an anchor element successfully', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
       expect(el).shadowDom.to.equal(
         `<a aria-disabled="false" class="${classValue(
           `contained medium`
@@ -386,7 +388,9 @@ describe('LinkButton component', () => {
     );
   });
 
-  const createLinkButtonComponent = (template = '<igc-button href="/"/>') => {
+  const createLinkButtonComponent = (
+    template = '<igc-button href="/">Click</igc-button>'
+  ) => {
     return fixture<IgcButtonComponent>(html`${unsafeStatic(template)}`);
   };
 });

--- a/src/components/button/icon-button.spec.ts
+++ b/src/components/button/icon-button.spec.ts
@@ -14,7 +14,7 @@ describe('IconButton component', () => {
 
   const DIFF_OPTIONS = {
     ignoreChildren: ['a'],
-    ignoreAttributes: ['aria-disabled', 'part', 'role'],
+    ignoreAttributes: ['aria-label', 'aria-disabled', 'part', 'role'],
   };
   let el: IgcIconButtonComponent;
 
@@ -24,10 +24,11 @@ describe('IconButton component', () => {
     });
 
     it('renders a button element internally', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
       expect(el).shadowDom.to.equal(`<button><igc-icon></igc-icon></button>`, {
         ignoreAttributes: [
           'variant',
+          'aria-label',
           'aria-disabled',
           'aria-hidden',
           'part',
@@ -41,10 +42,11 @@ describe('IconButton component', () => {
       el.href = 'https://test.com';
       await elementUpdated(el);
 
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
       expect(el).shadowDom.to.equal(`<a><igc-icon></igc-icon></a>`, {
         ignoreAttributes: [
           'variant',
+          'aria-label',
           'aria-disabled',
           'aria-hidden',
           'part',
@@ -79,6 +81,7 @@ describe('IconButton component', () => {
         {
           ignoreAttributes: [
             'variant',
+            'aria-label',
             'aria-disabled',
             'aria-hidden',
             'part',
@@ -100,6 +103,7 @@ describe('IconButton component', () => {
         {
           ignoreAttributes: [
             'variant',
+            'aria-label',
             'aria-disabled',
             'aria-hidden',
             'part',
@@ -159,7 +163,14 @@ describe('IconButton component', () => {
           <igc-icon></igc-icon>
         </button>`,
         {
-          ignoreAttributes: ['aria-hidden', 'part', 'role', 'size', 'variant'],
+          ignoreAttributes: [
+            'aria-label',
+            'aria-hidden',
+            'part',
+            'role',
+            'size',
+            'variant',
+          ],
         }
       );
     });
@@ -186,7 +197,9 @@ describe('IconButton component', () => {
       DIFF_OPTIONS
     );
   });
-  const createIconButtonComponent = (template = '<igc-icon-button/>') => {
+  const createIconButtonComponent = (
+    template = '<igc-icon-button aria-label="Icon button"/>'
+  ) => {
     return fixture<IgcIconButtonComponent>(html`${unsafeStatic(template)}`);
   };
 });

--- a/src/components/calendar/calendar-keyboard-navigation.spec.ts
+++ b/src/components/calendar/calendar-keyboard-navigation.spec.ts
@@ -25,7 +25,7 @@ describe('Calendar Rendering', () => {
     });
 
     it('passes the a11y audit', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(daysView).shadowDom.to.be.accessible();
     });
 
     it('successfully switches to next month by pressing PageDown', async () => {

--- a/src/components/calendar/calendar-rendering.spec.ts
+++ b/src/components/calendar/calendar-rendering.spec.ts
@@ -20,7 +20,7 @@ describe('Calendar Rendering', () => {
     });
 
     it('passes the a11y audit', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
     });
 
     it('renders calendar successfully', async () => {

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -622,7 +622,11 @@ export default class IgcCalendarComponent extends SizableMixin(
               aria-label=${this.previousButtonLabel}
               @click=${this.navigatePrevious}
             >
-              <igc-icon name="navigate_before" collection="internal"></igc-icon>
+              <igc-icon
+                aria-hidden="true"
+                name="navigate_before"
+                collection="internal"
+              ></igc-icon>
             </button>
             <button
               part=${partNameMap({
@@ -632,7 +636,11 @@ export default class IgcCalendarComponent extends SizableMixin(
               aria-label=${this.nextButtonLabel}
               @click=${this.navigateNext}
             >
-              <igc-icon name="navigate_next" collection="internal"></igc-icon>
+              <igc-icon
+                aria-hidden="true"
+                name="navigate_next"
+                collection="internal"
+              ></igc-icon>
             </button>
           </div>`
         : ''}

--- a/src/components/card/card.spec.ts
+++ b/src/components/card/card.spec.ts
@@ -23,7 +23,7 @@ describe('Card Component', () => {
 
   it('a11y audit', async () => {
     el = await fixture<IgcCardComponent>(html`<igc-card></igc-card>`);
-    expect(el).shadowDom.to.be.accessible();
+    await expect(el).shadowDom.to.be.accessible();
   });
 
   it('check the default outlined value', async () => {

--- a/src/components/checkbox/checkbox.spec.ts
+++ b/src/components/checkbox/checkbox.spec.ts
@@ -52,7 +52,7 @@ describe('Checkbox', () => {
     });
 
     it('should render a checkbox component successfully', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
     });
 
     it('should set the checkbox name property correctly', async () => {

--- a/src/components/checkbox/switch.spec.ts
+++ b/src/components/checkbox/switch.spec.ts
@@ -50,7 +50,7 @@ describe('Switch', () => {
     });
 
     it('should render a switch component successfully', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
     });
 
     it('should set the switch name property correctly', async () => {

--- a/src/components/form/form.spec.ts
+++ b/src/components/form/form.spec.ts
@@ -20,7 +20,7 @@ describe('Form', () => {
   it('passes the a11y audit', async () => {
     const el = await fixture<IgcFormComponent>(html`<igc-form></igc-form>`);
 
-    expect(el).shadowDom.to.be.accessible();
+    await expect(el).shadowDom.to.be.accessible();
   });
 
   it('displays content', async () => {

--- a/src/components/icon/icon.spec.ts
+++ b/src/components/icon/icon.spec.ts
@@ -28,10 +28,10 @@ describe('Icon component', () => {
 
   it('passes the a11y audit', async () => {
     const el = await fixture<IgcIconComponent>(
-      html`<igc-icon name="bug"></igc-icon>`
+      html`<igc-icon name="bug" aria-label="Bug icon"></igc-icon>`
     );
 
-    expect(el).to.be.accessible();
+    await expect(el).to.be.accessible();
   });
 
   it('should render icon with a name and default collection', async () => {

--- a/src/components/list/list.spec.ts
+++ b/src/components/list/list.spec.ts
@@ -23,7 +23,7 @@ describe('List', () => {
     });
 
     it('passes the a11y audit', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
     });
 
     it('renders list with items', async () => {

--- a/src/components/nav-drawer/nav-drawer.spec.ts
+++ b/src/components/nav-drawer/nav-drawer.spec.ts
@@ -30,7 +30,7 @@ describe('Navigation Drawer', () => {
     });
 
     it('passes the a11y audit', async () => {
-      expect(el).shadowDom.to.be.accessible();
+      await expect(el).shadowDom.to.be.accessible();
     });
 
     it('renders nav drawer with items', async () => {

--- a/src/components/navbar/navbar.spec.ts
+++ b/src/components/navbar/navbar.spec.ts
@@ -11,7 +11,7 @@ describe('Navbar component', () => {
       html`<igc-navbar></igc-navbar>`
     );
 
-    expect(el).shadowDom.to.be.accessible();
+    await expect(el).shadowDom.to.be.accessible();
   });
 
   it('displays content', async () => {

--- a/src/components/radio-group/radio-group.spec.ts
+++ b/src/components/radio-group/radio-group.spec.ts
@@ -27,7 +27,7 @@ describe('Radio Group Component', () => {
     });
 
     it('renders a radio element successfully', async () => {
-      expect(group).shadowDom.to.be.accessible();
+      await expect(group).shadowDom.to.be.accessible();
     });
 
     it('sets alignment properly', async () => {
@@ -118,7 +118,8 @@ describe('Radio Group Component', () => {
   const createRadioGroupComponent = (
     template = html`<igc-radio-group>
       ${values.map(
-        (value) => html`<igc-radio name="fruit" value=${value}></igc-radio>`
+        (value) =>
+          html`<igc-radio name="fruit" value=${value}>${value}</igc-radio>`
       )}
     </igc-radio-group>`
   ) => {

--- a/src/components/radio/radio.spec.ts
+++ b/src/components/radio/radio.spec.ts
@@ -50,7 +50,7 @@ describe('Radio Component', () => {
     });
 
     it('renders a radio element successfully', async () => {
-      expect(radio).shadowDom.to.be.accessible();
+      await expect(radio).shadowDom.to.be.accessible();
     });
 
     it('sets label position properly', async () => {

--- a/stories/button.stories.ts
+++ b/stories/button.stories.ts
@@ -56,6 +56,11 @@ const metadata = {
       control: 'boolean',
       defaultValue: false,
     },
+    ariaLabel: {
+      type: 'string',
+      description: 'The aria label of the button.',
+      control: 'text',
+    },
     size: {
       type: '"small" | "medium" | "large"',
       description: 'Determines the size of the component.',
@@ -76,6 +81,7 @@ interface ArgTypes {
   target: '_blank' | '_parent' | '_self' | '_top' | undefined;
   rel: string;
   disabled: boolean;
+  ariaLabel: string;
   size: 'small' | 'medium' | 'large';
 }
 // endregion

--- a/stories/icon-button.stories.ts
+++ b/stories/icon-button.stories.ts
@@ -76,6 +76,11 @@ const metadata = {
       control: 'boolean',
       defaultValue: false,
     },
+    ariaLabel: {
+      type: 'string',
+      description: 'The aria label of the button.',
+      control: 'text',
+    },
     size: {
       type: '"small" | "medium" | "large"',
       description: 'Determines the size of the component.',
@@ -99,6 +104,7 @@ interface ArgTypes {
   target: '_blank' | '_parent' | '_self' | '_top' | undefined;
   rel: string;
   disabled: boolean;
+  ariaLabel: string;
   size: 'small' | 'medium' | 'large';
 }
 // endregion


### PR DESCRIPTION
It appears that if we don't have `await` ([docs](https://open-wc.org/docs/testing/testing-package/#chai)) on the `accessible()` expect, it fails silently. I have added `await` and fixed all accessibility issues that came up.