### PR TITLE
feat(radio-group): Set radio properties through the group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Banner component [#1174](https://github.com/IgniteUI/igniteui-webcomponents/issues/1174)
+- Radio group - Bind underlying radio components name and checked state through the radio group [#315](https://github.com/IgniteUI/igniteui-webcomponents/issues/315)
 ### Fixed
 - Input, Textarea - passing `undefined` to **value** sets the underlying input value to undefined [#1206](https://github.com/IgniteUI/igniteui-webcomponents/issues/1206)
 - Mask input - after a form `reset` call correctly update underlying input value and placeholder state

--- a/src/components/radio-group/radio-group.ts
+++ b/src/components/radio-group/radio-group.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 
 import { themes } from '../../theming/theming-decorator.js';
 import { registerComponent } from '../common/definitions/register.js';
@@ -29,12 +29,84 @@ export default class IgcRadioGroupComponent extends LitElement {
     registerComponent(IgcRadioGroupComponent, IgcRadioComponent);
   }
 
+  private _internals: ElementInternals;
+  private _name!: string;
+  private _value!: string;
+
+  @queryAssignedElements({ flatten: true })
+  private _radios!: NodeListOf<IgcRadioComponent>;
+
   /**
    * Alignment of the radio controls inside this group.
    * @attr
    */
   @property({ reflect: true })
   public alignment: 'vertical' | 'horizontal' = 'vertical';
+
+  /**
+   * Gets/Sets the name for all child igc-radio components.
+   * @attr
+   */
+  @property({ reflect: true })
+  public set name(value: string) {
+    this._name = value;
+    this._setRadiosName();
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  /**
+   * Gets/Sets the checked igc-radio element that matches `value`
+   * @attr
+   */
+  @property()
+  public set value(value: string) {
+    this._value = value;
+    this._setSelectedRadio();
+  }
+
+  public get value(): string {
+    if (this._radios.length) {
+      this._value =
+        Array.from(this._radios).find((radio) => radio.checked)?.value ?? '';
+    }
+
+    return this._value;
+  }
+
+  constructor() {
+    super();
+
+    this._internals = this.attachInternals();
+    this._internals.role = 'radiogroup';
+  }
+
+  protected override firstUpdated() {
+    const radios = Array.from(this._radios);
+    const allRadiosUnchecked = radios.every((radio) => !radio.checked);
+
+    this._setRadiosName();
+
+    if (allRadiosUnchecked && this._value) {
+      this._setSelectedRadio();
+    }
+  }
+
+  private _setRadiosName() {
+    if (this._name) {
+      for (const radio of this._radios) {
+        radio.name = this._name;
+      }
+    }
+  }
+
+  private _setSelectedRadio() {
+    for (const radio of this._radios) {
+      radio.checked = radio.value === this._value;
+    }
+  }
 
   protected override render() {
     return html`<slot></slot>`;

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -65,7 +65,8 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
       key: 'valueMissing',
       message: messages.required,
       isValid: () => {
-        const { radios, checked } = this.group;
+        const radios = this._radios;
+        const checked = this._checkedRadios;
         return radios.some((radio) => radio.required)
           ? checked.length > 0
           : true;
@@ -92,12 +93,28 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
   @state()
   protected hideLabel = false;
 
-  private get group() {
-    return getGroup(this);
+  /** Returns all radio elements from the group, that is having the same name property. */
+  private get _radios() {
+    return getGroup(this).radios;
+  }
+
+  /** All sibling radio elements of the one invoking the getter. */
+  private get _siblings() {
+    return getGroup(this).siblings;
+  }
+
+  /** All non-disabled radio elements from the group. */
+  private get _active() {
+    return getGroup(this).active;
+  }
+
+  /** All checked radio elements from the group. */
+  private get _checkedRadios() {
+    return getGroup(this).checked;
   }
 
   protected override setDefaultValue(): void {
-    this._defaultValue = this === this.group.checked[0];
+    this._defaultValue = this === this._checkedRadios[0];
   }
 
   /**
@@ -124,10 +141,7 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
   @blazorTwoWayBind('igcChange', 'detail')
   public set checked(value: boolean) {
     this._checked = Boolean(value);
-
-    if (this.hasUpdated) {
-      this._checked ? this._updateCheckedState() : this._updateUncheckedState();
-    }
+    this._checked ? this._updateCheckedState() : this._updateUncheckedState();
   }
 
   public get checked(): boolean {
@@ -154,10 +168,18 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
       .set(arrowDown, () => this.navigate(1));
   }
 
+  protected override createRenderRoot() {
+    const root = super.createRenderRoot();
+    root.addEventListener('slotchange', () => {
+      this.hideLabel = this.label.length < 1;
+    });
+    return root;
+  }
+
   public override connectedCallback() {
     super.connectedCallback();
 
-    this._checked = this === this.group.checked[0];
+    this._checked = this === this._checkedRadios[0];
     this.updateValidity();
   }
 
@@ -183,7 +205,7 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
    * As long as `message` is not empty, the control is considered invalid.
    */
   public override setCustomValidity(message: string): void {
-    const { radios } = this.group;
+    const radios = this._radios;
 
     for (const radio of radios) {
       radio.updateValidity(message);
@@ -193,7 +215,7 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
 
   @watch('required', { waitUntilFirstUpdate: true })
   protected override requiredChange(): void {
-    const { radios } = this.group;
+    const radios = this._radios;
 
     for (const radio of radios) {
       radio.updateValidity();
@@ -202,7 +224,7 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
   }
 
   private _updateCheckedState() {
-    const { siblings } = this.group;
+    const siblings = this._siblings;
 
     this.setFormValue(this.value || 'on');
     this.updateValidity();
@@ -220,18 +242,29 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
   }
 
   private _updateUncheckedState() {
-    const { siblings } = this.group;
+    const siblings = this._siblings;
 
     this.setFormValue(null);
     this.updateValidity();
     this.setInvalidState();
 
-    if (this.hasUpdated) {
-      this._tabIndex = -1;
-    }
+    this._tabIndex = -1;
 
     for (const radio of siblings) {
       radio.updateValidity();
+    }
+  }
+
+  protected override formResetCallback() {
+    super.formResetCallback();
+    this._resetTabIndexes();
+  }
+
+  /** Called after a form reset callback to restore default keyboard navigation. */
+  private _resetTabIndexes() {
+    const radios = this._radios;
+    for (const radio of radios) {
+      radio._tabIndex = 0;
     }
   }
 
@@ -250,7 +283,7 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
   }
 
   protected navigate(idx: number) {
-    const { active } = this.group;
+    const active = this._active;
     const nextIdx = wrap(0, active.length - 1, active.indexOf(this) + idx);
     const radio = active[nextIdx];
 
@@ -259,18 +292,15 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
     radio.emitEvent('igcChange', { detail: radio.checked });
   }
 
-  protected handleSlotChange() {
-    this.hideLabel = this.label.length < 1;
-  }
-
   protected override render() {
     const labelledBy = this.getAttribute('aria-labelledby');
+    const checked = this.checked;
 
     return html`
       <label
         part=${partNameMap({
           base: true,
-          checked: this.checked,
+          checked,
           focused: this._kbFocus.focused,
         })}
         for=${this.inputId}
@@ -283,27 +313,27 @@ export default class IgcRadioComponent extends FormAssociatedRequiredMixin(
           value=${ifDefined(this.value)}
           .required=${this.required}
           .disabled=${this.disabled}
-          .checked=${live(this.checked)}
+          .checked=${live(checked)}
           tabindex=${this._tabIndex}
-          aria-checked=${this.checked ? 'true' : 'false'}
+          aria-checked=${checked ? 'true' : 'false'}
           aria-disabled=${this.disabled ? 'true' : 'false'}
           aria-labelledby=${labelledBy ? labelledBy : this.labelId}
           @click=${this.handleClick}
           @blur=${this.handleBlur}
           @focus=${this.handleFocus}
         />
-        <span part=${partNameMap({ control: true, checked: this.checked })}>
+        <span part=${partNameMap({ control: true, checked })}>
           <span
             .hidden=${this.disabled}
-            part=${partNameMap({ ripple: true, checked: this.checked })}
+            part=${partNameMap({ ripple: true, checked })}
           ></span>
         </span>
         <span
           .hidden=${this.hideLabel}
-          part=${partNameMap({ label: true, checked: this.checked })}
+          part=${partNameMap({ label: true, checked })}
           id=${this.labelId}
         >
-          <slot @slotchange=${this.handleSlotChange}></slot>
+          <slot></slot>
         </span>
       </label>
     `;

--- a/src/components/radio/utils.ts
+++ b/src/components/radio/utils.ts
@@ -1,4 +1,4 @@
-import { isDefined, iterNodes } from '../common/util.js';
+import { iterNodes } from '../common/util.js';
 import type IgcRadioComponent from './radio.js';
 
 type RadioQueryResult = {
@@ -20,7 +20,19 @@ export function getGroup(member: IgcRadioComponent) {
     siblings: [],
   };
 
-  if (!isDefined(globalThis.document)) {
+  // No name property for the passed radio. Skip DOM search and return a group of one radio
+  // with appropriate states.
+  if (!member.name) {
+    result.radios.push(member);
+
+    if (member.checked) {
+      result.checked.push(member);
+    }
+
+    if (!member.disabled) {
+      result.active.push(member);
+    }
+
     return result;
   }
 

--- a/stories/radio-group.stories.ts
+++ b/stories/radio-group.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { html } from 'lit';
+import { html, render } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { IgcRadioGroupComponent, defineComponents } from '../src/index.js';
@@ -27,6 +27,17 @@ const metadata: Meta<IgcRadioGroupComponent> = {
       control: { type: 'inline-radio' },
       table: { defaultValue: { summary: 'vertical' } },
     },
+    name: {
+      type: 'string',
+      description: 'Gets/Sets the name for all child igc-radio components.',
+      control: 'text',
+    },
+    value: {
+      type: 'string',
+      description:
+        'Gets/Sets the checked igc-radio element that matches `value`',
+      control: 'text',
+    },
   },
   args: { alignment: 'vertical' },
 };
@@ -36,6 +47,10 @@ export default metadata;
 interface IgcRadioGroupArgs {
   /** Alignment of the radio controls inside this group. */
   alignment: 'vertical' | 'horizontal';
+  /** Gets/Sets the name for all child igc-radio components. */
+  name: string;
+  /** Gets/Sets the checked igc-radio element that matches `value` */
+  value: string;
 }
 type Story = StoryObj<IgcRadioGroupArgs>;
 
@@ -50,18 +65,24 @@ Object.assign(metadata.parameters!, {
 const radios = ['apple', 'orange', 'mango', 'banana'];
 const titleCase = (s: string) => s.replace(/^\w/, (c) => c.toUpperCase());
 
-const Template = ({ alignment }: IgcRadioGroupArgs) => {
-  return html`
-    <igc-radio-group alignment="${ifDefined(alignment)}">
-      ${radios.map(
-        (v) =>
-          html`<igc-radio name="fruit" value=${v}>${titleCase(v)}</igc-radio> `
-      )}
+export const Default: Story = {
+  args: {
+    name: 'default-state',
+    value: 'mango',
+  },
+  render: (args) => html`
+    <igc-radio-group
+      alignment=${ifDefined(args.alignment)}
+      name=${ifDefined(args.name)}
+      value=${ifDefined(args.value)}
+    >
+      <igc-radio value="apple">Apple</igc-radio>
+      <igc-radio value="orange">Orange</igc-radio>
+      <igc-radio value="mango">Mango</igc-radio>
+      <igc-radio value="banana">Banana</igc-radio>
     </igc-radio-group>
-  `;
+  `,
 };
-
-export const Basic: Story = Template.bind({});
 
 export const Form: Story = {
   render: (args) => {


### PR DESCRIPTION
Added `name` and `value` properties on the igc-radio-group. Developers can now control the checked state of the underlying igc-radio components through the enclosing group.

Closes #315