### PR TITLE
fix(expansion-panel): not working with headings

### DIFF
--- a/src/components/expansion-panel/themes/light/expansion-panel.base.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.base.scss
@@ -40,9 +40,11 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
     margin: 0;
 }
 
-[part='subtitle']::slotted(*) {
-    @include type-category('subtitle-2');
-    @include ellipsis();
+[part='subtitle'] {
+    &::slotted(*) {
+        @include type-category('subtitle-2');
+        @include ellipsis();
+    }
 
     color: color(gray, 700);
 }
@@ -75,11 +77,12 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
     display: none;
 }
 
-:host([disabled]) [part='header'] {
+:host([disabled]) {
     pointer-events: none;
 
-    [part~='indicator'],
-    ::slotted(*) {
+    [part='title'],
+    [part='subtitle'],
+    [part~='indicator'] {
         color: $disabled-color;
     }
 }

--- a/src/components/expansion-panel/themes/light/expansion-panel.base.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.base.scss
@@ -23,7 +23,7 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
         background: color(gray, 100);
     }
 
-    div:not([part='indicator']) {
+    *:not([part='indicator']) {
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -33,14 +33,14 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
     }
 }
 
-[part='title'] {
+[part='title']::slotted(*) {
     @include type-category('h5');
     @include ellipsis();
 
     margin: 0;
 }
 
-[part='subtitle'] {
+[part='subtitle']::slotted(*) {
     @include type-category('subtitle-2');
     @include ellipsis();
 
@@ -54,11 +54,11 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
     padding: $padding;
 }
 
-[part~='indicator'] {
+slot[name='indicator'] {
     color: color(gray, 800);
 }
 
-[name='indicator'] igc-icon {
+slot[name='indicator'] igc-icon {
     --size: #{rem(24px)};
 }
 
@@ -75,12 +75,11 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
     display: none;
 }
 
-:host([disabled]) {
-    [part='header'] {
-        pointer-events: none;
+:host([disabled]) [part='header'] {
+    pointer-events: none;
 
-        * {
-            color: $disabled-color;
-        }
+    slot[name='indicator'],
+    ::slotted(*) {
+        color: $disabled-color;
     }
 }

--- a/src/components/expansion-panel/themes/light/expansion-panel.base.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.base.scss
@@ -23,7 +23,7 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
         background: color(gray, 100);
     }
 
-    *:not([part='indicator']) {
+    *:not([part~='indicator']) {
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -54,11 +54,11 @@ $padding: calc(var(--igc-spacing-large) * 2) calc(var(--igc-spacing-large) * 3);
     padding: $padding;
 }
 
-slot[name='indicator'] {
+[part~='indicator'] {
     color: color(gray, 800);
 }
 
-slot[name='indicator'] igc-icon {
+[part~='indicator'] igc-icon {
     --size: #{rem(24px)};
 }
 
@@ -78,7 +78,7 @@ slot[name='indicator'] igc-icon {
 :host([disabled]) [part='header'] {
     pointer-events: none;
 
-    slot[name='indicator'],
+    [part~='indicator'],
     ::slotted(*) {
         color: $disabled-color;
     }

--- a/src/components/expansion-panel/themes/light/expansion-panel.bootstrap.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.bootstrap.scss
@@ -1,11 +1,11 @@
 @use '../../../../styles/utilities/index' as *;
 
-[part='title'],
-[part~='indicator'] {
+[part='title']::slotted(*),
+slot[name='indicator'] {
     color: color(gray, 800);
 }
 
-[part='subtitle'] {
+[part='subtitle']::slotted(*) {
     @include type-category('body-2');
 
     color: color(gray, 600);

--- a/src/components/expansion-panel/themes/light/expansion-panel.bootstrap.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.bootstrap.scss
@@ -1,7 +1,7 @@
 @use '../../../../styles/utilities/index' as *;
 
 [part='title']::slotted(*),
-slot[name='indicator'] {
+[part~='indicator'] {
     color: color(gray, 800);
 }
 

--- a/src/components/expansion-panel/themes/light/expansion-panel.bootstrap.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.bootstrap.scss
@@ -1,12 +1,14 @@
 @use '../../../../styles/utilities/index' as *;
 
-[part='title']::slotted(*),
+[part='title'],
 [part~='indicator'] {
     color: color(gray, 800);
 }
 
-[part='subtitle']::slotted(*) {
-    @include type-category('body-2');
+[part='subtitle'] {
+    &::slotted(*) {
+        @include type-category('body-2');
+    }
 
     color: color(gray, 600);
 }

--- a/src/components/expansion-panel/themes/light/expansion-panel.fluent.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.fluent.scss
@@ -14,9 +14,10 @@
     color: color(gray, 700);
 }
 
-:host([disabled]) [part='header'] {
+:host([disabled]) {
     [part~='indicator'],
-    ::slotted(*) {
+    [part='title'],
+    [part='subtitle'] {
         color: color(gray, 400);
     }
 }

--- a/src/components/expansion-panel/themes/light/expansion-panel.fluent.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.fluent.scss
@@ -1,10 +1,10 @@
 @use '../../../../styles/utilities/index' as *;
 
-[part='title'] {
+[part='title']::slotted(*) {
     @include type-category('subtitle-1');
 }
 
-[part='subtitle'] {
+[part='subtitle']::slotted(*) {
     @include type-category('body-2');
 }
 
@@ -14,8 +14,9 @@
     color: color(gray, 700);
 }
 
-:host([disabled]) {
-    [part='header'] * {
+:host([disabled]) [part='header'] {
+    slot[name='indicator'],
+    ::slotted(*) {
         color: color(gray, 400);
     }
 }

--- a/src/components/expansion-panel/themes/light/expansion-panel.fluent.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.fluent.scss
@@ -15,7 +15,7 @@
 }
 
 :host([disabled]) [part='header'] {
-    slot[name='indicator'],
+    [part~='indicator'],
     ::slotted(*) {
         color: color(gray, 400);
     }

--- a/src/components/expansion-panel/themes/light/expansion-panel.indigo.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.indigo.scss
@@ -1,19 +1,20 @@
 @use '../../../../styles/utilities/index' as *;
 
-[part~='indicator'] {
+slot[name='indicator'] {
     color: color(gray, 600);
 }
 
-[part='subtitle'] {
+[part='subtitle']::slotted(*) {
     color: color(gray, 500);
-}
-
-:host([disabled]) {
-    [part='header'] * {
-        color: color(gray, 300);
-    }
 }
 
 :host([open]) [part~='content'] {
     @include type-category('body-1');
+}
+
+:host([disabled]) [part='header'] {
+    slot[name='indicator'],
+    ::slotted(*) {
+        color: color(gray, 300);
+    }
 }

--- a/src/components/expansion-panel/themes/light/expansion-panel.indigo.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.indigo.scss
@@ -4,7 +4,7 @@
     color: color(gray, 600);
 }
 
-[part='subtitle']::slotted(*) {
+[part='subtitle'] {
     color: color(gray, 500);
 }
 
@@ -12,9 +12,10 @@
     @include type-category('body-1');
 }
 
-:host([disabled]) [part='header'] {
+:host([disabled]) {
     [part~='indicator'],
-    ::slotted(*) {
+    [part='title'],
+    [part='subtitle'] {
         color: color(gray, 300);
     }
 }

--- a/src/components/expansion-panel/themes/light/expansion-panel.indigo.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.indigo.scss
@@ -1,6 +1,6 @@
 @use '../../../../styles/utilities/index' as *;
 
-slot[name='indicator'] {
+[part~='indicator'] {
     color: color(gray, 600);
 }
 
@@ -13,7 +13,7 @@ slot[name='indicator'] {
 }
 
 :host([disabled]) [part='header'] {
-    slot[name='indicator'],
+    [part~='indicator'],
     ::slotted(*) {
         color: color(gray, 300);
     }

--- a/stories/expansion-panel.stories.ts
+++ b/stories/expansion-panel.stories.ts
@@ -72,14 +72,14 @@ const Template: Story<ArgTypes, Context> = (
       @igcClosing=${handleClosing}
       @igcClosed=${handleClosed}
     >
-      <div slot="title">The Expendables</div>
-      <div slot="subtitle">Action, Adventure, Thriller</div>
-      <div>
-        Barney Ross leads the "Expendables", a band of highly skilled
+      <h1 slot="title">The Expendables</h1>
+      <h3 slot="subtitle">Action, Adventure, Thriller</h3>
+      <span
+        >Barney Ross leads the "Expendables", a band of highly skilled
         mercenaries including knife enthusiast Lee Christmas, martial arts
         expert Yin Yang, heavy weapons specialist Hale Caesar, demolitionist
-        Toll Road and loose-cannon sniper Gunner Jensen.
-      </div>
+        Toll Road and loose-cannon sniper Gunner Jensen.</span
+      >
     </igc-expansion-panel>
   `;
 };

--- a/stories/input.stories.ts
+++ b/stories/input.stories.ts
@@ -17,15 +17,15 @@ const metadata = {
       defaultValue: 'text',
     },
     inputmode: {
-      type: '"numeric" | "email" | "search" | "tel" | "url" | "none" | "txt" | "decimal"',
+      type: '"numeric" | "none" | "email" | "search" | "tel" | "url" | "txt" | "decimal"',
       description: 'The input mode attribute of the control.',
       options: [
         'numeric',
+        'none',
         'email',
         'search',
         'tel',
         'url',
-        'none',
         'txt',
         'decimal',
       ],
@@ -139,11 +139,11 @@ interface ArgTypes {
   type: 'number' | 'email' | 'password' | 'search' | 'tel' | 'text' | 'url';
   inputmode:
     | 'numeric'
+    | 'none'
     | 'email'
     | 'search'
     | 'tel'
     | 'url'
-    | 'none'
     | 'txt'
     | 'decimal';
   pattern: string;


### PR DESCRIPTION
The expansion panel, as it was, was not working with heading elements when passed to the slots for title, subtitle, etc. Additional improvements are introduced in this PR.