### PR TITLE
refactor(toggle): change middleware apply destructing assign

### DIFF
--- a/src/components/toggle/toggle.directive.ts
+++ b/src/components/toggle/toggle.directive.ts
@@ -95,7 +95,8 @@ export class IgcToggleDirective extends Directive {
       const floatingElement = this.floatingElement;
       middleware.push(
         size({
-          apply({ rects }) {
+          apply: (args) => {
+            const { rects } = args;
             Object.assign(floatingElement.style, {
               width: `${rects.reference.width}px`,
             });


### PR DESCRIPTION
Refactor the size middleware apply callback syntax:
While it was perfectly valid, it apparently can be confusing to some bundlers (perhaps too ambiguous with a func call) or the inline parameter destructive assign.. either way, at least in one case it made for a completely invalid argument handling that throws, so hopefully this is a little clearer. Certainly easier to read IMHO.