### PR TITLE
refactor: Use an EventTarget derived emitter for theme changes

### DIFF
--- a/src/theming/theming-event.ts
+++ b/src/theming/theming-event.ts
@@ -1,6 +1,19 @@
 import type { Theme, ThemeVariant } from './types.js';
 
+class ThemeChangedEmitter extends EventTarget {
+  constructor() {
+    super();
+    globalThis.addEventListener(CHANGE_THEME_EVENT, this);
+  }
+
+  public handleEvent() {
+    this.dispatchEvent(new CustomEvent(CHANGED_THEME_EVENT));
+  }
+}
+
 export const CHANGE_THEME_EVENT = 'igc-change-theme';
+export const CHANGED_THEME_EVENT = 'igc-changed-theme';
+export const _themeChangedEmitter = new ThemeChangedEmitter();
 
 declare global {
   interface WindowEventMap {


### PR DESCRIPTION
Dropped the set collection of registered callbacks for components. Instead add the callback directly
as an event listener to the global theme emitter.