### PR TITLE
feat(stories): Adding global color to all previews

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -94,6 +94,7 @@ const themeProvider: Decorator = (Story, context) => {
     .docs-story,
     .sb-main-padded {
         background: ${context.globals.variant === 'light' ? '#fff' : '#000'};
+        color: ${context.globals.variant === 'light' ? '#000' : '#fff'};
     }
 
     ${context.loaded.theme}


### PR DESCRIPTION
closes #822 

This fixes the icon color in the dark themes since the icon default color is set to 'currentColor'