### PR TITLE
Keep firstUpdated overrides protected

### DIFF
--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -218,7 +218,7 @@ export default class IgcDropdownComponent
     });
   }
 
-  public override async firstUpdated() {
+  protected override async firstUpdated() {
     if (this.targetNodes.length) {
       this.target = this.targetNodes[0];
       this.target.setAttribute('aria-haspopup', 'listbox');

--- a/src/components/expansion-panel/expansion-panel.ts
+++ b/src/components/expansion-panel/expansion-panel.ts
@@ -95,7 +95,7 @@ export default class IgcExpansionPanelComponent extends EventEmitterMixin<
       `igc-expansion-panel-${IgcExpansionPanelComponent.increment()}`;
   }
 
-  public override firstUpdated() {
+  protected override firstUpdated() {
     this.animationPlayer = new AnimationPlayer(this.panelContent);
   }
 

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -261,7 +261,7 @@ export default class IgcSelectComponent extends EventEmitterMixin<
     return !this.invalid;
   }
 
-  public override async firstUpdated() {
+  protected override async firstUpdated() {
     super.firstUpdated();
     await this.updateComplete;
 

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -79,7 +79,7 @@ export default class IgcSnackbarComponent extends EventEmitterMixin<
   @property({ attribute: 'action-text' })
   public actionText!: string;
 
-  public override firstUpdated() {
+  protected override firstUpdated() {
     this.animationPlayer = new AnimationPlayer(this.content);
   }
 

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -44,7 +44,7 @@ export default class IgcToastComponent extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'keep-open' })
   public keepOpen = false;
 
-  public override firstUpdated() {
+  protected override firstUpdated() {
     this.animationPlayer = new AnimationPlayer(this);
   }
 


### PR DESCRIPTION
Couple of newly added and some more missed from before `firstUpdated` overrides as public that show up in API docs - marked protected.