### PR TITLE
fix(theme): update stale --igc-* variables to --ig-*

### DIFF
--- a/src/components/dialog/themes/light/dialog.base.scss
+++ b/src/components/dialog/themes/light/dialog.base.scss
@@ -19,7 +19,7 @@ $content-color: var(--content-color, color(gray, 700));
     border: inherit;
     border-radius: inherit;
     min-width: inherit;
-    box-shadow: var(--igc-elevation-24);
+    box-shadow: var(--ig-elevation-24);
 }
 
 [part='content'] {

--- a/src/components/stepper/themes/stepper/stepper.base.scss
+++ b/src/components/stepper/themes/stepper/stepper.base.scss
@@ -3,7 +3,7 @@
 
 // STEPPER
 :host {
-    font-family: var(--igc-font-family);
+    font-family: var(--ig-font-family);
 
     --margin: #{rem(16px)};
     --body-padding: #{rem(16px)};


### PR DESCRIPTION
Related #603 

Some components were still using the old global CSS variables prefixed by `--igc-` resulting in visual issues for those components.