### PR TITLE
fix(tabs): icon & text misalignment

### DIFF
--- a/src/components/tabs/themes/light/tab.base.scss
+++ b/src/components/tabs/themes/light/tab.base.scss
@@ -67,12 +67,12 @@ $hover-background: var(--hover-background, color(gray, 200)) !default;
     ::slotted(*) {
         @include line-clamp(2, true, true);
     }
+
+    ::slotted(igc-icon:not(:only-child)) {
+        margin-bottom: rem(8px);
+    }
 }
 
 ::slotted(igc-icon) {
     --size: #{rem(24px)};
-}
-
-::slotted(igc-icon:not(:only-child)) {
-    margin-bottom: rem(8px);
 }


### PR DESCRIPTION
Misalignment when icon and text are displayed horizontally

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/59446295/179750146-2d40601b-e62b-45b2-ba15-593f991f1303.png)

