### PR TITLE
refactor: Icon registry and theming stack

### DIFF
--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -2,8 +2,7 @@ import { html } from 'lit';
 import { property, query, queryAll, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { themeSymbol, themes } from '../../theming/theming-decorator.js';
-import type { Theme } from '../../theming/types.js';
+import { themes } from '../../theming/theming-decorator.js';
 import { watch } from '../common/decorators/watch.js';
 import { registerComponent } from '../common/definitions/register.js';
 import {
@@ -83,7 +82,6 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
   private formatterMonth!: Intl.DateTimeFormat;
   private formatterWeekday!: Intl.DateTimeFormat;
   private formatterMonthDay!: Intl.DateTimeFormat;
-  private declare readonly [themeSymbol]: Theme;
 
   @state()
   private rangePreviewDate?: Date;

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -8,8 +8,7 @@ import {
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 
-import { themeSymbol, themes } from '../../theming/theming-decorator.js';
-import type { Theme } from '../../theming/types.js';
+import { themes } from '../../theming/theming-decorator.js';
 import { addRootClickHandler } from '../common/controllers/root-click.js';
 import { blazorAdditionalDependencies } from '../common/decorators/blazorAdditionalDependencies.js';
 import { blazorIndirectRender } from '../common/decorators/blazorIndirectRender.js';
@@ -146,7 +145,6 @@ export default class IgcComboComponent<
   protected navigationController = new NavigationController<T>(this);
   protected selectionController = new SelectionController<T>(this);
   protected dataController = new DataController<T>(this);
-  private declare readonly [themeSymbol]: Theme;
 
   @queryAssignedElements({ slot: 'helper-text' })
   protected helperText!: Array<HTMLElement>;

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -3,8 +3,7 @@ import { property, query, queryAssignedElements } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 
-import { themeSymbol, themes } from '../../theming/theming-decorator.js';
-import type { Theme } from '../../theming/types.js';
+import { getThemeController, themes } from '../../theming/theming-decorator.js';
 import IgcCalendarComponent, { focusActiveDate } from '../calendar/calendar.js';
 import {
   type DateRangeDescriptor,
@@ -137,7 +136,7 @@ const formats = new Set(['short', 'medium', 'long', 'full']);
  * @csspart selected - The calendar selected state for element(s). Applies to date, month and year elements.
  * @csspart current - The calendar current state for element(s). Applies to date, month and year elements.
  */
-@themes(all, true)
+@themes(all, { exposeController: true })
 @blazorAdditionalDependencies(
   'IgcCalendarComponent, IgcDateTimeInputComponent, IgcDialogComponent, IgcIconComponent'
 )
@@ -157,8 +156,6 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
 
   private static readonly increment = createCounter();
   protected inputId = `date-picker-${IgcDatePickerComponent.increment()}`;
-
-  private declare readonly [themeSymbol]: Theme;
 
   protected override validators: Validator<this>[] = [
     requiredValidator,
@@ -204,10 +201,6 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
     return this.mode === 'dropdown';
   }
 
-  private get isMaterialTheme() {
-    return this[themeSymbol] === 'material';
-  }
-
   @query(IgcDateTimeInputComponent.tagName)
   private _input!: IgcDateTimeInputComponent;
 
@@ -225,6 +218,10 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
 
   @queryAssignedElements({ slot: 'helper-text' })
   private helperText!: Array<HTMLElement>;
+
+  protected get _isMaterialTheme(): boolean {
+    return getThemeController(this)?.theme === 'material';
+  }
 
   /**
    * Sets the state of the datepicker dropdown.
@@ -767,7 +764,7 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
       <igc-date-time-input
         id=${id}
         aria-haspopup="dialog"
-        label=${ifDefined(this.isMaterialTheme ? this.label : undefined)}
+        label=${ifDefined(this._isMaterialTheme ? this.label : undefined)}
         input-format=${ifDefined(this._inputFormat)}
         display-format=${ifDefined(format)}
         ?disabled=${this.disabled}
@@ -804,7 +801,7 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
     const id = this.id || this.inputId;
 
     return html`
-      ${!this.isMaterialTheme ? this.renderLabel(id) : nothing}
+      ${!this._isMaterialTheme ? this.renderLabel(id) : nothing}
       ${this.renderInput(id)}${this.renderPicker(id)}${this.renderHelperText()}
     `;
   }

--- a/src/components/icon/icon-references.ts
+++ b/src/components/icon/icon-references.ts
@@ -1,24 +1,26 @@
-import type { IconMeta, IconReferences, Themes } from './icon.registry.js';
+import type {
+  IconMeta,
+  IconReference,
+  IconThemeKey,
+} from './registry/types.js';
 
-type Icon = {
-  [THEME in Themes]?: IconMeta;
-};
+type Icon = { [key in IconThemeKey]?: IconMeta };
 
-const iconRefs = (icons: Icon) => {
+const makeIconRefs = (icons: Icon) => {
   return new Map(
     Object.entries(icons).map((icon) => {
-      return icon as [theme: Themes, IconMeta];
+      return icon as [theme: IconThemeKey, IconMeta];
     })
   );
 };
 
-export const iconReferences: IconReferences = new Set([
+export const iconReferences: IconReference[] = [
   {
     alias: {
       name: 'expand',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'keyboard_arrow_down',
         collection: 'internal',
@@ -34,7 +36,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'collapse',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'keyboard_arrow_up',
         collection: 'internal',
@@ -50,7 +52,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'arrow_prev',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'navigate_before',
         collection: 'internal',
@@ -66,7 +68,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'arrow_next',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'navigate_next',
         collection: 'internal',
@@ -82,7 +84,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'selected',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'chip_select',
         collection: 'internal',
@@ -94,7 +96,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'remove',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'chip_cancel',
         collection: 'internal',
@@ -106,7 +108,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'clear',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'clear',
         collection: 'internal',
@@ -122,7 +124,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'expand',
       collection: 'combo',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'arrow_drop_down',
         collection: 'internal',
@@ -138,7 +140,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'collapse',
       collection: 'combo',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'arrow_drop_up',
         collection: 'internal',
@@ -154,7 +156,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'expand',
       collection: 'tree',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'keyboard_arrow_right',
         collection: 'internal',
@@ -166,7 +168,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'expand_rtl',
       collection: 'tree',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'navigate_before',
         collection: 'internal',
@@ -178,7 +180,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'collapse',
       collection: 'tree',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'keyboard_arrow_down',
         collection: 'internal',
@@ -190,7 +192,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'case-sensitive',
       collection: 'combo',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'case_sensitive',
         collection: 'internal',
@@ -202,7 +204,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'today',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'calendar_today',
         collection: 'internal',
@@ -214,7 +216,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'star-filled',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'star',
         collection: 'internal',
@@ -226,7 +228,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'star-outlined',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'star_border',
         collection: 'internal',
@@ -238,7 +240,7 @@ export const iconReferences: IconReferences = new Set([
       name: 'prev',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'navigate_before',
         collection: 'internal',
@@ -250,11 +252,11 @@ export const iconReferences: IconReferences = new Set([
       name: 'next',
       collection: 'default',
     },
-    target: iconRefs({
+    target: makeIconRefs({
       default: {
         name: 'navigate_next',
         collection: 'internal',
       },
     }),
   },
-]);
+];

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -2,8 +2,7 @@ import { LitElement, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 
-import { themeSymbol, themes } from '../../theming/theming-decorator.js';
-import type { Theme } from '../../theming/types.js';
+import { getThemeController, themes } from '../../theming/theming-decorator.js';
 import { blazorInclude } from '../common/decorators/blazorInclude.js';
 import { watch } from '../common/decorators/watch.js';
 import { registerComponent } from '../common/definitions/register.js';
@@ -23,11 +22,10 @@ import { all } from './themes/themes.js';
  *
  *
  */
-@themes(all, true)
+@themes(all, { exposeController: true })
 export default class IgcIconComponent extends LitElement {
   public static readonly tagName = 'igc-icon';
   public static override styles = [styles, shared];
-  private declare readonly [themeSymbol]: Theme;
 
   /* blazorSuppress */
   public static register() {
@@ -66,6 +64,9 @@ export default class IgcIconComponent extends LitElement {
     super();
     this.__internals = this.attachInternals();
     this.__internals.role = 'img';
+
+    getThemeController(this)!.onThemeChanged = (theme) =>
+      getIconRegistry().setRefsByTheme(theme);
   }
 
   public override connectedCallback() {
@@ -104,8 +105,6 @@ export default class IgcIconComponent extends LitElement {
   }
 
   protected override render() {
-    getIconRegistry().setRefsByTheme(this[themeSymbol]);
-
     return html`${unsafeSVG(this.svg)}`;
   }
 

--- a/src/components/icon/internal-icons-lib.ts
+++ b/src/components/icon/internal-icons-lib.ts
@@ -1,55 +1,57 @@
-import type { IconCollection } from './icon.registry.js';
+import type { SvgIcon } from './registry/types.js';
 
-export const internalIcons: IconCollection = {
-  navigate_before: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15.61 7.41L14.2 6l-6 6 6 6 1.41-1.41L11.03 12l4.58-4.59z"/></svg>`,
-  },
-  navigate_next: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M10.02 6L8.61 7.41 13.19 12l-4.58 4.59L10.02 18l6-6-6-6z"/></svg>`,
-  },
-  keyboard_arrow_up: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/></svg>`,
-  },
-  keyboard_arrow_down: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/></svg>`,
-  },
-  keyboard_arrow_right: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg>`,
-  },
-  chip_cancel: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/></svg>`,
-  },
-  chip_select: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>`,
-  },
-  star: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M0 0h24v24H0z" fill="none"/><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>`,
-  },
-  star_border: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></svg>`,
-  },
-  case_sensitive: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet"><path d="M21.2 16.5c0-.2-.1-.5-.1-.7v-4.4c0-.4-.1-.8-.3-1.2-.2-.3-.5-.6-.8-.7-.3-.2-.7-.3-1.1-.3-.4-.1-.8-.1-1.2-.1-.5 0-.9 0-1.4.1-.4.1-.8.3-1.2.5-.3.2-.6.5-.8.9s-.3.9-.3 1.3h1.4c0-.5.2-1 .7-1.3.5-.2 1-.4 1.5-.3.2 0 .5 0 .7.1.2 0 .4.1.6.2.2.1.3.2.5.4.1.2.2.5.2.7s-.1.4-.2.6c-.2.2-.4.3-.6.3-.3.1-.6.1-.9.2-.4 0-.7.1-1.1.2-.4.1-.7.1-1.1.2-.3.1-.7.2-1 .4s-.5.5-.7.8c-.2.4-.3.8-.3 1.2s.1.8.2 1.1c.1.3.4.5.6.7.3.2.6.3.9.4.9.2 1.9.2 2.8-.2.5-.2 1-.6 1.4-1 0 .4.1.7.3 1 .2.2.6.3.9.3.4 0 .7-.1 1-.2v-1.1c-.1 0-.3.1-.4.1-.1.1-.2 0-.2-.2zm-1.5-1.7c0 .2-.1.4-.2.6-.1.2-.3.5-.5.6-.2.2-.5.4-.8.5-.4.1-.8.2-1.2.2-.2 0-.4 0-.6-.1-.2 0-.4-.1-.5-.2-.2-.1-.3-.2-.4-.4-.1-.2-.2-.4-.1-.6 0-.3.1-.6.2-.8.2-.2.4-.4.6-.5.3-.1.6-.2.9-.2s.7-.1 1-.1.6-.1.9-.1.5-.1.7-.3v1.4zm-9.6-.4l1.3 3.6h1.8L8.5 6H6.7L2 18h1.7L5 14.4h5.1zm-2.5-7l2.1 5.5H5.5l2.1-5.5z"></path></svg>`,
-  },
-  clear: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>`,
-  },
-  arrow_drop_up: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 14l5-5 5 5z"/></svg>`,
-  },
-  arrow_drop_down: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>`,
-  },
-  arrow_downward: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"/></svg>`,
-  },
-  arrow_upward: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"/></svg>`,
-  },
-  calendar: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M200-80q-33 0-56.5-23.5T120-160v-560q0-33 23.5-56.5T200-800h40v-80h80v80h320v-80h80v80h40q33 0 56.5 23.5T840-720v560q0 33-23.5 56.5T760-80H200Zm0-80h560v-400H200v400Zm0-480h560v-80H200v80Zm0 0v-80 80Z"/></svg>`,
-  },
-  calendar_today: {
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/></svg>`,
-  },
-};
+export const internalIcons = new Map<string, SvgIcon>(
+  Object.entries({
+    navigate_before: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15.61 7.41L14.2 6l-6 6 6 6 1.41-1.41L11.03 12l4.58-4.59z"/></svg>`,
+    },
+    navigate_next: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M10.02 6L8.61 7.41 13.19 12l-4.58 4.59L10.02 18l6-6-6-6z"/></svg>`,
+    },
+    keyboard_arrow_up: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/></svg>`,
+    },
+    keyboard_arrow_down: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/></svg>`,
+    },
+    keyboard_arrow_right: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg>`,
+    },
+    chip_cancel: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/></svg>`,
+    },
+    chip_select: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>`,
+    },
+    star: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M0 0h24v24H0z" fill="none"/><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>`,
+    },
+    star_border: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></svg>`,
+    },
+    case_sensitive: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet"><path d="M21.2 16.5c0-.2-.1-.5-.1-.7v-4.4c0-.4-.1-.8-.3-1.2-.2-.3-.5-.6-.8-.7-.3-.2-.7-.3-1.1-.3-.4-.1-.8-.1-1.2-.1-.5 0-.9 0-1.4.1-.4.1-.8.3-1.2.5-.3.2-.6.5-.8.9s-.3.9-.3 1.3h1.4c0-.5.2-1 .7-1.3.5-.2 1-.4 1.5-.3.2 0 .5 0 .7.1.2 0 .4.1.6.2.2.1.3.2.5.4.1.2.2.5.2.7s-.1.4-.2.6c-.2.2-.4.3-.6.3-.3.1-.6.1-.9.2-.4 0-.7.1-1.1.2-.4.1-.7.1-1.1.2-.3.1-.7.2-1 .4s-.5.5-.7.8c-.2.4-.3.8-.3 1.2s.1.8.2 1.1c.1.3.4.5.6.7.3.2.6.3.9.4.9.2 1.9.2 2.8-.2.5-.2 1-.6 1.4-1 0 .4.1.7.3 1 .2.2.6.3.9.3.4 0 .7-.1 1-.2v-1.1c-.1 0-.3.1-.4.1-.1.1-.2 0-.2-.2zm-1.5-1.7c0 .2-.1.4-.2.6-.1.2-.3.5-.5.6-.2.2-.5.4-.8.5-.4.1-.8.2-1.2.2-.2 0-.4 0-.6-.1-.2 0-.4-.1-.5-.2-.2-.1-.3-.2-.4-.4-.1-.2-.2-.4-.1-.6 0-.3.1-.6.2-.8.2-.2.4-.4.6-.5.3-.1.6-.2.9-.2s.7-.1 1-.1.6-.1.9-.1.5-.1.7-.3v1.4zm-9.6-.4l1.3 3.6h1.8L8.5 6H6.7L2 18h1.7L5 14.4h5.1zm-2.5-7l2.1 5.5H5.5l2.1-5.5z"></path></svg>`,
+    },
+    clear: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>`,
+    },
+    arrow_drop_up: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 14l5-5 5 5z"/></svg>`,
+    },
+    arrow_drop_down: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>`,
+    },
+    arrow_downward: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"/></svg>`,
+    },
+    arrow_upward: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"/></svg>`,
+    },
+    calendar: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M200-80q-33 0-56.5-23.5T120-160v-560q0-33 23.5-56.5T200-800h40v-80h80v80h320v-80h80v80h40q33 0 56.5 23.5T840-720v560q0 33-23.5 56.5T760-80H200Zm0-80h560v-400H200v400Zm0-480h560v-80H200v80Zm0 0v-80 80Z"/></svg>`,
+    },
+    calendar_today: {
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/></svg>`,
+    },
+  })
+);

--- a/src/components/icon/registry/default-map.ts
+++ b/src/components/icon/registry/default-map.ts
@@ -1,0 +1,29 @@
+/* blazorSuppress */
+export class DefaultMap<T, U> {
+  private _defaultValue: () => U;
+  private _map = new Map<T, U>();
+
+  constructor(defaultValue: () => U) {
+    this._defaultValue = defaultValue;
+  }
+
+  public getOrCreate(key: T) {
+    if (!this._map.has(key)) {
+      this._map.set(key, this._defaultValue());
+    }
+
+    return this._map.get(key) as U;
+  }
+
+  public get(key: T) {
+    return this._map.get(key);
+  }
+
+  public set(key: T, value: U) {
+    this._map.set(key, value);
+  }
+
+  public has(key: T) {
+    return this._map.has(key);
+  }
+}

--- a/src/components/icon/registry/parser.ts
+++ b/src/components/icon/registry/parser.ts
@@ -1,0 +1,33 @@
+export type SvgIcon = {
+  svg: string;
+  title?: string;
+};
+
+/* blazorSuppress */
+export class SvgIconParser {
+  private _parser: DOMParser;
+
+  constructor() {
+    this._parser = new DOMParser();
+  }
+
+  public parse(svgString: string): SvgIcon {
+    const root = this._parser.parseFromString(svgString, 'image/svg+xml');
+    const svg = root.querySelector('svg');
+    const error = root.querySelector('parsererror');
+
+    if (error || !svg) {
+      throw new Error('SVG element not found or malformed SVG string.');
+    }
+
+    const title = svg.querySelector('title')?.textContent ?? '';
+
+    svg.setAttribute('fit', '');
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+
+    return {
+      svg: svg.outerHTML,
+      title,
+    };
+  }
+}

--- a/src/components/icon/registry/parser.ts
+++ b/src/components/icon/registry/parser.ts
@@ -1,7 +1,4 @@
-export type SvgIcon = {
-  svg: string;
-  title?: string;
-};
+import type { SvgIcon } from './types.js';
 
 /* blazorSuppress */
 export class SvgIconParser {

--- a/src/components/icon/registry/types.ts
+++ b/src/components/icon/registry/types.ts
@@ -1,0 +1,33 @@
+import type { Theme } from '../../../theming/types.js';
+import type { DefaultMap } from './default-map.js';
+
+// Exported internal types
+
+export type Collection<T, U> = DefaultMap<T, U>;
+
+export type IconCallback = (name: string, collection: string) => void;
+export type IconThemeKey = Theme | 'default';
+
+export type SvgIcon = {
+  svg: string;
+  title?: string;
+};
+
+export type IconReference = {
+  alias: IconMeta;
+  target: Map<IconThemeKey, IconMeta>;
+};
+
+export type IconReferencePair = {
+  alias: IconMeta;
+  target: IconMeta;
+  overwrite: boolean;
+};
+
+// Exported public types
+
+export interface IconMeta {
+  name: string;
+  collection: string;
+  external?: boolean;
+}

--- a/src/components/input/input-base.ts
+++ b/src/components/input/input-base.ts
@@ -1,8 +1,7 @@
 import { LitElement, type TemplateResult, html, nothing } from 'lit';
 import { property, query, queryAssignedElements } from 'lit/decorators.js';
 
-import { themeSymbol, themes } from '../../theming/theming-decorator.js';
-import type { Theme } from '../../theming/types.js';
+import { getThemeController, themes } from '../../theming/theming-decorator.js';
 import { blazorDeepImport } from '../common/decorators/blazorDeepImport.js';
 import type { Constructor } from '../common/mixins/constructor.js';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
@@ -21,13 +20,11 @@ export interface IgcInputEventMap {
   igcBlur: CustomEvent<void>;
 }
 
-@themes(all, true)
 @blazorDeepImport
+@themes(all, { exposeController: true })
 export abstract class IgcInputBaseComponent extends FormAssociatedRequiredMixin(
   EventEmitterMixin<IgcInputEventMap, Constructor<LitElement>>(LitElement)
 ) {
-  private declare readonly [themeSymbol]: Theme;
-
   protected static shadowRootOptions = {
     ...LitElement.shadowRootOptions,
     delegatesFocus: true,
@@ -53,6 +50,10 @@ export abstract class IgcInputBaseComponent extends FormAssociatedRequiredMixin(
 
   @queryAssignedElements({ slot: 'helper-text' })
   protected helperText!: Array<HTMLElement>;
+
+  protected get _isMaterial() {
+    return getThemeController(this)?.theme === 'material';
+  }
 
   /**
    * Whether the control will have outlined appearance.
@@ -187,10 +188,6 @@ export abstract class IgcInputBaseComponent extends FormAssociatedRequiredMixin(
   }
 
   protected override render() {
-    return html`
-      ${this[themeSymbol] === 'material'
-        ? this.renderMaterial()
-        : this.renderStandard()}
-    `;
+    return this._isMaterial ? this.renderMaterial() : this.renderStandard();
   }
 }

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -7,8 +7,7 @@ import {
 } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-import { themeSymbol, themes } from '../../theming/theming-decorator.js';
-import type { Theme } from '../../theming/types.js';
+import { themes } from '../../theming/theming-decorator.js';
 import {
   addKeybindings,
   altKey,
@@ -91,7 +90,7 @@ export interface IgcSelectEventMap {
  * @csspart toggle-icon - The toggle icon wrapper of the igc-select.
  * @csspart helper-text - The helper text wrapper of the igc-select.
  */
-@themes(all, true)
+@themes(all)
 @blazorAdditionalDependencies(
   'IgcIconComponent, IgcInputComponent, IgcSelectGroupComponent, IgcSelectHeaderComponent, IgcSelectItemComponent'
 )
@@ -117,7 +116,6 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
     );
   }
 
-  private declare readonly [themeSymbol]: Theme;
   private _value!: string;
   private _searchTerm = '';
   private _lastKeyTime = 0;

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -9,8 +9,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 
-import { themeSymbol, themes } from '../../theming/theming-decorator.js';
-import type { Theme } from '../../theming/types.js';
+import { getThemeController, themes } from '../../theming/theming-decorator.js';
 import { watch } from '../common/decorators/watch.js';
 import { registerComponent } from '../common/definitions/register.js';
 import type { Constructor } from '../common/mixins/constructor.js';
@@ -58,7 +57,7 @@ export interface IgcTextareaEventMap {
  * @csspart suffix - The suffix wrapper.
  * @csspart helper-text - The helper text wrapper.
  */
-@themes(all, true)
+@themes(all, { exposeController: true })
 export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   EventEmitterMixin<IgcTextareaEventMap, Constructor<LitElement>>(LitElement)
 ) {
@@ -70,7 +69,6 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
     registerComponent(IgcTextareaComponent);
   }
 
-  private declare readonly [themeSymbol]: Theme;
   protected override validators: Validator<this>[] = [
     requiredValidator,
     minLengthValidator,
@@ -107,6 +105,10 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
     return {
       resize: this.resize === 'auto' ? 'none' : this.resize,
     };
+  }
+
+  protected get _isMaterial() {
+    return getThemeController(this)?.theme === 'material';
   }
 
   /**
@@ -493,8 +495,7 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   }
 
   protected override render() {
-    const isMaterial = this[themeSymbol] === 'material';
-    return isMaterial ? this.renderMaterial() : this.renderStandard();
+    return this._isMaterial ? this.renderMaterial() : this.renderStandard();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,4 +95,4 @@ export type {
   ComboItemTemplate,
   IgcComboChangeEventArgs,
 } from './components/combo/types.js';
-export type { IconMeta } from './components/icon/icon.registry.js';
+export type { IconMeta } from './components/icon/registry/types.js';

--- a/src/theming/config.spec.ts
+++ b/src/theming/config.spec.ts
@@ -2,7 +2,7 @@ import { aTimeout, expect, oneEvent } from '@open-wc/testing';
 
 import { configureTheme, getTheme } from './config.js';
 import { CHANGE_THEME_EVENT } from './theming-event.js';
-import { getAllCSSVariables } from './utils.js';
+import { getAllCssVariables } from './utils.js';
 
 describe('Theming Config', () => {
   it('parses CSS variables from the document style sheets', async () => {
@@ -10,7 +10,7 @@ describe('Theming Config', () => {
     sheet.textContent = ':root { --igc-size: 1; --my-custom-size: 2rem }';
     document.head.append(sheet);
 
-    expect(getAllCSSVariables()).to.eql({
+    expect(getAllCssVariables()).to.eql({
       igcSize: '1',
       myCustomSize: '2rem',
     });
@@ -28,7 +28,7 @@ describe('Theming Config', () => {
     document.head.append(link);
     await aTimeout(1000);
 
-    expect(() => getAllCSSVariables()).not.to.throw();
+    expect(() => getAllCssVariables()).not.to.throw();
 
     link.remove();
   });

--- a/src/theming/config.ts
+++ b/src/theming/config.ts
@@ -4,7 +4,7 @@ import {
   type ChangeThemeEventDetail,
 } from './theming-event.js';
 import type { Theme, ThemeVariant } from './types.js';
-import { getAllCSSVariables } from './utils.js';
+import { getAllCssVariables } from './utils.js';
 
 let theme: Theme;
 let themeVariant: ThemeVariant;
@@ -30,9 +30,9 @@ export const getTheme: () => {
   theme: Theme;
   themeVariant: ThemeVariant;
 } = () => {
-  if (!theme || !themeVariant) {
+  if (!(theme && themeVariant)) {
     const [_theme, _variant] =
-      Object.entries(getAllCSSVariables()).filter(
+      Object.entries(getAllCssVariables()).filter(
         ([v]) => v === 'igTheme' || v === 'igThemeVariant'
       ) || [];
 

--- a/src/theming/theming-controller.ts
+++ b/src/theming/theming-controller.ts
@@ -9,7 +9,13 @@ import {
 
 import { getTheme } from './config.js';
 import { CHANGE_THEME_EVENT } from './theming-event.js';
-import type { Theme, ThemeController, ThemeVariant, Themes } from './types.js';
+import type {
+  Theme,
+  ThemeChangedCallback,
+  ThemeController,
+  ThemeVariant,
+  Themes,
+} from './types.js';
 
 type ThemeCallback = () => void;
 
@@ -28,20 +34,23 @@ class ThemeEventListeners {
     }
   }
 
-  public handleEvent = () => {
+  public handleEvent() {
     for (const listener of this.listeners) {
       listener();
     }
-  };
+  }
 }
 
-const _themingEventListeners = new ThemeEventListeners();
+const _themeListeners = new ThemeEventListeners();
 
-class ThemingController implements ReactiveController, ThemeController {
+/* blazorSuppress */
+export class ThemingController implements ReactiveController, ThemeController {
   private themes: Themes;
   private host: ReactiveControllerHost & ReactiveElement;
+
   public theme!: Theme;
   public themeVariant!: ThemeVariant;
+  public onThemeChanged?: ThemeChangedCallback;
 
   constructor(host: ReactiveControllerHost & ReactiveElement, themes: Themes) {
     this.host = host;
@@ -50,11 +59,27 @@ class ThemingController implements ReactiveController, ThemeController {
 
   public hostConnected() {
     this.adoptStyles();
-    _themingEventListeners.add(this.themeChanged);
+    _themeListeners.add(this.themeChanged);
   }
 
   public hostDisconnected() {
-    _themingEventListeners.remove(this.themeChanged);
+    _themeListeners.remove(this.themeChanged);
+  }
+
+  private getStyles() {
+    const styleSheets = Object.entries(this.themes[this.themeVariant]);
+    const styles = { shared: css``, theme: css`` };
+
+    for (const [name, sheet] of styleSheets) {
+      if (name === 'shared') {
+        styles.shared = sheet;
+      }
+      if (name === this.theme) {
+        styles.theme = sheet;
+      }
+    }
+
+    return styles;
   }
 
   protected adoptStyles() {
@@ -63,49 +88,14 @@ class ThemingController implements ReactiveController, ThemeController {
     this.themeVariant = themeVariant;
 
     const ctor = this.host.constructor as typeof LitElement;
-    const stylesheets = Object.entries(this.themes[themeVariant]);
+    const { shared, theme: _theme } = this.getStyles();
 
-    const [_unused, sharedStyles] =
-      stylesheets.find(([name]) => name === 'shared') ?? [];
-    const [_, themeStyles] =
-      stylesheets.find(([name]) => name === this.theme) ?? [];
-
-    adoptStyles(this.host.shadowRoot as ShadowRoot, [
-      ...ctor.elementStyles,
-      sharedStyles ?? css``,
-      themeStyles ?? css``,
-    ]);
+    adoptStyles(this.host.shadowRoot!, [...ctor.elementStyles, shared, _theme]);
   }
 
   private themeChanged: ThemeCallback = () => {
     this.adoptStyles();
+    this.onThemeChanged?.call(this.host, this.theme);
     this.host.requestUpdate();
   };
 }
-
-const _updateWhenThemeChanges = (
-  host: ReactiveControllerHost & ReactiveElement,
-  themes: Themes,
-  exposeTheme?: boolean
-) => {
-  const controller = new ThemingController(host, themes);
-  host.addController(controller);
-
-  if (exposeTheme) {
-    Object.defineProperty(host, themeSymbol, {
-      get() {
-        return controller.theme;
-      },
-      configurable: true,
-      enumerable: false,
-    });
-  }
-
-  return controller;
-};
-
-export const updateWhenThemeChanges: typeof _updateWhenThemeChanges & {
-  _THEMING_CONTROLLER_FN_?: never;
-} = _updateWhenThemeChanges;
-
-export const themeSymbol = Symbol('Current active theme');

--- a/src/theming/theming-decorator.ts
+++ b/src/theming/theming-decorator.ts
@@ -1,38 +1,71 @@
-import type { ReactiveElement } from 'lit';
+import type { LitElement } from 'lit';
 
-import { updateWhenThemeChanges } from './theming-controller.js';
+import { ThemingController } from './theming-controller.js';
 import type { Themes } from './types.js';
 
 /**
  * Class decorator to enable multiple theme support for a component.
  * The component will re-render on theme changes.
  *
- * See also {@link updateWhenThemeChanges} for the same functionality
- * without the use of this decorator.
+ * Passing `{ exposeController: true }` in the decorator options will create an internal symbol
+ * which can be used by {@link getThemeController} to additionally query and modify the component
+ * based on the themes.
  *
  * Usage:
  *  ```ts
  *  import { LitElement, html } from 'lit';
  *  import { themes } from 'igniteui-webcomponents/themes';
- *  import { styles } from './themes/my-element.base.css';
- *  import { styles as material } from './themes/my-element.material.css';
- *  import { styles as bootstrap } from './themes/my-element.bootstrap.css';
- *  import { styles as indigo } from './themes/my-element.indigo.css';
+ *  import { styles } from './themes/my-element.base.css.js';
+ *  import { styles as shared } from './themes/shared/my-picker.common.css.js';
+ *  import { all } from './themes/themes.js';
  *
- *  @themes({ material, bootstrap, indigo })
+ *  @themes(all)
  *  class MyElement extends LitElement {
- *    public static styles = styles;
+ *    public static styles = [styles, shared];
+ *  }
+ *
+ *  @themes(all, { exposeController: true })
+ *  class MyElementWithExposedTheming extends LitElement {
+ *    ...
+ *
+ *    render() {
+ *      const theme = getThemeController(this)?.theme;
+ *      ...
+ *    }
  *  }
  *  ```
  */
-export function themes(themes: Themes, exposeTheme = false) {
-  return (clazz: any) => {
-    clazz.addInitializer((instance: ReactiveElement) => {
-      updateWhenThemeChanges(instance, themes, exposeTheme);
-    });
+export function themes(themes: Themes, options?: ThemeOptions) {
+  return (proto: unknown) => {
+    (proto as typeof LitElement).addInitializer((instance) => {
+      const controller = new ThemingController(instance, themes);
+      instance.addController(controller);
 
-    return clazz;
+      if (options?.exposeController) {
+        Object.defineProperty(instance, themeSymbol, {
+          get() {
+            return controller;
+          },
+          configurable: true,
+          enumerable: false,
+        });
+      }
+    });
   };
 }
 
-export { themeSymbol } from './theming-controller.js';
+/**
+ * Returns the theming controller for the given element if exposed.
+ */
+export function getThemeController(host: LitElement) {
+  return isControllerExposed(host) ? host[themeSymbol] : undefined;
+}
+
+function isControllerExposed(
+  host: LitElement
+): host is LitElement & { [themeSymbol]: ThemingController } {
+  return Object.getOwnPropertySymbols(host).includes(themeSymbol);
+}
+
+const themeSymbol = Symbol('Theming Controller');
+type ThemeOptions = { exposeController?: boolean };

--- a/src/theming/theming-event.ts
+++ b/src/theming/theming-event.ts
@@ -2,8 +2,6 @@ import type { Theme, ThemeVariant } from './types.js';
 
 export const CHANGE_THEME_EVENT = 'igc-change-theme';
 
-// Misfiring eslint rule
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare global {
   interface WindowEventMap {
     [CHANGE_THEME_EVENT]: CustomEvent<ChangeThemeEventDetail>;

--- a/src/theming/types.ts
+++ b/src/theming/types.ts
@@ -12,6 +12,8 @@ export type Themes = {
   };
 };
 
+export type ThemeChangedCallback = (theme: Theme) => unknown;
+
 /**
  * A controller responsible for adopting various component themes;
  * See also {@link updateWhenThemeChanges}.
@@ -21,4 +23,9 @@ export interface ThemeController {
    * The name of the currently adopted theme. See {@link Theme}.
    */
   theme: Theme;
+
+  /**
+   * Optional callback function to invoke when the theme is changed at runtime.
+   */
+  onThemeChanged?: ThemeChangedCallback;
 }

--- a/src/theming/utils.ts
+++ b/src/theming/utils.ts
@@ -2,7 +2,7 @@ import { isServer } from 'lit';
 
 import { isDefined } from '../components/common/util.js';
 
-function isAStyleRule(rule: CSSRule): rule is CSSStyleRule {
+function isStyleRule(rule: CSSRule): rule is CSSStyleRule {
   return !!rule && 'style' in rule;
 }
 
@@ -10,9 +10,10 @@ function cssKeyToJsKey(key: string): string {
   return key.replace('--', '').replace(/-./g, (x) => x.toUpperCase()[1]);
 }
 
-function getAllCSSVariableNames(): Set<string> {
+function getAllCssVariableNames(): Set<string> {
   const cssVars = new Set<string>();
 
+  /* c8 ignore next 3 */
   if (isServer || !isDefined(globalThis.document)) {
     return cssVars;
   }
@@ -22,14 +23,14 @@ function getAllCSSVariableNames(): Set<string> {
     (sheet) => {
       try {
         return sheet.cssRules;
-      } catch (e) {
+      } catch {
         return false;
       }
     }
   );
 
   for (const sheet of styleSheets) {
-    const rules = Array.from(sheet.cssRules).filter(isAStyleRule);
+    const rules = Array.from(sheet.cssRules).filter(isStyleRule);
 
     for (const rule of rules) {
       Array.from(rule.style).forEach((style) => {
@@ -43,20 +44,21 @@ function getAllCSSVariableNames(): Set<string> {
   return cssVars;
 }
 
-function getElementCSSVariables(
-  allCSSVars: Set<string>,
+function getElementCssVariables(
+  allCssVars: Set<string>,
   element: HTMLElement,
   pseudo?: string
 ): Record<string, string> {
   const cssVars: Record<string, string> = {};
 
+  /* c8 ignore next 3 */
   if (!isDefined(globalThis.getComputedStyle)) {
     return cssVars;
   }
 
   const styles = globalThis.getComputedStyle(element, pseudo);
 
-  for (const key of allCSSVars) {
+  for (const key of allCssVars) {
     const value = styles.getPropertyValue(key);
 
     if (value) {
@@ -67,11 +69,12 @@ function getElementCSSVariables(
   return cssVars;
 }
 
-export function getAllCSSVariables(): Record<string, string> {
+export function getAllCssVariables(): Record<string, string> {
+  /* c8 ignore next 2 */
   return isServer || !isDefined(globalThis.document)
     ? {}
-    : getElementCSSVariables(
-        getAllCSSVariableNames(),
+    : getElementCssVariables(
+        getAllCssVariableNames(),
         globalThis.document.documentElement
       );
 }


### PR DESCRIPTION
* Refactored some of the logic inside the icon registry around the default internal collection of icons.
* Revamped the themes decorator to be more explicit when the controller is exposed to the decorated element.
* Changed the typing around the decorator.
* Refactored the logic around getting the shared/theme styles.
* Exposed a new property on the theming decorator, `onThemeChanged`. Elements can register a callback accepting the new theme and run some logic before the element is re-rendered.