### PR TITLE
fix(rating): only projected symbols override default content

### DIFF
--- a/src/components/rating/rating-symbol.ts
+++ b/src/components/rating/rating-symbol.ts
@@ -18,6 +18,11 @@ export default class IgcRatingSymbolComponent extends LitElement {
   public static readonly tagName = 'igc-rating-symbol';
   public static override styles = [styles];
 
+  public override connectedCallback() {
+    super.connectedCallback();
+    this.slot = this.slot.length > 0 ? this.slot : 'symbol';
+  }
+
   protected override render() {
     return html`
       <div part="symbol full">

--- a/src/components/rating/rating.spec.ts
+++ b/src/components/rating/rating.spec.ts
@@ -24,7 +24,7 @@ describe('Rating component', () => {
     ) as NodeListOf<IgcRatingSymbolComponent>;
   const getProjectedSymbols = (el: IgcRatingComponent) => {
     const slot = el.shadowRoot!.querySelector(
-      'slot:not([name])'
+      'slot[name="symbol"]'
     ) as HTMLSlotElement;
     return slot
       .assignedElements()

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -394,7 +394,7 @@ export default class IgcRatingComponent extends SizableMixin(
           @mouseleave=${this.hoverPreview ? this.handleMouseLeave : nothing}
           @mousemove=${this.hoverPreview ? this.handleMouseMove : nothing}
         >
-          <slot @slotchange=${this.handleSlotChange}>
+          <slot name="symbol" @slotchange=${this.handleSlotChange}>
             ${guard(props, () => {
               this.clipProjected();
               return this.renderSymbols();


### PR DESCRIPTION
The default rendering of the Rating (when no custom symbols are provided) is handled by the default slot fallback content. However, many frameworks (read: Angular, Blazor, even Lit) like to leave anchor nodes for possible content, usually comments like this:
```html
<igc-rating size="large"> <!--?lit$333866644$--> </igc-rating>
```
This triggers the default slot projection and wipes the fallback content leaving an empty rating.

To avoid this, moved to a named slot with a self-assign approach for the rating symbol components, similar to the Tab panels.