### PR TITLE
docs(stepper): drop internal prop from public API

### DIFF
--- a/src/components/stepper/step.ts
+++ b/src/components/stepper/step.ts
@@ -166,6 +166,7 @@ export default class IgcStepComponent extends LitElement {
     );
   }
 
+  /** @hidden @internal */
   public get isAccessible(): boolean {
     return !this.disabled && !this.linearDisabled;
   }


### PR DESCRIPTION
Don't think this prop on the step was meant to be public (not in the spec for sure), so marking it as internal. Feel free to correct me if not the case.