### PR TITLE
Refactor Input, select and combo to use colors from schemas

### DIFF
--- a/src/components/input/themes/dark/input.dark.bootstrap.scss
+++ b/src/components/input/themes/dark/input.dark.bootstrap.scss
@@ -1,7 +1,17 @@
+@use 'sass:map';
+@use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
+
+$schema: extend(
+    (
+        name: 'ig-input-group'
+    ),
+    map.get($dark-bootstrap-schema, 'input-group')
+);
+$theme: digest-schema($schema);
+
 @mixin theme() {
-    igc-input,
-    igc-mask-input,
-    igc-date-time-input {
-        --input-background: transparent;
+    igc-input {
+        @include css-vars($theme);
     }
 }

--- a/src/components/input/themes/dark/input.dark.fluent.scss
+++ b/src/components/input/themes/dark/input.dark.fluent.scss
@@ -1,7 +1,17 @@
+@use 'sass:map';
+@use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
+
+$schema: extend(
+    (
+        name: 'ig-input-group'
+    ),
+    map.get($dark-fluent-schema, 'input-group')
+);
+$theme: digest-schema($schema);
+
 @mixin theme() {
-    igc-input,
-    igc-mask-input,
-    igc-date-time-input {
-        --container-background: transparent;
+    igc-input {
+        @include css-vars($theme);
     }
 }

--- a/src/components/input/themes/dark/input.dark.indigo.scss
+++ b/src/components/input/themes/dark/input.dark.indigo.scss
@@ -1,9 +1,17 @@
-@use '../../../../styles/utilities' as utils;
+@use 'sass:map';
+@use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
+
+$schema: extend(
+    (
+        name: 'ig-input-group'
+    ),
+    map.get($dark-indigo-schema, 'input-group')
+);
+$theme: digest-schema($schema);
 
 @mixin theme() {
-    igc-input,
-    igc-mask-input,
-    igc-date-time-input {
-        --label-focus-color: #{utils.color(gray, 800)};
+    igc-input {
+        @include css-vars($theme);
     }
 }

--- a/src/components/input/themes/dark/input.dark.material.scss
+++ b/src/components/input/themes/dark/input.dark.material.scss
@@ -1,9 +1,17 @@
-@use '../../../../styles/utilities' as utils;
+@use 'sass:map';
+@use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
+
+$schema: extend(
+    (
+        name: 'ig-input-group'
+    ),
+    map.get($dark-material-schema, 'input-group')
+);
+$theme: digest-schema($schema);
 
 @mixin theme() {
-    igc-input,
-    igc-mask-input,
-    igc-date-time-input {
-        --focus-background: #{utils.color(gray, 100)};
+    igc-input {
+        @include css-vars($theme);
     }
 }

--- a/src/components/input/themes/light/input.base.scss
+++ b/src/components/input/themes/light/input.base.scss
@@ -4,7 +4,6 @@
 %starfix {
     display: flex;
     align-items: center;
-    color: color(gray, 700);
 }
 
 :host {
@@ -14,12 +13,6 @@
     display: block;
     font-family: var(--ig-font-family);
     outline-style: none;
-}
-
-:host([invalid]) {
-    [part='helper-text'] {
-        color: color(error, 500);
-    }
 }
 
 :host([size='large']) {
@@ -46,7 +39,6 @@
     height: var(--size);
     border: none;
     outline-style: none;
-    color: inherit;
     font-family: var(--ig-font-family);
     z-index: 1;
 }
@@ -54,7 +46,6 @@
 [part^='container'] {
     position: relative;
     display: grid;
-    color: color(gray, 900);
     height: var(--size);
 }
 

--- a/src/components/input/themes/light/input.bootstrap.scss
+++ b/src/components/input/themes/light/input.bootstrap.scss
@@ -1,5 +1,16 @@
 @use '../../../../styles/utilities' as *;
+@use 'sass:map';
+@use '../../../../styles/common/component';
+@use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
 
+$schema: extend(
+    (
+        name: 'ig-input'
+    ),
+    map.get($light-bootstrap-schema, 'input-group')
+);
+$theme: digest-schema($schema);
 $input-background: var(--input-background, #fff) !default;
 
 :host([size='large']) {
@@ -19,6 +30,8 @@ $input-background: var(--input-background, #fff) !default;
     --font: #{sizable(rem(14px), rem(16px), rem(20px))};
     --input-font: #{sizable(rem(16px), rem(16px), rem(20px))};
 
+    @include css-vars($theme);
+
     &::after {
         background: none;
     }
@@ -34,6 +47,10 @@ $input-background: var(--input-background, #fff) !default;
         &::after {
             display: none;
         }
+    }
+
+    [part^='container'] {
+        color: color(gray, 900);
     }
 
     [part~='input'] {
@@ -150,6 +167,24 @@ $input-background: var(--input-background, #fff) !default;
 
         margin-top: rem(4px);
         color: color(gray, 700);
+    }
+}
+
+:host([invalid]) {
+    [part='helper-text'] {
+        color: color(error, 500);
+    }
+}
+
+[part~='prefixed'] [part='prefix'] {
+    ::slotted(*) {
+        color: var-get($theme, 'input-prefix-color');
+    }
+}
+
+[part~='suffixed'] [part='suffix'] {
+    ::slotted(*) {
+        color: var-get($theme, 'input-suffix-color');
     }
 }
 

--- a/src/components/input/themes/light/input.fluent.scss
+++ b/src/components/input/themes/light/input.fluent.scss
@@ -1,5 +1,15 @@
+@use 'sass:map';
+@use '../../../../styles/common/component';
 @use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
 
+$schema: extend(
+    (
+        name: 'ig-input'
+    ),
+    map.get($light-fluent-schema, 'input-group')
+);
+$theme: digest-schema($schema);
 $container-background: var(--container-background, color(surface, 500)) !default;
 $resting-border-width: rem(1px);
 $focused-border-width: rem(2px);
@@ -20,6 +30,8 @@ $focused-height: calc(var(--size) - #{($focused-border-width * 2)});
 
 :host {
     --size: #{sizable(rem(32px), rem(40px), rem(48px))};
+
+    @include css-vars($theme);
 
     [part='prefix'],
     [part='suffix'] {
@@ -55,6 +67,7 @@ $focused-height: calc(var(--size) - #{($focused-border-width * 2)});
     [part^='container'] {
         @include border-radius(2px);
 
+        color: color(gray, 900);
         border: #{$resting-border-width} solid color(gray, 500);
         transition: none;
         background: $container-background;
@@ -84,6 +97,18 @@ $focused-height: calc(var(--size) - #{($focused-border-width * 2)});
         padding: 0;
         margin-top: rem(5px);
         color: color(gray, 700);
+    }
+}
+
+[part~='prefixed'] [part='prefix'] {
+    ::slotted(*) {
+        color: var-get($theme, 'input-prefix-color');
+    }
+}
+
+[part~='suffixed'] [part='suffix'] {
+    ::slotted(*) {
+        color: var-get($theme, 'input-suffix-color');
     }
 }
 
@@ -126,6 +151,12 @@ $focused-height: calc(var(--size) - #{($focused-border-width * 2)});
 :host([required]),
 :host([outlined][required]) {
     [part='label']::after {
+        color: color(error, 500);
+    }
+}
+
+:host([invalid]) {
+    [part='helper-text'] {
         color: color(error, 500);
     }
 }

--- a/src/components/input/themes/light/input.indigo.scss
+++ b/src/components/input/themes/light/input.indigo.scss
@@ -1,5 +1,15 @@
+@use 'sass:map';
+@use '../../../../styles/common/component';
 @use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
 
+$schema: extend(
+    (
+        name: 'ig-input'
+    ),
+    map.get($light-indigo-schema, 'input-group')
+);
+$theme: digest-schema($schema);
 $label-focus-color: var(--label-focus-color, color(primary, 500)) !default;
 
 %suffix-preffix {
@@ -11,6 +21,8 @@ $label-focus-color: var(--label-focus-color, color(primary, 500)) !default;
 }
 
 :host {
+    @include css-vars($theme);
+
     [part='prefix'],
     [part='suffix'] {
         color: color(gray, 600);
@@ -40,6 +52,7 @@ $label-focus-color: var(--label-focus-color, color(primary, 500)) !default;
     }
 
     [part^='container'] {
+        color: color(gray, 900);
         background: transparent;
         border-bottom: 1px solid color(gray, 500);
         transition: background .25s ease-out;
@@ -84,6 +97,18 @@ $label-focus-color: var(--label-focus-color, color(primary, 500)) !default;
     }
 }
 
+[part~='prefixed'] [part='prefix'] {
+    ::slotted(*) {
+        color: var-get($theme, 'input-prefix-color');
+    }
+}
+
+[part~='suffixed'] [part='suffix'] {
+    ::slotted(*) {
+        color: var-get($theme, 'input-suffix-color');
+    }
+}
+
 :host(:hover),
 :host([outlined]:hover) {
     [part^='container'] {
@@ -116,6 +141,10 @@ $label-focus-color: var(--label-focus-color, color(primary, 500)) !default;
     }
 
     [part='label'] {
+        color: color(error, 500);
+    }
+
+    [part='helper-text'] {
         color: color(error, 500);
     }
 }

--- a/src/components/input/themes/light/input.material.scss
+++ b/src/components/input/themes/light/input.material.scss
@@ -1,6 +1,15 @@
 @use 'sass:map';
+@use '../../../../styles/common/component';
 @use '../../../../styles/utilities' as *;
+@use '../../../../styles/themes/schemas' as *;
 
+$schema: extend(
+    (
+        name: 'ig-input'
+    ),
+    map.get($light-material-schema, 'input-group')
+);
+$theme: digest-schema($schema);
 $idle-color: color(gray, 500) !default;
 $idle-hover-color: color(gray, 800) !default;
 $hover-background: color(gray, 200) !default;
@@ -31,13 +40,30 @@ $fs: rem(16px) !default;
 }
 
 :host {
-    input:placeholder-shown + [part='notch'],
-    [part~='filled'] + [part='notch'] {
+    @include css-vars($theme);
+
+    input:placeholder-shown + [part='notch'] {
         @extend %floated-styles;
     }
 
     input::placeholder {
-        color: color(gray, 700);
+        color: var-get($theme, 'placeholder-color');
+    }
+}
+
+[part~='prefixed'] [part='prefix'] {
+    color: var-get($theme, 'input-prefix-color');
+
+    ::slotted(*) {
+        color: inherit;
+    }
+}
+
+[part~='suffixed'] [part='suffix'] {
+    color: var-get($theme, 'input-suffix-color');
+
+    ::slotted(*) {
+        color: inherit;
     }
 }
 
@@ -47,6 +73,7 @@ input:placeholder-shown + [part='notch'] [part='label'],
 }
 
 [part~='input'] {
+    color: var-get($theme, 'filled-text-color');
     background: transparent;
     padding: 0 rem(4px);
     font-size: rem(16px);
@@ -54,7 +81,7 @@ input:placeholder-shown + [part='notch'] [part='label'],
 }
 
 [part='label'] {
-    color: color(gray, 700);
+    color: var-get($theme, 'idle-secondary-color');
     transition:
         transform 150ms cubic-bezier(.4, 0, .2, 1),
         color 150ms cubic-bezier(.4, 0, .2, 1),
@@ -65,64 +92,23 @@ input:placeholder-shown + [part='notch'] [part='label'],
     will-change: font-size, color, transform;
 }
 
-:host(:focus-within) {
-    [part='start'] {
-        border: {
-            color: $active-color;
-            inline: {
-                start-width: $active-border-width;
-            };
-            block: {
-                start-width: $active-border-width;
-                end-width: $active-border-width;
-            }
-        }
-    }
-
-    [part='notch'] {
-        border: {
-            width: $active-border-width;
-            color: $active-color;
-            top: $idle-border-width solid transparent;
-        }
-    }
-
-    [part='filler'] {
-        border: {
-            width: $active-border-width;
-            color: $active-color;
-        }
-    }
-
-    [part='end'] {
-        border: {
-            color: $active-color;
-            inline: {
-                end-width: $active-border-width;
-            };
-            block: {
-                start-width: $active-border-width;
-                end-width: $active-border-width;
-            };
-        }
-    }
-
-    [part='label'] {
-        @extend %label;
-
-        color: $active-color;
-    }
-
-    [part~='prefix'],
-    [part~='suffix'] {
-        color: color(gray, 900);
-    }
-}
-
 [part~='filled'] {
-    [part~='prefix'],
+    [part~='prefix'] {
+        background: var-get($theme, 'input-prefix-background--filled');
+        color: var-get($theme, 'input-prefix-color--filled');
+
+        ::slotted(*) {
+            color: inherit;
+        }
+    }
+
     [part~='suffix'] {
-        color: color(gray, 900);
+        background: var-get($theme, 'input-suffix-background--filled');
+        color: var-get($theme, 'input-suffix-color--filled');
+
+        ::slotted(*) {
+            color: inherit;
+        }
     }
 }
 
@@ -133,24 +119,6 @@ input:placeholder-shown + [part='notch'] [part='label'],
 [part='start'] {
     justify-content: flex-start;
     grid-area: 1 / 1;
-    border: {
-        style: solid;
-        color: $idle-color;
-        inline: {
-            start-width: $idle-border-width;
-            end-width: 0;
-        };
-        block: {
-            start-width: $idle-border-width;
-            end-width: $idle-border-width;
-        };
-        start: {
-            start-radius: rem(4px);
-        };
-        end: {
-            start-radius: rem(4px);
-        };
-    }
 
     > [part='prefix'] {
         ::slotted(*) {
@@ -167,14 +135,6 @@ input:placeholder-shown + [part='notch'] [part='label'],
     height: 100%;
     grid-area: 1 / 2;
     padding: 0 rem(4px);
-    border: {
-        width: $idle-border-width;
-        style: solid;
-        color: $idle-color;
-        left: none;
-        right: none;
-    }
-
     overflow: visible;
 
     &:empty {
@@ -184,36 +144,11 @@ input:placeholder-shown + [part='notch'] [part='label'],
 
 [part='filler'] {
     grid-area: 1 / 3;
-    border: {
-        width: $idle-border-width;
-        style: solid;
-        color: $idle-color;
-        left: none;
-        right: none;
-    }
 }
 
 [part='end'] {
     justify-content: flex-end;
     grid-area: 1 / 4;
-    border: {
-        style: solid;
-        color: $idle-color;
-        inline: {
-            start-width: 0;
-            end-width: $idle-border-width;
-        };
-        block: {
-            start-width: $idle-border-width;
-            end-width: $idle-border-width;
-        };
-        start: {
-            end-radius: rem(4px);
-        };
-        end: {
-            end-radius: rem(4px);
-        };
-    }
 
     > [part='suffix'] {
         ::slotted(*) {
@@ -238,33 +173,115 @@ input:placeholder-shown + [part='notch'] [part='label'],
     color: color(gray, 700);
 }
 
-:host([invalid]),
-:host([invalid]:focus-within) {
-    [part='start'],
-    [part='notch'],
-    [part='filler'],
-    [part='end'] {
-        border-color: $error-color;
-    }
-
+:host(:focus-within) {
     [part='label'] {
-        color: $error-color;
+        @extend %label;
+
+        color: var-get($theme, 'focused-secondary-color');
     }
 
-    [part~='filled'] + [part='notch'] {
-        @extend %floated-styles;
+    [part~='prefix'] {
+        background: var-get($theme, 'input-prefix-background--focused');
+        color: var-get($theme, 'input-prefix-color--focused');
+
+        ::slotted(*) {
+            color: inherit;
+        }
+    }
+
+    [part~='suffix'] {
+        background: var-get($theme, 'input-suffix-background--focused');
+        color: var-get($theme, 'input-suffix-color--focused');
+
+        ::slotted(*) {
+            color: inherit;
+        }
     }
 }
 
-:host([invalid]:focus-within) {
-    [part='notch'] {
-        border-top: $idle-border-width solid transparent;
+:host(:not([outlined])) {
+    [part='label'] {
+        inset-inline-start: rem(2px);
+    }
+
+    [part~='container'] {
+        background: var-get($theme, 'box-background');
+        border-bottom: 1px solid var-get($theme, 'idle-bottom-line-color');
+
+        border: {
+            start: {
+                end-radius: var-get($theme, 'box-border-radius');
+                start-radius: var-get($theme, 'box-border-radius');
+            };
+        }
+
+        transition: border-bottom-width 150ms cubic-bezier(.4, 0, .2, 1);
+
+        &::after {
+            position: absolute;
+            content: '';
+            width: 100%;
+            height: rem(2px);
+            left: 0;
+            right: 0;
+            bottom: -1px;
+            background: var-get($theme, 'idle-bottom-line-color');
+            transform: scaleX(0);
+            transition: transform 180ms cubic-bezier(.4, 0, .2, 1), opacity 180ms cubic-bezier(.4, 0, .2, 1);
+        }
+    }
+
+    [part~='labelled'] [part~='input'] {
+        padding-top: rem(20px);
+        padding-bottom: rem(6px);
+    }
+
+    input:placeholder-shown + [part='notch'] [part='label'],
+    [part~='filled'] + [part='notch'] [part='label'] {
+        transform: translateY(-106%);
     }
 }
 
-:host([disabled]) {
-    pointer-events: none;
+:host(:not([outlined]):hover) {
+    [part~='container'] {
+        background: var-get($theme, 'box-background-hover');
+        border-bottom-color: var-get($theme, 'hover-bottom-line-color');
 
+        &::after {
+            background: var-get($theme, 'hover-bottom-line-color');
+        }
+    }
+}
+
+:host(:not([outlined]):focus-within) {
+    [part~='container'] {
+        background: var-get($theme, 'box-background-focus');
+        border-bottom-color: var-get($theme, 'focused-bottom-line-color');
+
+        &::after {
+            background: var-get($theme, 'focused-bottom-line-color');
+            transform: scaleX(1);
+            opacity: 1;
+        }
+    }
+
+    [part='notch'] [part='label'] {
+        transform: translateY(-106%);
+    }
+}
+
+:host(:not([outlined])[invalid]),
+:host(:not([outlined])[invalid]:focus-within) {
+    [part~='container'] {
+        border-color: var-get($theme, 'error-secondary-color');
+
+        &::after {
+            background: var-get($theme, 'error-secondary-color');
+        }
+    }
+}
+
+:host(:not([outlined])[disabled]) {
     [part~='input'],
     [part='label'],
     [part='prefix'],
@@ -273,16 +290,79 @@ input:placeholder-shown + [part='notch'] [part='label'],
         color: color(gray, 500);
     }
 
-    [part='start'],
-    [part='filler'],
-    [part='notch'],
-    [part='end'] {
-        color: color(gray, 500);
+    [part~='container'] {
+        background: color(gray, 100);
         border-color: color(gray, 500);
+        border-bottom-style: dashed;
+    }
+}
+
+:host([outlined]) {
+    [part^='container'] {
+        border-radius: var-get($theme, 'border-border-radius');
+        background: var-get($theme, 'border-background');
     }
 
-    input::placeholder {
-        color: color(gray, 500);
+    [part='start'] {
+        border: {
+            style: solid;
+            color: var-get($theme, 'border-color');
+            inline: {
+                start-width: $idle-border-width;
+                end-width: 0;
+            };
+            block: {
+                start-width: $idle-border-width;
+                end-width: $idle-border-width;
+            };
+            start: {
+                start-radius: var-get($theme, 'border-border-radius');
+            };
+            end: {
+                start-radius: var-get($theme, 'border-border-radius');
+            };
+        }
+    }
+
+    [part='notch'] {
+        border: {
+            width: $idle-border-width;
+            style: solid;
+            color: var-get($theme, 'border-color');
+            left: none;
+            right: none;
+        }
+    }
+
+    [part='filler'] {
+        border: {
+            width: $idle-border-width;
+            style: solid;
+            color: var-get($theme, 'border-color');
+            left: none;
+            right: none;
+        }
+    }
+
+    [part='end'] {
+        border: {
+            style: solid;
+            color: var-get($theme, 'border-color');
+            inline: {
+                start-width: 0;
+                end-width: $idle-border-width;
+            };
+            block: {
+                start-width: $idle-border-width;
+                end-width: $idle-border-width;
+            };
+            start: {
+                end-radius: var-get($theme, 'border-border-radius');
+            };
+            end: {
+                end-radius: var-get($theme, 'border-border-radius');
+            };
+        }
     }
 
     [part~='filled'] + [part='notch'] {
@@ -290,7 +370,49 @@ input:placeholder-shown + [part='notch'] [part='label'],
     }
 }
 
-// Filled Style
+:host([outlined]:focus-within) {
+    [part='start'] {
+        border: {
+            color: var-get($theme, 'focused-border-color');
+            inline: {
+                start-width: $active-border-width;
+            };
+            block: {
+                start-width: $active-border-width;
+                end-width: $active-border-width;
+            }
+        }
+    }
+
+    [part='notch'] {
+        border: {
+            width: $active-border-width;
+            color: var-get($theme, 'focused-border-color');
+            top: $idle-border-width solid transparent;
+        }
+    }
+
+    [part='filler'] {
+        border: {
+            width: $active-border-width;
+            color: var-get($theme, 'focused-border-color');
+        }
+    }
+
+    [part='end'] {
+        border: {
+            color: var-get($theme, 'focused-border-color');
+            inline: {
+                end-width: $active-border-width;
+            };
+            block: {
+                start-width: $active-border-width;
+                end-width: $active-border-width;
+            };
+        }
+    }
+}
+
 :host([outlined]:active),
 :host([outlined]:focus),
 :host([outlined]:focus-within) {
@@ -310,123 +432,68 @@ input:placeholder-shown + [part='notch'] [part='label'],
     }
 }
 
-:host(:not([outlined])) {
-    [part='start'],
-    [part='end'] {
-        border-color: transparent;
-        border-width: rem(1px);
-    }
-
-    [part='start'] {
-        border-end-start-radius: 0;
-    }
-
-    [part='end'] {
-        border-end-end-radius: 0;
-    }
-
-    [part='notch'],
-    [part='filler'] {
-        border-top: 1px solid transparent;
-        border-bottom: transparent;
-        border-bottom-width: rem(1px);
-    }
-
-    [part='label'] {
-        inset-inline-start: rem(2px);
-    }
-
-    [part~='container'] {
-        background: color(gray, 200);
-        border-bottom: 1px solid $idle-color;
-
-        border: {
-            start: {
-                end-radius: rem(4px);
-                start-radius: rem(4px);
-            };
-        }
-
-        transition: border-bottom-width 150ms cubic-bezier(.4, 0, .2, 1);
-
-        &::after {
-            position: absolute;
-            content: '';
-            width: 100%;
-            height: rem(2px);
-            left: 0;
-            right: 0;
-            bottom: -1px;
-            background: $active-color;
-            transform: scaleX(0);
-            transition: transform 180ms cubic-bezier(.4, 0, .2, 1), opacity 180ms cubic-bezier(.4, 0, .2, 1);
-        }
-    }
-
-    [part~='labelled'] [part~='input'] {
-        padding-top: rem(20px);
-        padding-bottom: rem(6px);
-    }
-
-    input:placeholder-shown + [part='notch'] [part='label'],
-    [part~='filled'] + [part='notch'] [part='label'] {
-        transform: translateY(-106%);
-    }
-}
-
-:host(:not([outlined]):hover) {
-    [part~='container'] {
-        background: $hover-background;
-        border-bottom: 1px solid color(gray, 800);
-    }
-}
-
-:host(:not([outlined]):focus-within) {
-    [part~='container'] {
-        background: $focus-background;
-        border-bottom: 1px solid $active-color;
-
-        &::after {
-            transform: scaleX(1);
-            opacity: 1;
-        }
-    }
-
-    [part='notch'] [part='label'] {
-        transform: translateY(-106%);
-    }
-}
-
-:host(:not([outlined])[invalid]),
-:host(:not([outlined])[invalid]:focus-within) {
+:host([outlined][invalid]),
+:host([outlined][invalid]:focus-within) {
     [part='start'],
     [part='notch'],
     [part='filler'],
     [part='end'] {
-        border-color: transparent;
+        border-color: var-get($theme, 'error-secondary-color');
     }
 
-    [part~='container'] {
-        border-color: $error-color;
-
-        &::after {
-            background: $error-color;
-        }
+    [part~='filled'] + [part='notch'] {
+        @extend %floated-styles;
     }
 }
 
-:host(:not([outlined])[disabled]) {
+:host([outlined][invalid]:focus-within) {
+    [part='notch'] {
+        border-top: $idle-border-width solid transparent;
+    }
+}
+
+:host([invalid]) {
+    [part='label'] {
+        color: var-get($theme, 'error-secondary-color');
+    }
+
+    [part='helper-text'] {
+        color: var-get($theme, 'error-secondary-color');
+    }
+}
+
+:host([disabled][outlined]) {
+    [part='start'],
+    [part='filler'],
+    [part='notch'],
+    [part='end'] {
+        border-color: var-get($theme, 'disabled-border-color');
+    }
+}
+
+:host([disabled]) {
+    pointer-events: none;
+
     [part~='input'],
     [part='label'],
     [part='prefix'],
     [part='suffix'],
     [part='helper-text'] {
-        color: color(gray, 500);
+        color: var-get($theme, 'disabled-text-color');
     }
 
-    [part~='container'] {
-        background: color(gray, 100);
-        border-color: color(gray, 500);
-        border-bottom-style: dashed;
+    [part='start'],
+    [part='filler'],
+    [part='notch'],
+    [part='end'] {
+        color: var-get($theme, 'disabled-text-color');
+    }
+
+    input::placeholder {
+        color: var-get($theme, 'disabled-text-color');
+    }
+
+    [part~='filled'] + [part='notch'] {
+        @extend %floated-styles;
     }
 }


### PR DESCRIPTION
closes #767

- Move all colors inside the shared base file to individual themes.
- Prepare all themes to use schema colors
- Make input material theme consume colors from the schema