### PR TITLE
refactor(btn-group): Removed theme property listener

### DIFF
--- a/src/components/button-group/button-group.ts
+++ b/src/components/button-group/button-group.ts
@@ -14,6 +14,7 @@ import { watch } from '../common/decorators/watch.js';
 import { registerComponent } from '../common/definitions/register.js';
 import type { Constructor } from '../common/mixins/constructor.js';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
+import { findElementFromEventPath } from '../common/util.js';
 
 export interface IgcButtonGroupComponentEventMap {
   igcSelect: CustomEvent<string | undefined>;
@@ -33,7 +34,7 @@ export interface IgcButtonGroupComponentEventMap {
  *
  * @csspart group - The button group container.
  */
-@themes(all, true)
+@themes(all)
 export default class IgcButtonGroupComponent extends EventEmitterMixin<
   IgcButtonGroupComponentEventMap,
   Constructor<LitElement>
@@ -64,11 +65,11 @@ export default class IgcButtonGroupComponent extends EventEmitterMixin<
       added.length ? added.at(-1)! : attributes.at(-1)!
     );
 
-    buttons.forEach((button, i) => {
+    for (const [i, button] of buttons.entries()) {
       if (button.selected && i !== idx) {
         button.selected = false;
       }
-    });
+    }
   }
 
   private get _selectedButtons(): Array<IgcToggleButtonComponent> {
@@ -160,11 +161,10 @@ export default class IgcButtonGroupComponent extends EventEmitterMixin<
   }
 
   private handleClick(event: MouseEvent) {
-    const button = event
-      .composedPath()
-      .find(
-        (element) => element instanceof IgcToggleButtonComponent
-      ) as IgcToggleButtonComponent;
+    const button = findElementFromEventPath<IgcToggleButtonComponent>(
+      IgcToggleButtonComponent.tagName,
+      event
+    );
 
     if (button) {
       this.isMultiple


### PR DESCRIPTION
Use `findElementFromEventPath` in the click handler