### PR TITLE
build: Disabled storybook autodocs feature

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,7 +12,7 @@ const config: StorybookConfig = {
     options: {},
   },
   docs: {
-    autodocs: true,
+    autodocs: false,
   },
   viteFinal: async (config, options) => {
     const { mergeConfig } = await import('vite');


### PR DESCRIPTION
The autodocs feature is of questionable value in our current build as it creates "invalid" states of how a component behaves (see #1171 as a recent example). Dumping all the samples and a table of properties without any additional explanation and guidance is not enough IMO. We already have dedicated pages for samples and documentation topics.

Let's disable the autodocs. If we want to improve the Storybook samples with additional documentation and user stories, then we should create a task for it.