### PR TITLE
chore(storybook): Sourcemaps and files for SB cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Infragistics",
   "license": "SEE LICENSE IN LICENSE",
   "exports": {
-    ".": "./dist/src/index.js",
-    "./types": "./dist/src/types.js"
+    ".": "./src/index.js",
+    "./types": "./src/types.js"
   },
   "type": "module",
   "repository": {


### PR DESCRIPTION
Point the internal package.json to the src directory so Storybook and Vite can serve the latest version of the files while developing.