### PR TITLE
fix: Dangling references after element disconnect

### DIFF
--- a/src/components/checkbox/checkbox-base.ts
+++ b/src/components/checkbox/checkbox-base.ts
@@ -141,6 +141,7 @@ export class IgcCheckboxBaseComponent extends EventEmitterMixin<
 
   public override disconnectedCallback() {
     this.removeEventListener('keyup', this.handleKeyUp);
+    super.disconnectedCallback();
   }
 
   protected handleKeyUp() {

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -130,6 +130,7 @@ export default class IgcRadioComponent extends EventEmitterMixin<
 
   public override disconnectedCallback() {
     this.removeEventListener('keyup', this.handleKeyUp);
+    super.disconnectedCallback();
   }
 
   protected handleKeyUp() {

--- a/src/components/select/select-group.ts
+++ b/src/components/select/select-group.ts
@@ -43,6 +43,7 @@ export default class IgcSelectGroupComponent extends IgcDropdownGroupComponent {
 
   public override disconnectedCallback() {
     this.observer.disconnect();
+    super.disconnectedCallback();
   }
 
   protected override getParent() {

--- a/src/components/slider/slider-base.ts
+++ b/src/components/slider/slider-base.ts
@@ -267,6 +267,7 @@ export class IgcSliderBaseComponent extends LitElement {
 
   public override disconnectedCallback() {
     this.removeEventListener('keyup', this.handleKeyUp);
+    super.disconnectedCallback();
   }
 
   protected handleKeyUp() {


### PR DESCRIPTION
Several components did not call the parent `disconnectedCallback`, preventing triggering `hostDisconnected`
for any controllers (theming in this case) and
leading to a memory leak.