### PR TITLE
refactor: Reduced LTR query calls and improved rating rendering

### DIFF
--- a/src/components/common/util.ts
+++ b/src/components/common/util.ts
@@ -48,3 +48,7 @@ export function createCounter() {
     return i;
   };
 }
+
+export function isLTR(element: HTMLElement) {
+  return getComputedStyle(element).getPropertyValue('direction') === 'ltr';
+}

--- a/src/components/radio-group/radio-group.ts
+++ b/src/components/radio-group/radio-group.ts
@@ -1,6 +1,7 @@
 import { html, LitElement } from 'lit';
 import { property, queryAssignedElements } from 'lit/decorators.js';
 import { defineComponents } from '../common/definitions/defineComponents.js';
+import { isLTR } from '../common/util.js';
 import IgcRadioComponent from '../radio/radio.js';
 import { styles } from './radio-group.base.css.js';
 
@@ -16,11 +17,6 @@ export default class IgcRadioGroupComponent extends LitElement {
     selector: 'igc-radio:not([disabled])',
   })
   private radios!: Array<IgcRadioComponent>;
-
-  private get isLTR(): boolean {
-    const styles = window.getComputedStyle(this);
-    return styles.getPropertyValue('direction') === 'ltr';
-  }
 
   constructor() {
     super();
@@ -53,16 +49,17 @@ export default class IgcRadioGroupComponent extends LitElement {
     if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(key)) {
       const checked = this.radios.find((radio) => radio.checked);
       let index = this.radios.indexOf(checked!);
+      const ltr = isLTR(this);
 
       switch (key) {
         case 'ArrowUp':
           index += -1;
           break;
         case 'ArrowLeft':
-          index += this.isLTR ? -1 : 1;
+          index += ltr ? -1 : 1;
           break;
         case 'ArrowRight':
-          index += this.isLTR ? 1 : -1;
+          index += ltr ? 1 : -1;
           break;
         default:
           index += 1;

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -353,6 +353,7 @@ export default class IgcRatingComponent extends SizableMixin(
       this.max,
       this.step,
       this.single,
+      this.hoverState,
       this.ratingSymbols,
     ];
 

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -1,19 +1,14 @@
 import { html, LitElement, nothing } from 'lit';
-import {
-  property,
-  query,
-  queryAssignedElements,
-  queryAssignedNodes,
-  state,
-} from 'lit/decorators.js';
+import { property, query, queryAssignedNodes, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import { guard } from 'lit/directives/guard.js';
 import { themes } from '../../theming/theming-decorator.js';
 import { watch } from '../common/decorators/watch.js';
 import { Constructor } from '../common/mixins/constructor.js';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
 import { SizableMixin } from '../common/mixins/sizable.js';
-import { clamp } from '../common/util.js';
+import { clamp, isLTR } from '../common/util.js';
 import { styles } from './rating.base.css.js';
 import { styles as bootstrap } from './rating.bootstrap.css.js';
 import { styles as fluent } from './rating.fluent.css.js';
@@ -61,14 +56,13 @@ export default class IgcRatingComponent extends SizableMixin(
 
   public static styles = [styles];
 
+  protected ratingSymbols: Array<IgcRatingSymbolComponent> = [];
+
   @query('[part="symbols"]', true)
   protected container!: HTMLElement;
 
   @queryAssignedNodes({ slot: 'value-label', flatten: true })
   protected valueLabel!: Array<Node>;
-
-  @queryAssignedElements({ selector: 'igc-rating-symbol' })
-  protected ratingSymbols!: Array<IgcRatingSymbolComponent>;
 
   @state()
   protected hoverValue = -1;
@@ -82,12 +76,6 @@ export default class IgcRatingComponent extends SizableMixin(
 
   protected get hasProjectedSymbols() {
     return this.ratingSymbols.length > 0;
-  }
-
-  protected get isLTR() {
-    return (
-      window.getComputedStyle(this).getPropertyValue('direction') === 'ltr'
-    );
   }
 
   protected get valueText() {
@@ -215,15 +203,16 @@ export default class IgcRatingComponent extends SizableMixin(
     }
 
     let result = this.value;
+    const ltr = isLTR(this);
 
     switch (key) {
       case 'ArrowUp':
       case 'ArrowRight':
-        result += this.isLTR ? this.step : -this.step;
+        result += ltr ? this.step : -this.step;
         break;
       case 'ArrowDown':
       case 'ArrowLeft':
-        result -= this.isLTR ? this.step : -this.step;
+        result -= ltr ? this.step : -this.step;
         break;
       case 'Home':
         result = this.step;
@@ -243,16 +232,25 @@ export default class IgcRatingComponent extends SizableMixin(
     }
   }
 
-  protected handleSlotChange() {
+  protected handleSlotChange(event: Event) {
+    const slot = event.target as HTMLSlotElement;
+
+    this.ratingSymbols = slot
+      .assignedElements()
+      .filter(
+        (el) => el instanceof IgcRatingSymbolComponent
+      ) as IgcRatingSymbolComponent[];
+
     if (this.hasProjectedSymbols) {
       this.max = this.ratingSymbols.length;
     }
+
     this.requestUpdate();
   }
 
   protected calcNewValue(x: number) {
     const { width, left, right } = this.container.getBoundingClientRect();
-    const percent = this.isLTR ? (x - left) / width : (right - x) / width;
+    const percent = isLTR(this) ? (x - left) / width : (right - x) / width;
     const value = this.round(this.max * percent + this.step / 2);
 
     return clamp(value, this.step, this.max);
@@ -274,20 +272,21 @@ export default class IgcRatingComponent extends SizableMixin(
     const exclusive = progress === 0 || this.value === index + 1 ? 0 : 1;
     const selection = this.single ? exclusive : progress;
     const activate = (p: number) => clamp(p * 100, 0, 100);
+    const ltr = isLTR(this);
 
     const forward = `inset(0 ${activate(
-      this.isLTR ? selection : 1 - selection
+      ltr ? selection : 1 - selection
     )}% 0 0)`;
     const backward = `inset(0 0 0 ${activate(
-      this.isLTR ? 1 - selection : selection
+      ltr ? 1 - selection : selection
     )}%)`;
 
     switch (direction) {
       case 'backward':
-        return this.isLTR ? backward : forward;
+        return ltr ? backward : forward;
       case 'forward':
       default:
-        return this.isLTR ? forward : backward;
+        return ltr ? forward : backward;
     }
   }
 
@@ -348,7 +347,13 @@ export default class IgcRatingComponent extends SizableMixin(
   }
 
   protected override render() {
-    this.clipProjected();
+    const props = [
+      this.hoverState ? this.hoverValue : this.value,
+      this.max,
+      this.step,
+      this.single,
+      this.ratingSymbols,
+    ];
 
     return html`
       <label part="label" ?hidden=${!this.label}>${this.label}</label>
@@ -371,7 +376,10 @@ export default class IgcRatingComponent extends SizableMixin(
           @mousemove=${this.hoverPreview ? this.handleMouseMove : nothing}
         >
           <slot @slotchange=${this.handleSlotChange}>
-            ${this.renderSymbols()}
+            ${guard(props, () => {
+              this.clipProjected();
+              return this.renderSymbols();
+            })}
           </slot>
         </div>
         <label part="value-label" ?hidden=${this.valueLabel.length === 0}>

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -348,7 +348,8 @@ export default class IgcRatingComponent extends SizableMixin(
 
   protected override render() {
     const props = [
-      this.hoverState ? this.hoverValue : this.value,
+      this.value,
+      this.hoverValue,
       this.max,
       this.step,
       this.single,

--- a/src/components/slider/slider-base.ts
+++ b/src/components/slider/slider-base.ts
@@ -19,6 +19,7 @@ import { styles as material } from './themes/light/slider.material.css.js';
 import { defineComponents } from '../common/definitions/defineComponents.js';
 import IgcSliderLabelComponent from './slider-label.js';
 import { blazorDeepImport } from '../common/decorators/blazorDeepImport.js';
+import { isLTR } from '../common/util.js';
 
 defineComponents(IgcSliderLabelComponent);
 
@@ -295,11 +296,6 @@ export class IgcSliderBaseComponent extends LitElement {
       : this.max;
   }
 
-  private get isLTR(): boolean {
-    const styles = window.getComputedStyle(this);
-    return styles.getPropertyValue('direction') === 'ltr';
-  }
-
   protected validateValue(value: number) {
     value = this.valueInRange(value, this.actualMin, this.actualMax);
     value = this.normalizeByStep(value);
@@ -398,7 +394,7 @@ export class IgcSliderBaseComponent extends LitElement {
     const thumbPositionX = thumbBoundaries.left + thumbCenter;
 
     const scale = this.getBoundingClientRect().width / (this.max - this.min);
-    const change = this.isLTR
+    const change = isLTR(this)
       ? mouseX - thumbPositionX
       : thumbPositionX - mouseX;
 
@@ -469,13 +465,14 @@ export class IgcSliderBaseComponent extends LitElement {
     let increment = 0;
     const value = this.activeValue;
     const step = this.step ? this.step : 1;
+    const ltr = isLTR(this);
 
     switch (key) {
       case 'ArrowLeft':
-        increment += this.isLTR ? -step : step;
+        increment += ltr ? -step : step;
         break;
       case 'ArrowRight':
-        increment += this.isLTR ? step : -step;
+        increment += ltr ? step : -step;
         break;
       case 'ArrowUp':
         increment = step;

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -15,7 +15,7 @@ import { styles as fluent } from './themes/light/tabs.fluent.css.js';
 import { styles as indigo } from './themes/light/tabs.indigo.css.js';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
 import { Constructor } from '../common/mixins/constructor.js';
-import { createCounter, getOffset } from '../common/util.js';
+import { createCounter, getOffset, isLTR } from '../common/util.js';
 import {
   getAttributesForTags,
   getNodesForTags,
@@ -97,12 +97,6 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     return this.tabs.filter((tab) => !tab.disabled);
   }
 
-  protected get isLTR() {
-    return (
-      window.getComputedStyle(this).getPropertyValue('direction') === 'ltr'
-    );
-  }
-
   /** Returns the currently selected tab. */
   public get selected(): string {
     return this.activeTab?.panel ?? '';
@@ -132,7 +126,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
       Object.assign(styles, {
         width: `${this.activeTab!.offsetWidth}px`,
         transform: `translate(${
-          this.isLTR
+          isLTR(this)
             ? getOffset(this.activeTab!, this.wrapper).left
             : getOffset(this.activeTab!, this.wrapper).right
         }px)`,
@@ -277,7 +271,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
 
   protected scrollByTabOffset(direction: 'start' | 'end') {
     const { scrollLeft, offsetWidth } = this.container;
-    const LTR = this.isLTR,
+    const LTR = isLTR(this),
       next = direction === 'end';
 
     const pivot = Math.abs(next ? offsetWidth + scrollLeft : scrollLeft);
@@ -295,7 +289,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
       .at(next ? 0 : -1)!.width;
 
     amount *= next ? 1 : -1;
-    this.container.scrollBy({ left: this.isLTR ? amount : -amount });
+    this.container.scrollBy({ left: LTR ? amount : -amount });
   }
 
   protected handleClick(event: MouseEvent) {
@@ -314,6 +308,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
   protected handleKeyDown = (event: KeyboardEvent) => {
     const { key } = event;
     const enabledTabs = this.enabledTabs;
+    const ltr = isLTR(this);
 
     let index = enabledTabs.indexOf(
       document.activeElement?.closest('igc-tab') as IgcTabComponent
@@ -321,12 +316,12 @@ export default class IgcTabsComponent extends EventEmitterMixin<
 
     switch (key) {
       case 'ArrowLeft':
-        index = this.isLTR
+        index = ltr
           ? (enabledTabs.length + index - 1) % enabledTabs.length
           : (index + 1) % enabledTabs.length;
         break;
       case 'ArrowRight':
-        index = this.isLTR
+        index = ltr
           ? (index + 1) % enabledTabs.length
           : (enabledTabs.length + index - 1) % enabledTabs.length;
         break;


### PR DESCRIPTION
- Extracted `isLTR` to an external helper function.
- Reduced number of LTR query calls in certain scenarios to avoid
  reflow thrashing.
- Cached rating symbols rendering logic. Properties not related
  to the symbols state will not trigger a DOM re-render.