### PR TITLE
fix(slider): allow touch sliding

### DIFF
--- a/src/components/slider/themes/slider.base.scss
+++ b/src/components/slider/themes/slider.base.scss
@@ -25,6 +25,7 @@ slot {
     height: rem(48px);
     transition: all .2s ease-out;
     font-family: var(--ig-font-family);
+    touch-action: pan-y pinch-zoom;
 }
 
 [part='track'] {


### PR DESCRIPTION
Fix taken from https://github.com/IgniteUI/igniteui-angular/pull/14052

Test against https://igniteui.github.io/igniteui-webcomponents/?path=/docs/slider--docs with dev tools emulation or on mobile and the pointer handling doesn't work for sliding without this.