### PR TITLE
docs(dropdown): deprecation format

### DIFF
--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -137,7 +137,7 @@ export default class IgcDropdownComponent extends SizableMixin(
    * Sets the component's positioning strategy.
    * @attr position-strategy
    *
-   * @deprecated since v4.9.0 - Stacking context is now handled through the popover API.
+   * @deprecated since v4.9.0. Stacking context is now handled through the popover API.
    */
   @property({ attribute: 'position-strategy' })
   public positionStrategy: 'absolute' | 'fixed' = 'absolute';


### PR DESCRIPTION
Sadly, I don't think there's a good way for this to be folded into 4.9.x to have a consistent base for the analyzer ¯\_(ツ)_/¯