### PR TITLE
chore: igc-select flip on by default

### DIFF
--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -329,13 +329,13 @@ export default class IgcComboComponent<T extends object = any>
 
   /**
    * Sets the component's positioning strategy.
-   * @hidden @internal
+   * @hidden @internal @private
    */
   public positionStrategy: 'absolute' | 'fixed' = 'fixed';
 
   /**
    * Whether the dropdown's width should be the same as the target's one.
-   * @hidden @internal
+   * @hidden @internal @private
    */
   public sameWidth = true;
 

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -187,17 +187,28 @@ export default class IgcSelectComponent extends EventEmitterMixin<
 
   /**
    * @deprecated since version 5.0. It will be removed in the next major release.
-   * @hidden @internal
+   * @hidden @internal @private
    */
   public override positionStrategy: 'absolute' | 'fixed' = 'fixed';
 
   /**
    * Whether the dropdown's width should be the same as the target's one.
    * @deprecated since version 5.0. It will be removed in the next major release.
+   * @hidden @internal @private
    * @attr same-width
    */
   @property({ type: Boolean, attribute: 'same-width' })
   public override sameWidth = true;
+
+  /**
+   * Whether the component should be flipped to the opposite side of the target once it's about to overflow the visible area.
+   * When true, once enough space is detected on its preferred side, it will flip back.
+   * @deprecated since version 5.0. It will be removed in the next major release.
+   * @hidden @internal @private
+   * @attr
+   */
+  @property({ type: Boolean })
+  public override flip = true;
 
   /**
    * The direction attribute of the control.

--- a/stories/combo.stories.ts
+++ b/stories/combo.stories.ts
@@ -119,20 +119,6 @@ const metadata: Meta<IgcComboComponent> = {
       control: 'boolean',
       defaultValue: false,
     },
-    positionStrategy: {
-      type: '"absolute" | "fixed"',
-      description: "Sets the component's positioning strategy.",
-      options: ['absolute', 'fixed'],
-      control: { type: 'inline-radio' },
-      defaultValue: 'fixed',
-    },
-    sameWidth: {
-      type: 'boolean',
-      description:
-        "Whether the dropdown's width should be the same as the target's one.",
-      control: 'boolean',
-      defaultValue: true,
-    },
   },
   args: {
     disabled: false,
@@ -148,8 +134,6 @@ const metadata: Meta<IgcComboComponent> = {
     groupSorting: 'asc',
     caseSensitiveIcon: false,
     disableFiltering: false,
-    positionStrategy: 'fixed',
-    sameWidth: true,
   },
 };
 
@@ -189,10 +173,6 @@ interface IgcComboArgs {
   caseSensitiveIcon: boolean;
   /** Disables the filtering of the list of options. */
   disableFiltering: boolean;
-  /** Sets the component's positioning strategy. */
-  positionStrategy: 'absolute' | 'fixed';
-  /** Whether the dropdown's width should be the same as the target's one. */
-  sameWidth: boolean;
 }
 type Story = StoryObj<IgcComboArgs>;
 

--- a/stories/select.stories.ts
+++ b/stories/select.stories.ts
@@ -123,32 +123,11 @@ const metadata: Meta<IgcSelectComponent> = {
       control: { type: 'select' },
       defaultValue: 'bottom-start',
     },
-    positionStrategy: {
-      type: '"absolute" | "fixed"',
-      description: "Sets the component's positioning strategy.",
-      options: ['absolute', 'fixed'],
-      control: { type: 'inline-radio' },
-      defaultValue: 'fixed',
-    },
-    flip: {
-      type: 'boolean',
-      description:
-        "Whether the component should be flipped to the opposite side of the target once it's about to overflow the visible area.\nWhen true, once enough space is detected on its preferred side, it will flip back.",
-      control: 'boolean',
-      defaultValue: false,
-    },
     distance: {
       type: 'number',
       description: 'The distance from the target element.',
       control: 'number',
       defaultValue: '0',
-    },
-    sameWidth: {
-      type: 'boolean',
-      description:
-        "Whether the dropdown's width should be the same as the target's one.",
-      control: 'boolean',
-      defaultValue: true,
     },
     size: {
       type: '"small" | "medium" | "large"',
@@ -169,10 +148,7 @@ const metadata: Meta<IgcSelectComponent> = {
     keepOpenOnOutsideClick: false,
     open: false,
     placement: 'bottom-start',
-    positionStrategy: 'fixed',
-    flip: false,
     distance: '0',
-    sameWidth: true,
     size: 'medium',
   },
 };
@@ -222,17 +198,8 @@ interface IgcSelectArgs {
     | 'left'
     | 'left-start'
     | 'left-end';
-  /** Sets the component's positioning strategy. */
-  positionStrategy: 'absolute' | 'fixed';
-  /**
-   * Whether the component should be flipped to the opposite side of the target once it's about to overflow the visible area.
-   * When true, once enough space is detected on its preferred side, it will flip back.
-   */
-  flip: boolean;
   /** The distance from the target element. */
   distance: number;
-  /** Whether the dropdown's width should be the same as the target's one. */
-  sameWidth: boolean;
   /** Determines the size of the component. */
   size: 'small' | 'medium' | 'large';
 }


### PR DESCRIPTION
Hide deprecated properties from elements manifest and API documentation