### PR TITLE
chore(combo): drop blazorAlternateType meta that's now redundant

### DIFF
--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -133,7 +133,6 @@ export default class IgcComboComponent<T extends object>
 
   /** The data source used to generate the list of options. */
   /* treatAsRef */
-  /* blazorAlternateType: object */
   @property({ attribute: false })
   public data: Array<T> = [];
 
@@ -232,7 +231,6 @@ export default class IgcComboComponent<T extends object>
   @property({ type: Boolean })
   public flip = true;
 
-  /* blazorAlternateType: string */
   /**
    * The key in the data source used when selecting items.
    * @attr value-key
@@ -240,7 +238,6 @@ export default class IgcComboComponent<T extends object>
   @property({ attribute: 'value-key', reflect: false })
   public valueKey?: Keys<T>;
 
-  /* blazorAlternateType: string */
   /**
    * The key in the data source used to display items in the list.
    * @attr display-key
@@ -248,7 +245,6 @@ export default class IgcComboComponent<T extends object>
   @property({ attribute: 'display-key', reflect: false })
   public displayKey?: Keys<T> = this.valueKey;
 
-  /* blazorAlternateType: string */
   /**
    * The key in the data source used to group items in the list.
    * @attr group-key


### PR DESCRIPTION
These can be handled by static analysis and resolved to baseline object array and string properties