### PR TITLE
fix(select,combo): error in Chromium on remove from DOM after blur

### DIFF
--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -532,6 +532,7 @@ export default class IgcComboComponent<T extends object>
   /** Removes focus from the component. */
   public override blur() {
     this.target.blur();
+    super.blur();
   }
 
   protected normalizeSelection(items: Item<T> | Item<T>[] = []): Item<T>[] {

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -238,6 +238,7 @@ export default class IgcSelectComponent extends EventEmitterMixin<
   @alternateName('blurComponent')
   public override blur() {
     this.target.blur();
+    super.blur();
   }
 
   /** Checks the validity of the control and moves the focus to it if it is not valid. */


### PR DESCRIPTION
Fixes https://github.com/IgniteUI/igniteui-angular/issues/13096

## Additional details:
Issue is specific to Chromium-based browsers and doesn't reproduce in Firefox and the Select/Combo being used as templates in the Elements Grid, so no cleaner repro available.

It's to do with how blur is handled immediately before an element is discarded from the DOM, which is exactly what the Grid's virtualization does - blurs the `activeElement` (to avoid a previous bug with that being removed from the DOM) on scroll and then if scrolled further enough the select/combo template might also be replaced with different content, i.e. removed from the DOM.
It's not a 100% consistent, but when that happens in quick succession you get a cryptic error for `insertBefore` with completely unrelated stack.

Tracking this down, narrowing that only the select and combo cause this (which normal `igc-input` works just fine) and then trashing most of their internal handling to isolate the problem led to this:
https://github.com/IgniteUI/igniteui-webcomponents/blob/9505939a3701845f958a112ae17aae38e066a96a/src/components/select/select.ts#L239-L241
I also tried leaving the handler completely empty, since I don't get it's point and even the mere presence of the override caused the error. Which led me to the conclusion that the base `HTMLElement` blur does something actually needed in Chromium and thus this fix.

I'd still argue the blur override might not even be needed, but that's for a separate issue.