### PR TITLE
fix(dropdown): header css import extension

### DIFF
--- a/src/components/dropdown/dropdown-header.ts
+++ b/src/components/dropdown/dropdown-header.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from 'lit';
 import { themes } from '../../theming/theming-decorator.js';
-import { styles } from './themes/light/header/dropdown-header.base.css';
+import { styles } from './themes/light/header/dropdown-header.base.css.js';
 import { styles as bootstrap } from './themes/light/header/dropdown-header.bootstrap.css.js';
 import { styles as fluent } from './themes/light/header/dropdown-header.fluent.css.js';
 import { styles as indigo } from './themes/light/header/dropdown-header.indigo.css.js';


### PR DESCRIPTION
Ensure full extension for the css import as in some consuming apps (namely Webpack depending on config) it will fail to build with "Module not found: Error: Can't resolve './themes/light/header/dropdown-header.base.css'"