### PR TITLE
feat(animations): add a basic animation player

### DIFF
--- a/src/animations/easings.ts
+++ b/src/animations/easings.ts
@@ -1,0 +1,34 @@
+enum EaseIn {
+  Quad = 'cubic-bezier(0.550, 0.085, 0.680, 0.530)',
+  Cubic = 'cubic-bezier(0.550, 0.055, 0.675, 0.190)',
+  Quart = 'cubic-bezier(0.895, 0.030, 0.685, 0.220)',
+  Quint = 'cubic-bezier(0.755, 0.050, 0.855, 0.060)',
+  Sine = 'cubic-bezier(0.470, 0.000, 0.745, 0.715)',
+  Expo = 'cubic-bezier(0.950, 0.050, 0.795, 0.035)',
+  Circ = 'cubic-bezier(0.600, 0.040, 0.980, 0.335)',
+  Back = 'cubic-bezier(0.600, -0.280, 0.735, 0.045)',
+}
+
+enum EaseOut {
+  Quad = 'cubic-bezier(0.250, 0.460, 0.450, 0.940)',
+  Cubic = 'cubic-bezier(0.215, 0.610, 0.355, 1.000)',
+  Quart = 'cubic-bezier(0.165, 0.840, 0.440, 1.000)',
+  Quint = 'cubic-bezier(0.230, 1.000, 0.320, 1.000)',
+  Sine = 'cubic-bezier(0.390, 0.575, 0.565, 1.000)',
+  Expo = 'cubic-bezier(0.190, 1.000, 0.220, 1.000)',
+  Circ = 'cubic-bezier(0.075, 0.820, 0.165, 1.000)',
+  Back = 'cubic-bezier(0.175, 0.885, 0.320, 1.275)',
+}
+
+enum EaseInOut {
+  Quad = 'cubic-bezier(0.455, 0.030, 0.515, 0.955)',
+  Cubic = 'cubic-bezier(0.645, 0.045, 0.355, 1.000)',
+  Quart = 'cubic-bezier(0.770, 0.000, 0.175, 1.000)',
+  Quint = 'cubic-bezier(0.860, 0.000, 0.070, 1.000)',
+  Sine = 'cubic-bezier(0.445, 0.050, 0.550, 0.950)',
+  Expo = 'cubic-bezier(1.000, 0.000, 0.000, 1.000)',
+  Circ = 'cubic-bezier(0.785, 0.135, 0.150, 0.860)',
+  Back = 'cubic-bezier(0.680, -0.550, 0.265, 1.550)',
+}
+
+export { EaseIn, EaseOut, EaseInOut };

--- a/src/animations/index.ts
+++ b/src/animations/index.ts
@@ -1,0 +1,3 @@
+export * from './presets/index.js';
+export * from './easings.js';
+export * from './player.js';

--- a/src/animations/player.spec.ts
+++ b/src/animations/player.spec.ts
@@ -1,0 +1,51 @@
+import { html } from 'lit';
+import { expect, fixture } from '@open-wc/testing';
+import { AnimationPlayer } from './player.js';
+import { AnimationReferenceMetadata, animation } from './types.js';
+import { EaseOut } from './easings.js';
+
+const keyframes = [
+  { opacity: 0, transform: 'scale(0.1)' },
+  { opacity: 1, transform: 'scale(1)' },
+];
+
+const animationOptions = {
+  duration: 100,
+  easing: EaseOut.Quad,
+};
+
+const fade: AnimationReferenceMetadata = animation(keyframes, animationOptions);
+
+describe('Animations Player', () => {
+  let el: HTMLElement;
+  let animationPlayer: AnimationPlayer;
+
+  beforeEach(async () => {
+    el = await fixture<HTMLElement>(
+      html`<div style="width: 300px; height: 300px; background: red;"></div>`
+    );
+    animationPlayer = new AnimationPlayer(el);
+  });
+
+  it('should construct animation reference metadata', () => {
+    expect(fade.steps).to.equal(keyframes);
+    expect(fade.options).to.equal(animationOptions);
+  });
+
+  it('animate an element to completion', async () => {
+    const animation = (await animationPlayer.play(
+      fade
+    )) as AnimationPlaybackEvent;
+
+    expect(animation.type).to.equal('finish');
+  });
+
+  it('should cancel running animations', async () => {
+    const [playbackEvent] = (await Promise.all([
+      animationPlayer.play(fade),
+      animationPlayer.stopAll(),
+    ])) as AnimationPlaybackEvent[];
+
+    expect(playbackEvent.type).to.equal('cancel');
+  });
+});

--- a/src/animations/player.ts
+++ b/src/animations/player.ts
@@ -25,7 +25,7 @@ export class AnimationPlayer {
   public async play(animation: AnimationReferenceMetadata) {
     const { steps, options } = animation;
 
-    return new Promise((resolve) => {
+    return new Promise<AnimationPlaybackEvent>((resolve) => {
       if (options?.duration === Infinity) {
         throw new Error('Promise-based animations must be finite.');
       }
@@ -45,12 +45,12 @@ export class AnimationPlayer {
     return Promise.all(
       this.target.getAnimations().map((animation) => {
         return new Promise((resolve) => {
-          const handleAnimationEvent = requestAnimationFrame(resolve);
+          const handleAnimationEvent = () => requestAnimationFrame(resolve);
 
-          animation.addEventListener('cancel', () => handleAnimationEvent, {
+          animation.addEventListener('cancel', handleAnimationEvent, {
             once: true,
           });
-          animation.addEventListener('finish', () => handleAnimationEvent, {
+          animation.addEventListener('finish', handleAnimationEvent, {
             once: true,
           });
           animation.cancel();

--- a/src/animations/player.ts
+++ b/src/animations/player.ts
@@ -1,0 +1,65 @@
+import { nothing } from 'lit';
+import { AnimationReferenceMetadata } from './types.js';
+
+export class AnimationPlayer {
+  private _defaultCallback = () => nothing;
+
+  private prefersReducedMotion() {
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    return query.matches;
+  }
+
+  private parseKeyframes(el: HTMLElement, keyframes: Keyframe[]) {
+    return keyframes.map((keyframe) => ({
+      ...keyframe,
+      height:
+        keyframe.height === 'auto' ? `${el.scrollHeight}px` : keyframe.height,
+    }));
+  }
+
+  public async animate(
+    el: HTMLElement,
+    animation: AnimationReferenceMetadata,
+    onDone?: () => void
+  ) {
+    const { steps, options } = animation;
+
+    // cancel all running animations, useful for togglable elements
+    await this.stopAnimations(el);
+
+    return new Promise((resolve) => {
+      if (options?.duration === Infinity) {
+        throw new Error('Promise-based animations must be finite.');
+      }
+
+      const parsedKeyframes = this.parseKeyframes(el, steps);
+      const animation = el.animate(parsedKeyframes, {
+        ...options,
+        duration: this.prefersReducedMotion() ? 0 : options!.duration,
+      });
+
+      animation.addEventListener('cancel', resolve, { once: true });
+      animation.addEventListener('finish', onDone || this._defaultCallback, {
+        once: true,
+      });
+    });
+  }
+
+  private stopAnimations(el: HTMLElement) {
+    return Promise.all(
+      el.getAnimations().map((animation) => {
+        return new Promise((resolve) => {
+          const handleAnimationEvent = requestAnimationFrame(resolve);
+
+          animation.addEventListener('cancel', () => handleAnimationEvent, {
+            once: true,
+          });
+          animation.addEventListener('finish', () => handleAnimationEvent, {
+            once: true,
+          });
+          animation.cancel();
+        });
+      })
+    );
+  }
+}

--- a/src/animations/player.ts
+++ b/src/animations/player.ts
@@ -1,53 +1,49 @@
-import { nothing } from 'lit';
 import { AnimationReferenceMetadata } from './types.js';
 
 export class AnimationPlayer {
-  private _defaultCallback = () => nothing;
+  private target!: HTMLElement;
+
+  constructor(target: HTMLElement) {
+    this.target = target;
+  }
 
   private prefersReducedMotion() {
     const query = window.matchMedia('(prefers-reduced-motion: reduce)');
     return query.matches;
   }
 
-  private parseKeyframes(el: HTMLElement, keyframes: Keyframe[]) {
+  private parseKeyframes(keyframes: Keyframe[]) {
     return keyframes.map((keyframe) => ({
       ...keyframe,
       height:
-        keyframe.height === 'auto' ? `${el.scrollHeight}px` : keyframe.height,
+        keyframe.height === 'auto'
+          ? `${this.target.scrollHeight}px`
+          : keyframe.height,
     }));
   }
 
-  public async animate(
-    el: HTMLElement,
-    animation: AnimationReferenceMetadata,
-    onDone?: () => void
-  ) {
+  public async play(animation: AnimationReferenceMetadata) {
     const { steps, options } = animation;
-
-    // cancel all running animations, useful for togglable elements
-    await this.stopAnimations(el);
 
     return new Promise((resolve) => {
       if (options?.duration === Infinity) {
         throw new Error('Promise-based animations must be finite.');
       }
 
-      const parsedKeyframes = this.parseKeyframes(el, steps);
-      const animation = el.animate(parsedKeyframes, {
+      const parsedKeyframes = this.parseKeyframes(steps);
+      const animation = this.target.animate(parsedKeyframes, {
         ...options,
         duration: this.prefersReducedMotion() ? 0 : options!.duration,
       });
 
       animation.addEventListener('cancel', resolve, { once: true });
-      animation.addEventListener('finish', onDone || this._defaultCallback, {
-        once: true,
-      });
+      animation.addEventListener('finish', resolve, { once: true });
     });
   }
 
-  private stopAnimations(el: HTMLElement) {
+  public stopAll() {
     return Promise.all(
-      el.getAnimations().map((animation) => {
+      this.target.getAnimations().map((animation) => {
         return new Promise((resolve) => {
           const handleAnimationEvent = requestAnimationFrame(resolve);
 

--- a/src/animations/presets/grow/index.ts
+++ b/src/animations/presets/grow/index.ts
@@ -1,0 +1,26 @@
+import { EaseOut } from '../../easings.js';
+import { animation } from '../../types.js';
+
+const growVerIn = animation(
+  [
+    { opacity: 0, height: 0 },
+    { opacity: 1, height: 'auto' },
+  ],
+  {
+    duration: 350,
+    easing: EaseOut.Quad,
+  }
+);
+
+const growVerOut = animation(
+  [
+    { opacity: 1, height: 'auto' },
+    { opacity: 0, height: 0 },
+  ],
+  {
+    duration: 350,
+    easing: EaseOut.Quad,
+  }
+);
+
+export { growVerIn, growVerOut };

--- a/src/animations/presets/index.ts
+++ b/src/animations/presets/index.ts
@@ -1,0 +1,1 @@
+export * from './grow/index.js';

--- a/src/animations/types.ts
+++ b/src/animations/types.ts
@@ -1,0 +1,14 @@
+export interface AnimationReferenceMetadata {
+  steps: Keyframe[];
+  options: KeyframeAnimationOptions | null;
+}
+
+export function animation(
+  steps: Keyframe[],
+  options: KeyframeAnimationOptions | null
+): AnimationReferenceMetadata {
+  return {
+    steps,
+    options,
+  };
+}

--- a/src/animations/types.ts
+++ b/src/animations/types.ts
@@ -1,11 +1,11 @@
 export interface AnimationReferenceMetadata {
   steps: Keyframe[];
-  options: KeyframeAnimationOptions | null;
+  options?: KeyframeAnimationOptions;
 }
 
 export function animation(
   steps: Keyframe[],
-  options: KeyframeAnimationOptions | null
+  options?: KeyframeAnimationOptions
 ): AnimationReferenceMetadata {
   return {
     steps,

--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -121,7 +121,7 @@ export default class IgcAccordionComponent extends LitElement {
     if (!panel.emitEvent('igcClosing', { cancelable: true, detail: panel })) {
       return;
     }
-    panel.open = false;
+    panel.hide();
     await panel.updateComplete;
 
     panel.emitEvent('igcClosed', { detail: panel });
@@ -135,7 +135,7 @@ export default class IgcAccordionComponent extends LitElement {
       return;
     }
 
-    panel.open = true;
+    panel.show();
     await panel.updateComplete;
 
     panel.emitEvent('igcOpened', { detail: panel });
@@ -143,12 +143,12 @@ export default class IgcAccordionComponent extends LitElement {
 
   /** Hides all of the child expansion panels' contents. */
   public hideAll() {
-    this.panels.forEach((p) => (p.open = false));
+    this.panels.forEach((p) => p.hide());
   }
 
   /** Shows all of the child expansion panels' contents. */
   public showAll() {
-    this.panels.forEach((p) => (p.open = true));
+    this.panels.forEach((p) => p.show());
   }
 
   protected override render() {

--- a/src/components/accordion/themes/accordion.base.scss
+++ b/src/components/accordion/themes/accordion.base.scss
@@ -3,6 +3,8 @@
 :host {
     ::slotted(igc-expansion-panel) {
         --lines-clamped: 4;
+
+        transition: margin 350ms ease-out;
     }
 
     ::slotted(igc-expansion-panel[open]) {
@@ -15,5 +17,11 @@
 
     ::slotted(igc-expansion-panel:last-of-type) {
         margin-bottom: 0;
+    }
+
+    @media (prefers-reduced-motion) {
+        ::slotted(igc-expansion-panel) {
+            transition: none;
+        }
     }
 }

--- a/src/components/expansion-panel/expansion-panel.spec.ts
+++ b/src/components/expansion-panel/expansion-panel.spec.ts
@@ -4,6 +4,7 @@ import {
   expect,
   unsafeStatic,
   elementUpdated,
+  waitUntil,
 } from '@open-wc/testing';
 import sinon from 'sinon';
 import { defineComponents, IgcExpansionPanelComponent } from '../../index.js';
@@ -168,16 +169,16 @@ describe('Expansion Panel', () => {
     it('Should get expanded/collapsed on using the API toggle() method', async () => {
       expect(panel.open).to.be.false;
 
-      let contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).to.have.attribute('hidden');
+      let content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('true');
 
       panel.toggle();
       await elementUpdated(panel);
 
       expect(panel.open).to.be.true;
 
-      contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).not.to.have.attribute('hidden');
+      content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('false');
 
       expect(eventSpy).not.to.have.been.called;
     });
@@ -190,8 +191,8 @@ describe('Expansion Panel', () => {
 
       expect(panel.open).to.be.true;
 
-      let contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).not.to.have.attribute('hidden');
+      let content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('false');
 
       expect(eventSpy).not.to.have.been.called;
 
@@ -200,8 +201,8 @@ describe('Expansion Panel', () => {
 
       expect(panel.open).to.be.false;
 
-      contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).to.have.attribute('hidden');
+      content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('true');
 
       expect(eventSpy).not.to.have.been.called;
     });
@@ -214,8 +215,8 @@ describe('Expansion Panel', () => {
 
       expect(panel.open).to.be.true;
 
-      let contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).not.to.have.attribute('hidden');
+      let content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('false');
 
       expect(eventSpy).not.to.have.been.called;
 
@@ -224,8 +225,8 @@ describe('Expansion Panel', () => {
 
       expect(panel.open).to.be.false;
 
-      contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).to.have.attribute('hidden');
+      content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('true');
 
       expect(eventSpy).not.to.have.been.called;
     });
@@ -236,12 +237,9 @@ describe('Expansion Panel', () => {
       expect(panel.open).to.be.false;
 
       header?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcOpened'));
 
       expect(panel.open).to.be.true;
-
-      let contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).not.to.have.attribute('hidden');
 
       // Verify events are called
       expect(eventSpy.callCount).to.equal(2);
@@ -260,13 +258,9 @@ describe('Expansion Panel', () => {
       eventSpy.resetHistory();
 
       header?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcClosed'));
 
       expect(panel.open).to.be.false;
-
-      contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).to.have.attribute('hidden');
-
       expect(eventSpy.callCount).to.equal(2);
 
       const closingArgs = {
@@ -288,12 +282,12 @@ describe('Expansion Panel', () => {
       expect(panel.open).to.be.false;
 
       indicator?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcOpened'));
 
       expect(panel.open).to.be.true;
 
-      let contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).not.to.have.attribute('hidden');
+      let content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('false');
 
       // Verify events are called
       expect(eventSpy.callCount).to.equal(2);
@@ -312,12 +306,12 @@ describe('Expansion Panel', () => {
       eventSpy.resetHistory();
 
       indicator?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcClosed'));
 
       expect(panel.open).to.be.false;
 
-      contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).to.have.attribute('hidden');
+      content = panel.shadowRoot!.querySelector(PARTS.content);
+      expect(content?.ariaHidden).to.equal('true');
       expect(eventSpy.callCount).to.equal(2);
 
       const closingArgs = {
@@ -335,12 +329,9 @@ describe('Expansion Panel', () => {
     it('Should get expanded/collapsed on arrowdown/arrowup', async () => {
       const header = panel.shadowRoot?.querySelector(PARTS.header);
       triggerKeydown(header as HTMLElement, 'arrowdown');
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcOpened'));
 
       expect(panel.open).to.be.true;
-
-      let contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).not.to.have.attribute('hidden');
 
       // Verify events are called
       expect(eventSpy.callCount).to.equal(2);
@@ -359,13 +350,9 @@ describe('Expansion Panel', () => {
       eventSpy.resetHistory();
 
       triggerKeydown(header as HTMLElement, 'arrowup');
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcClosed'));
 
       expect(panel.open).to.be.false;
-
-      contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).to.have.attribute('hidden');
-
       expect(eventSpy.callCount).to.equal(2);
 
       const closingArgs = {
@@ -383,12 +370,9 @@ describe('Expansion Panel', () => {
     it('Should get expanded/collapsed on space/enter', async () => {
       const header = panel.shadowRoot?.querySelector(PARTS.header);
       triggerKeydown(header as HTMLElement, ' ', false);
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcOpened'));
 
       expect(panel.open).to.be.true;
-
-      let contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).not.to.have.attribute('hidden');
 
       // Verify events are called
       expect(eventSpy.callCount).to.equal(2);
@@ -407,13 +391,9 @@ describe('Expansion Panel', () => {
       eventSpy.resetHistory();
 
       triggerKeydown(header as HTMLElement, 'enter', false);
-      await elementUpdated(panel);
+      await waitUntil(() => eventSpy.calledWith('igcClosed'));
 
       expect(panel.open).to.be.false;
-
-      contentSlot = getDefaultSlot(panel);
-      expect(contentSlot).to.have.attribute('hidden');
-
       expect(eventSpy.callCount).to.equal(2);
 
       const closingArgs = {

--- a/src/components/expansion-panel/expansion-panel.ts
+++ b/src/components/expansion-panel/expansion-panel.ts
@@ -135,12 +135,13 @@ export default class IgcExpansionPanelComponent extends EventEmitterMixin<
 
   private async toggleAnimation(dir: 'open' | 'close') {
     const animation = dir === 'open' ? growVerIn : growVerOut;
-    await this.animationPlayer.stopAll();
 
-    const event = (await this.animationPlayer.play(
-      animation
-    )) as AnimationPlaybackEvent;
-    return event.type;
+    const [_, event] = await Promise.all([
+      this.animationPlayer.stopAll(),
+      this.animationPlayer.play(animation),
+    ]);
+
+    return event.type === 'finish';
   }
 
   /**
@@ -165,9 +166,7 @@ export default class IgcExpansionPanelComponent extends EventEmitterMixin<
 
     this.open = true;
 
-    const status = await this.toggleAnimation('open');
-
-    if (status === 'finish') {
+    if (await this.toggleAnimation('open')) {
       this.emitEvent('igcOpened', { detail: this });
     }
   }
@@ -194,16 +193,14 @@ export default class IgcExpansionPanelComponent extends EventEmitterMixin<
 
     this.open = false;
 
-    const status = await this.toggleAnimation('close');
-
-    if (status === 'finish') {
+    if (await this.toggleAnimation('close')) {
       this.emitEvent('igcClosed', { detail: this });
     }
   }
 
   /** Toggles panel open state. */
   public toggle(): void {
-    this.open = !this.open;
+    this.open ? this.hide() : this.show();
   }
 
   /** Hides the panel content. */

--- a/src/components/expansion-panel/themes/light/expansion-panel.base.scss
+++ b/src/components/expansion-panel/themes/light/expansion-panel.base.scss
@@ -1,3 +1,4 @@
+@use '../../../../styles/common/component';
 @use '../../../../styles/utilities/index' as *;
 
 $disabled-color: var(--disabled-color, color(gray, 500)) !default;
@@ -52,12 +53,26 @@ $disabled-color: var(--disabled-color, color(gray, 500)) !default;
     color: color(gray, 700);
 }
 
-:host([open]) [part~='content'] {
+[part='content'] ::slotted(*) {
     @include type-style('body-2');
+}
 
+[part~='content'] {
     overflow: hidden;
-    padding-inline: pad-inline(24px);
-    padding-block: pad-block(16px);
+
+    > slot {
+        display: block;
+        padding-inline: pad-inline(24px);
+        padding-block: pad-block(16px);
+    }
+}
+
+:host(:not([open])) [part~='content'] {
+    height: 0;
+}
+
+:host([open]) [part~='content'] {
+    height: auto;
 }
 
 [part~='indicator'] {

--- a/stories/accordion.stories.ts
+++ b/stories/accordion.stories.ts
@@ -19,39 +19,23 @@ interface ArgTypes {
   singleExpand: boolean;
 }
 // endregion
+
+(metadata as any).parameters = {
+  actions: {
+    handles: ['igcOpening', 'igcOpened', 'igcClosing', 'igcClosed'],
+  },
+};
+
 interface Context {
   globals: { theme: string; direction: 'ltr' | 'rtl' | 'auto' };
 }
-
-const handleOpening = (ev: any) => {
-  console.log(ev);
-};
-
-const handleOpened = (ev: any) => {
-  console.log(ev);
-};
-
-const handleClosing = (ev: any) => {
-  console.log(ev);
-};
-
-const handleClosed = (ev: any) => {
-  console.log(ev);
-};
 
 const Template: Story<ArgTypes, Context> = (
   { singleExpand = false }: ArgTypes,
   { globals: { direction } }: Context
 ) => {
   return html`
-    <igc-accordion
-      .singleExpand="${singleExpand}"
-      .dir="${direction}"
-      @igcOpening=${handleOpening}
-      @igcOpened=${handleOpened}
-      @igcClosing=${handleClosing}
-      @igcClosed=${handleClosed}
-    >
+    <igc-accordion .singleExpand="${singleExpand}" .dir="${direction}">
       <igc-expansion-panel>
         <div slot="title">Expansion panel 1 title</div>
         <div slot="subtitle">Expansion panel 1 subtitle</div>

--- a/stories/expansion-panel.stories.ts
+++ b/stories/expansion-panel.stories.ts
@@ -38,24 +38,16 @@ interface ArgTypes {
   indicatorPosition: 'start' | 'end' | 'none';
 }
 // endregion
+
+(metadata as any).parameters = {
+  actions: {
+    handles: ['igcOpening', 'igcOpened', 'igcClosing', 'igcClosed'],
+  },
+};
+
 interface Context {
   globals: { theme: string; direction: 'ltr' | 'rtl' | 'auto' };
 }
-
-const handleOpening = (ev: any) => {
-  console.log(ev);
-};
-
-const handleOpened = (ev: any) => {
-  console.log(ev);
-};
-
-const handleClosing = (ev: any) => {
-  console.log(ev);
-};
-const handleClosed = (ev: any) => {
-  console.log(ev);
-};
 
 const Template: Story<ArgTypes, Context> = (
   { open = false, disabled = false, indicatorPosition = 'start' }: ArgTypes,
@@ -67,10 +59,6 @@ const Template: Story<ArgTypes, Context> = (
       .open="${open}"
       .disabled="${disabled}"
       .dir="${direction}"
-      @igcOpening=${handleOpening}
-      @igcOpened=${handleOpened}
-      @igcClosing=${handleClosing}
-      @igcClosed=${handleClosed}
     >
       <h1 slot="title">The Expendables</h1>
       <h3 slot="subtitle">Action, Adventure, Thriller</h3>


### PR DESCRIPTION
Closes #599 

Add a basic animation player that plays Web Animations and calls a function when the animation finishes playing. As a bonus feature, the animation player will animate height automatically if its value is set to 'auto'.

This PR animates the expansion panel as a showcase for how the player can be used.