### PR TITLE
perf(core): Improved LTR-RTL detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "lit-analyzer": "^2.0.3",
         "madge": "^7.0.0",
         "node-watch": "^0.7.4",
+        "playwright": "^1.44.1",
         "postcss": "^8.4.38",
         "prettier": "^3.3.1",
         "rimraf": "^5.0.7",
@@ -14319,12 +14320,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.39.0"
+        "playwright-core": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14337,10 +14339,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "lit-analyzer": "^2.0.3",
     "madge": "^7.0.0",
     "node-watch": "^0.7.4",
+    "playwright": "^1.44.1",
     "postcss": "^8.4.38",
     "prettier": "^3.3.1",
     "rimraf": "^5.0.7",

--- a/src/components/common/util.ts
+++ b/src/components/common/util.ts
@@ -49,8 +49,11 @@ export function createCounter() {
   };
 }
 
+/**
+ * Returns whether an element has a Left-to-Right directionality.
+ */
 export function isLTR(element: HTMLElement) {
-  return getComputedStyle(element).getPropertyValue('direction') === 'ltr';
+  return element.matches(':dir(ltr)');
 }
 
 /**

--- a/src/components/input/input.spec.ts
+++ b/src/components/input/input.spec.ts
@@ -417,6 +417,19 @@ describe('Input component', () => {
 
       spec.submitValidates();
     });
+
+    it('validates schema types - url', async () => {
+      spec.element.type = 'url';
+      spec.element.value = '123';
+      await elementUpdated(spec.element);
+
+      spec.submitFails();
+
+      spec.element.value = 'https://github.com/IgniteUI/igniteui-webcomponents';
+      await elementUpdated(spec.element);
+
+      spec.submitValidates();
+    });
   });
 
   describe('issue-1066', () => {


### PR DESCRIPTION
Changed `isLTR` to use the new `:dir(ltr|rtl)` selector, instead of the `getComputedStyle` call which triggers a style reflow. After some prelimenary benchmarks it seems to be ~80% faster for repeated calls.

This is already baseline for our target browsers but I had to updated the playwright package version so it can support the new syntax.
As an added bonus since the new version supports `URL.canParse` I've added a test for the input as well.