### PR TITLE
refactor(combo): generic type param default, explicit selection type

### DIFF
--- a/src/components/combo/combo.spec.ts
+++ b/src/components/combo/combo.spec.ts
@@ -1038,7 +1038,7 @@ describe('Combo', () => {
     });
 
     it('should display primitive values correctly', async () => {
-      const combo = await fixture<IgcComboComponent<any>>(
+      const combo = await fixture<IgcComboComponent>(
         html`<igc-combo .data=${primitive}></igc-combo>`
       );
 
@@ -1065,7 +1065,7 @@ describe('Combo', () => {
     });
 
     it('should set the initial selection by using the `value` attribute', async () => {
-      const combo = await fixture<IgcComboComponent<any>>(
+      const combo = await fixture<IgcComboComponent>(
         html`<igc-combo
           .data=${primitive}
           .value=${['Sofia', 'Varna']}

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -97,7 +97,7 @@ defineComponents(
 @blazorAdditionalDependencies('IgcIconComponent, IgcInputComponent')
 @blazorIndirectRender
 // TODO: pressing arrow down should scroll to the selected item
-export default class IgcComboComponent<T extends object>
+export default class IgcComboComponent<T extends object = any>
   extends EventEmitterMixin<IgcComboEventMap, Constructor<LitElement>>(
     LitElement
   )
@@ -543,7 +543,7 @@ export default class IgcComboComponent<T extends object>
   /**
    * Returns the current selection as an array of objects as provided in the `data` source.
    */
-  public get selection() {
+  public get selection(): Array<T> {
     return Array.from(this.selectionController.selected.values());
   }
 


### PR DESCRIPTION
Assign a default `any` to the Combo's generic type param so the type can be used without necessarily specifying it (can also default to object I suppose?).
Also explicitly typing `selection` - so far it's inferred correctly, but just in case the code changes.