### PR TITLE
suppress internal combo components for blazor

### DIFF
--- a/src/components/combo/combo-header.ts
+++ b/src/components/combo/combo-header.ts
@@ -4,6 +4,7 @@ import { styles } from './themes/light/header/combo-header.base.css.js';
 import { styles as bootstrap } from '../dropdown/themes/light/dropdown-header.bootstrap.css.js';
 import { styles as fluent } from '../dropdown/themes/light/dropdown-header.fluent.css.js';
 
+/* blazorSuppress */
 @themes({ bootstrap, fluent })
 export default class IgcComboHeaderComponent extends LitElement {
   public static readonly tagName: string = 'igc-combo-header';

--- a/src/components/combo/combo-item.ts
+++ b/src/components/combo/combo-item.ts
@@ -10,7 +10,7 @@ import IgcCheckboxComopnent from '../checkbox/checkbox.js';
 import { defineComponents } from '../common/definitions/defineComponents.js';
 
 defineComponents(IgcCheckboxComopnent);
-
+/* blazorSuppress */
 @themes({ bootstrap, fluent, indigo })
 export default class IgcComboItemComponent extends LitElement {
   public static readonly tagName: string = 'igc-combo-item';

--- a/src/components/combo/combo-list.ts
+++ b/src/components/combo/combo-list.ts
@@ -1,5 +1,6 @@
 import { LitVirtualizer } from '@lit-labs/virtualizer';
 
+/* blazorSuppress */
 /* blazorAlternateBaseType: BaseElement */
 export default class IgcComboListComponent extends LitVirtualizer {
   public static readonly tagName = 'igc-combo-list';

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -92,9 +92,7 @@ defineComponents(
  * @csspart empty - The container holding the empty content.
  */
 @themes({ material, bootstrap, fluent, indigo })
-@blazorAdditionalDependencies(
-  'IgcIconComponent, IgcComboListComponent, IgcComboItemComponent, IgcComboHeaderComponent, IgcInputComponent'
-)
+@blazorAdditionalDependencies('IgcIconComponent, IgcInputComponent')
 @blazorIndirectRender
 // TODO: pressing arrow down should scroll to the selected item
 export default class IgcComboComponent<T extends object>


### PR DESCRIPTION
combo-header, combo-item and combo-list are not publically [exposed](https://github.com/IgniteUI/igniteui-webcomponents/blob/master/src/index.ts) so I am suppressing them for blazor.