### PR TITLE
Fix DateTimeInput Value binding issue in Blazor

### DIFF
--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -27,6 +27,7 @@ export default class IgcAccordionComponent extends LitElement {
   public static readonly tagName = 'igc-accordion';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcExpansionPanelComponent);
   }

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -28,6 +28,7 @@ export default class IgcAvatarComponent extends SizableMixin(LitElement) {
   public static readonly tagName = 'igc-avatar';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -23,6 +23,7 @@ export default class IgcBadgeComponent extends LitElement {
   public static readonly tagName = 'igc-badge';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/button-group/button-group.ts
+++ b/src/components/button-group/button-group.ts
@@ -36,6 +36,7 @@ export default class IgcButtonGroupComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-button-group';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcToggleButtonComponent);
   }

--- a/src/components/button-group/toggle-button.ts
+++ b/src/components/button-group/toggle-button.ts
@@ -27,6 +27,7 @@ export default class IgcToggleButtonComponent extends LitElement {
     delegatesFocus: true,
   };
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -30,6 +30,7 @@ export default class IgcButtonComponent extends IgcButtonBaseComponent {
   public static readonly tagName = 'igc-button';
   protected static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/button/icon-button.ts
+++ b/src/components/button/icon-button.ts
@@ -27,6 +27,7 @@ export default class IgcIconButtonComponent extends IgcButtonBaseComponent {
   public static readonly tagName = 'igc-icon-button';
   protected static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcIconComponent);
   }

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -68,6 +68,7 @@ export default class IgcCalendarComponent extends SizableMixin(
   public static readonly tagName = 'igc-calendar';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/calendar/days-view/days-view.ts
+++ b/src/components/calendar/days-view/days-view.ts
@@ -56,6 +56,7 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-days-view';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/calendar/months-view/months-view.ts
+++ b/src/components/calendar/months-view/months-view.ts
@@ -37,6 +37,7 @@ export default class IgcMonthsViewComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-months-view';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/calendar/years-view/years-view.ts
+++ b/src/components/calendar/years-view/years-view.ts
@@ -36,6 +36,7 @@ export default class IgcYearsViewComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-years-view';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/card/card.actions.ts
+++ b/src/components/card/card.actions.ts
@@ -18,6 +18,7 @@ export default class IgcCardActionsComponent extends LitElement {
   public static readonly tagName = 'igc-card-actions';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/card/card.content.ts
+++ b/src/components/card/card.content.ts
@@ -16,6 +16,7 @@ export default class IgcCardContentComponent extends LitElement {
   public static readonly tagName = 'igc-card-content';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/card/card.header.ts
+++ b/src/components/card/card.header.ts
@@ -21,6 +21,7 @@ export default class IgcCardHeaderComponent extends LitElement {
   public static readonly tagName = 'igc-card-header';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/card/card.media.ts
+++ b/src/components/card/card.media.ts
@@ -12,6 +12,7 @@ export default class IgcCardMediaComponent extends LitElement {
   public static readonly tagName = 'igc-card-media';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -21,6 +21,7 @@ export default class IgcCardComponent extends LitElement {
   public static readonly tagName = 'igc-card';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -31,6 +31,7 @@ export default class IgcCheckboxComponent extends IgcCheckboxBaseComponent {
   public static readonly tagName = 'igc-checkbox';
   protected static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/checkbox/switch.ts
+++ b/src/components/checkbox/switch.ts
@@ -30,6 +30,7 @@ export default class IgcSwitchComponent extends IgcCheckboxBaseComponent {
   public static readonly tagName = 'igc-switch';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/chip/chip.ts
+++ b/src/components/chip/chip.ts
@@ -41,6 +41,7 @@ export default class IgcChipComponent extends SizableMixin(
   public static readonly tagName = 'igc-chip';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcIconComponent);
   }

--- a/src/components/combo/combo-header.ts
+++ b/src/components/combo/combo-header.ts
@@ -11,6 +11,7 @@ export default class IgcComboHeaderComponent extends LitElement {
   public static readonly tagName: string = 'igc-combo-header';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/combo/combo-item.ts
+++ b/src/components/combo/combo-item.ts
@@ -14,6 +14,7 @@ export default class IgcComboItemComponent extends LitElement {
   public static readonly tagName: string = 'igc-combo-item';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcCheckboxComponent);
   }

--- a/src/components/combo/combo-list.ts
+++ b/src/components/combo/combo-list.ts
@@ -8,6 +8,7 @@ export default class IgcComboListComponent extends LitVirtualizer {
   public static readonly tagName = 'igc-combo-list';
   public override scroller = true;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -106,6 +106,7 @@ export default class IgcComboComponent<
   public static readonly tagName = 'igc-combo';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/date-time-input/date-time-input.ts
+++ b/src/components/date-time-input/date-time-input.ts
@@ -71,6 +71,7 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
 >(IgcMaskInputBaseComponent) {
   public static readonly tagName = 'igc-date-time-input';
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/date-time-input/date-time-input.ts
+++ b/src/components/date-time-input/date-time-input.ts
@@ -144,12 +144,12 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
    * The value of the input.
    * @attr
    */
-  @property({ converter: converter })
-  @blazorTwoWayBind('igcChange', 'detail')
   public get value(): Date | null {
     return this._value;
   }
 
+  @property({ converter: converter })
+  @blazorTwoWayBind('igcChange', 'detail')
   public set value(val: Date | null) {
     this._value = val
       ? DateTimeUtil.isValidDate(val)

--- a/src/components/dialog/dialog.ts
+++ b/src/components/dialog/dialog.ts
@@ -47,6 +47,7 @@ export default class IgcDialogComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-dialog';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcButtonComponent);
   }

--- a/src/components/dropdown/dropdown-group.ts
+++ b/src/components/dropdown/dropdown-group.ts
@@ -23,6 +23,7 @@ export default class IgcDropdownGroupComponent extends LitElement {
   public static readonly tagName: string = 'igc-dropdown-group';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/dropdown/dropdown-header.ts
+++ b/src/components/dropdown/dropdown-header.ts
@@ -17,6 +17,7 @@ export default class IgcDropdownHeaderComponent extends LitElement {
   public static readonly tagName: string = 'igc-dropdown-header';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/dropdown/dropdown-item.ts
+++ b/src/components/dropdown/dropdown-item.ts
@@ -22,6 +22,7 @@ export default class IgcDropdownItemComponent extends IgcBaseOptionLikeComponent
   public static readonly tagName = 'igc-dropdown-item';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -78,6 +78,7 @@ export default class IgcDropdownComponent extends SizableMixin(
   public static readonly tagName = 'igc-dropdown';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/expansion-panel/expansion-panel.ts
+++ b/src/components/expansion-panel/expansion-panel.ts
@@ -60,6 +60,7 @@ export default class IgcExpansionPanelComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-expansion-panel';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcIconComponent);
   }

--- a/src/components/form/form.ts
+++ b/src/components/form/form.ts
@@ -38,6 +38,7 @@ export default class IgcFormComponent extends EventEmitterMixin<
     }
   `;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -28,6 +28,7 @@ export default class IgcIconComponent extends SizableMixin(LitElement) {
   public static readonly tagName = 'igc-icon';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -44,6 +44,7 @@ import {
 export default class IgcInputComponent extends IgcInputBaseComponent {
   public static readonly tagName = 'igc-input';
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/list/list-header.ts
+++ b/src/components/list/list-header.ts
@@ -18,6 +18,7 @@ export default class IgcListHeaderComponent extends LitElement {
   public static readonly tagName = 'igc-list-header';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/list/list-item.ts
+++ b/src/components/list/list-item.ts
@@ -30,6 +30,7 @@ export default class IgcListItemComponent extends LitElement {
   public static readonly tagName = 'igc-list-item';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/list/list.ts
+++ b/src/components/list/list.ts
@@ -20,6 +20,7 @@ export default class IgcListComponent extends SizableMixin(LitElement) {
   public static readonly tagName = 'igc-list';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcListItemComponent, IgcListHeaderComponent);
   }

--- a/src/components/mask-input/mask-input.ts
+++ b/src/components/mask-input/mask-input.ts
@@ -36,6 +36,7 @@ import { Validator, requiredValidator } from '../common/validators.js';
 export default class IgcMaskInputComponent extends IgcMaskInputBaseComponent {
   public static readonly tagName = 'igc-mask-input';
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/nav-drawer/nav-drawer-header-item.ts
+++ b/src/components/nav-drawer/nav-drawer-header-item.ts
@@ -17,6 +17,7 @@ export default class IgcNavDrawerHeaderItemComponent extends LitElement {
   public static readonly tagName = 'igc-nav-drawer-header-item';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/nav-drawer/nav-drawer-item.ts
+++ b/src/components/nav-drawer/nav-drawer-item.ts
@@ -30,6 +30,7 @@ export default class IgcNavDrawerItemComponent extends LitElement {
   public static readonly tagName = 'igc-nav-drawer-item';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/nav-drawer/nav-drawer.ts
+++ b/src/components/nav-drawer/nav-drawer.ts
@@ -28,6 +28,7 @@ export default class IgcNavDrawerComponent extends LitElement {
   public static readonly tagName = 'igc-nav-drawer';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/navbar/navbar.ts
+++ b/src/components/navbar/navbar.ts
@@ -26,6 +26,7 @@ export default class IgcNavbarComponent extends LitElement {
   public static readonly tagName = 'igc-navbar';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -48,6 +48,7 @@ export default class IgcPopoverComponent extends LitElement {
   public static readonly tagName = 'igc-popover';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/progress/circular-gradient.ts
+++ b/src/components/progress/circular-gradient.ts
@@ -15,6 +15,7 @@ import { registerComponent } from '../common/definitions/register.js';
 export default class IgcCircularGradientComponent extends LitElement {
   public static readonly tagName = 'igc-circular-gradient';
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/progress/circular-progress.ts
+++ b/src/components/progress/circular-progress.ts
@@ -40,6 +40,7 @@ export default class IgcCircularProgressComponent extends IgcProgressBaseCompone
   public static readonly tagName = 'igc-circular-progress';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcCircularGradientComponent);
   }

--- a/src/components/progress/linear-progress.ts
+++ b/src/components/progress/linear-progress.ts
@@ -35,6 +35,7 @@ export default class IgcLinearProgressComponent extends IgcProgressBaseComponent
   public static readonly tagName = 'igc-linear-progress';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/radio-group/radio-group.ts
+++ b/src/components/radio-group/radio-group.ts
@@ -20,6 +20,7 @@ export default class IgcRadioGroupComponent extends LitElement {
   public static readonly tagName = 'igc-radio-group';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcRadioComponent);
   }

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -51,6 +51,7 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
   public static readonly tagName = 'igc-radio';
   protected static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/rating/rating-symbol.ts
+++ b/src/components/rating/rating-symbol.ts
@@ -20,6 +20,7 @@ export default class IgcRatingSymbolComponent extends LitElement {
   public static readonly tagName = 'igc-rating-symbol';
   public static override styles = [styles];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -70,6 +70,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   public static readonly tagName = 'igc-rating';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcIconComponent, IgcRatingSymbolComponent);
   }

--- a/src/components/ripple/ripple.ts
+++ b/src/components/ripple/ripple.ts
@@ -13,6 +13,7 @@ export default class IgcRippleComponent extends LitElement {
   public static readonly tagName = 'igc-ripple';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/select/select-group.ts
+++ b/src/components/select/select-group.ts
@@ -21,6 +21,7 @@ export default class IgcSelectGroupComponent extends LitElement {
   public static readonly tagName = 'igc-select-group';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/select/select-header.ts
+++ b/src/components/select/select-header.ts
@@ -17,6 +17,7 @@ export default class IgcSelectHeaderComponent extends LitElement {
   public static readonly tagName = 'igc-select-header';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/select/select-item.ts
+++ b/src/components/select/select-item.ts
@@ -23,6 +23,7 @@ export default class IgcSelectItemComponent extends IgcBaseOptionLikeComponent {
   public static readonly tagName = 'igc-select-item';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -105,6 +105,7 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
   public static readonly tagName = 'igc-select';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/slider/range-slider.ts
+++ b/src/components/slider/range-slider.ts
@@ -55,6 +55,7 @@ export default class IgcRangeSliderComponent extends EventEmitterMixin<
 >(IgcSliderBaseComponent) {
   public static readonly tagName = 'igc-range-slider';
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcSliderLabelComponent);
   }

--- a/src/components/slider/slider-label.ts
+++ b/src/components/slider/slider-label.ts
@@ -10,6 +10,7 @@ export default class IgcSliderLabelComponent extends LitElement {
     }
   `;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -50,6 +50,7 @@ export default class IgcSliderComponent extends FormAssociatedMixin(
 ) {
   public static readonly tagName = 'igc-slider';
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcSliderLabelComponent);
   }

--- a/src/components/snackbar/snackbar.ts
+++ b/src/components/snackbar/snackbar.ts
@@ -40,6 +40,7 @@ export default class IgcSnackbarComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-snackbar';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcButtonComponent);
   }

--- a/src/components/stepper/step.ts
+++ b/src/components/stepper/step.ts
@@ -48,6 +48,7 @@ export default class IgcStepComponent extends LitElement {
   public static readonly tagName = 'igc-step';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/stepper/stepper.ts
+++ b/src/components/stepper/stepper.ts
@@ -39,6 +39,7 @@ export default class IgcStepperComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-stepper';
   protected static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcStepComponent);
   }

--- a/src/components/tabs/tab-panel.ts
+++ b/src/components/tabs/tab-panel.ts
@@ -15,6 +15,7 @@ export default class IgcTabPanelComponent extends LitElement {
   public static readonly tagName = 'igc-tab-panel';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -27,6 +27,7 @@ export default class IgcTabComponent extends LitElement {
   public static readonly tagName = 'igc-tab';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -58,6 +58,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
   public static readonly tagName = 'igc-tabs';
   public static styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -69,6 +69,7 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   public static readonly tagName = 'igc-textarea';
   public static styles = [styles];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -20,6 +20,7 @@ export default class IgcToastComponent extends IgcBaseAlertLikeComponent {
   public static readonly tagName = 'igc-toast';
   public static override styles = [styles, shared];
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this);
   }

--- a/src/components/tree/tree-item.ts
+++ b/src/components/tree/tree-item.ts
@@ -47,6 +47,7 @@ export default class IgcTreeItemComponent extends LitElement {
   public static readonly tagName = 'igc-tree-item';
   public static override styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(
       this,

--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -39,6 +39,7 @@ export default class IgcTreeComponent extends SizableMixin(
   public static readonly tagName = 'igc-tree';
   public static styles = styles;
 
+  /* blazorSuppress */
   public static register() {
     registerComponent(this, IgcTreeItemComponent);
   }


### PR DESCRIPTION
The two way binding decorator for blazor needs to be applied to the property setter so I adjusted them accordingly.

I also blazor suppressed the static register method on all the components because blazor does not want those.