### PR TITLE
feat(chip): add prefix and suffix slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Chip: Added `prefix` and `suffix` slots
+
+### Deprecated
+- Chip: Previously exposed `start` and `end` slots are replaced by prefix and suffix. They remain active, but are now deprecated and will be removed in a future version.
+
 ## [3.0.0] - 2022-04-12
 ### Changed
 - **Breaking Change**: All dropdown related classes renamed from `IgcDropDown*` to `IgcDropdown*`

--- a/src/components/chip/chip.ts
+++ b/src/components/chip/chip.ts
@@ -97,10 +97,12 @@ export default class IgcChipComponent extends SizableMixin(
               </slot>`
             : nothing}
           <slot name="start"></slot>
+          <slot name="prefix"></slot>
         </span>
         <slot></slot>
         <span part="suffix">
           <slot name="end"></slot>
+          <slot name="suffix"></slot>
           ${this.removable && !this.disabled
             ? html`<slot
                 @slotchange=${this.slotChanges}

--- a/stories/chip.stories.ts
+++ b/stories/chip.stories.ts
@@ -82,7 +82,9 @@ const ChipTemplate: Story<ArgTypes, Context> = (
     dir=${direction}
     variant=${ifDefined(variant)}
   >
+    <span slot="prefix">😱</span>
     Chip
+    <span slot="suffix">👀</span>
   </igc-chip>
 `;
 


### PR DESCRIPTION
Added `prefix` and `suffix` slots as described in the component doc comment.
Deprecated the existing `start` and `end`. Didn't see a decent way to mark that in the template other than a `<!-- deprecated -->` which renders in the final output and decided to skip, let me know if we should add such comments.
