### PR TITLE
fix(rating): step and line-height

### DIFF
--- a/src/components/rating/rating-symbol.base.scss
+++ b/src/components/rating/rating-symbol.base.scss
@@ -20,7 +20,6 @@
     height: var(--symbol-size);
     min-width: var(--symbol-size);
     min-height: var(--symbol-size);
-    line-height: var(--symbol-size);
     font-size: var(--symbol-size);
     font-family: sans-serif;
 

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -157,7 +157,10 @@ export default class IgcRatingComponent extends SizableMixin(
 
   @watch('single')
   protected handleSelectionChange() {
-    this.step = 1;
+    if (this.single) {
+      this.step = 1;
+      this.value = Math.ceil(this.value);
+    }
   }
 
   constructor() {


### PR DESCRIPTION
Step would be set to 1 on initial render regardless of the provided step value. Also, the current value should be ceiled when switching to single selection mode to avoid a visual glitch where the selected symbol will not show if the value is a floating number.

This PR also fixes a rendering issue in Firefox when emojis are used due to line-height being set explicitly.