### PR TITLE
refactor(combo): Use key-bindings controller

### DIFF
--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -1,12 +1,8 @@
 import { LitElement, type TemplateResult, html, nothing } from 'lit';
-import {
-  property,
-  query,
-  queryAssignedElements,
-  state,
-} from 'lit/decorators.js';
+import { property, queryAssignedElements, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 
 import { themes } from '../../theming/theming-decorator.js';
 import { addRootClickHandler } from '../common/controllers/root-click.js';
@@ -36,7 +32,7 @@ import IgcComboHeaderComponent from './combo-header.js';
 import IgcComboItemComponent from './combo-item.js';
 import IgcComboListComponent from './combo-list.js';
 import { DataController } from './controllers/data.js';
-import { NavigationController } from './controllers/navigation.js';
+import { ComboNavigationController } from './controllers/navigation.js';
 import { SelectionController } from './controllers/selection.js';
 import { styles } from './themes/combo.base.css.js';
 import { styles as shared } from './themes/shared/combo.common.css.js';
@@ -68,6 +64,7 @@ import { comboValidators } from './validators.js';
  * @slot suffix - Renders content after the input of the combo.
  * @slot header - Renders a container before the list of options of the combo.
  * @slot footer - Renders a container after the list of options of the combo.
+ * @slot empty - Renders content when the combo dropdown list has no items/data.
  * @slot helper-text - Renders content below the input of the combo.
  * @slot toggle-icon - Renders content inside the suffix container of the combo.
  * @slot clear-icon - Renders content inside the suffix container of the combo.
@@ -135,6 +132,15 @@ export default class IgcComboComponent<
     return comboValidators;
   }
 
+  /** The primary input of the combo component. */
+  private _inputRef = createRef<IgcInputComponent>();
+
+  /** The search input of the combo component. */
+  private _searchRef = createRef<IgcInputComponent>();
+
+  /** The combo virtualized dropdown list. */
+  private _listRef = createRef<IgcComboListComponent>();
+
   protected override _formValue: FormValue<ComboValue<T>[]>;
   private _data: T[] = [];
 
@@ -160,22 +166,17 @@ export default class IgcComboComponent<
 
   protected _state = new DataController<T>(this);
   protected _selection = new SelectionController<T>(this, this._state);
-  protected _navigation = new NavigationController<T>(this, this._state);
+  protected _navigation = new ComboNavigationController(this, this._state, {
+    input: this._inputRef,
+    search: this._searchRef,
+    list: this._listRef,
+  });
 
   @queryAssignedElements({ slot: 'suffix' })
   protected inputSuffix!: Array<HTMLElement>;
 
   @queryAssignedElements({ slot: 'prefix' })
   protected inputPrefix!: Array<HTMLElement>;
-
-  @query('[part="search-input"]')
-  protected _searchInput!: IgcInputComponent;
-
-  @query('#target', true)
-  private _input!: IgcInputComponent;
-
-  @query(IgcComboListComponent.tagName, true)
-  private _list!: IgcComboListComponent;
 
   /** The data source used to generate the list of options. */
   /* treatAsRef */
@@ -458,11 +459,6 @@ export default class IgcComboComponent<
     });
 
     this.addEventListener('blur', this._handleBlur);
-
-    this.addEventListener(
-      'keydown',
-      this._navigation.navigateHost.bind(this._navigation)
-    );
   }
 
   protected override async firstUpdated() {
@@ -524,20 +520,20 @@ export default class IgcComboComponent<
 
     if (!initial) {
       this._validate();
-      this._list.requestUpdate();
+      this._listRef.value!.requestUpdate();
     }
   }
 
   /* alternateName: focusComponent */
   /** Sets focus on the component. */
   public override focus(options?: FocusOptions) {
-    this._input.focus(options);
+    this._inputRef.value!.focus(options);
   }
 
   /* alternateName: blurComponent */
   /** Removes focus from the component. */
   public override blur() {
-    this._input.blur();
+    this._inputRef.value!.blur();
   }
 
   /**
@@ -612,7 +608,7 @@ export default class IgcComboComponent<
     this._navigation.active = detail ? matchIndex : -1;
 
     // update the list after changing the active item
-    this._list.requestUpdate();
+    this._listRef.value!.requestUpdate();
 
     // clear the selection upon typing
     this.clearSingleSelection();
@@ -651,11 +647,11 @@ export default class IgcComboComponent<
     }
 
     if (!this.singleSelect) {
-      this._list.focus();
+      this._listRef.value!.focus();
     }
 
     if (!this.autofocusList) {
-      this._searchInput.focus();
+      this._searchRef.value!.focus();
     }
 
     return true;
@@ -743,17 +739,6 @@ export default class IgcComboComponent<
     `;
   };
 
-  protected listKeydownHandler(event: KeyboardEvent) {
-    const target = findElementFromEventPath<IgcComboListComponent>(
-      IgcComboListComponent.tagName,
-      event
-    );
-
-    if (target) {
-      this._navigation.navigateList(event, target);
-    }
-  }
-
   protected itemClickHandler(event: PointerEvent) {
     const target = findElementFromEventPath<IgcComboItemComponent>(
       IgcComboItemComponent.tagName,
@@ -767,10 +752,10 @@ export default class IgcComboComponent<
     this.toggleSelect(target.index);
 
     if (this.singleSelect) {
-      this._input.focus();
+      this._inputRef.value!.focus();
       this._hide();
     } else {
-      this._searchInput.focus();
+      this._searchRef.value!.focus();
     }
   }
 
@@ -813,14 +798,6 @@ export default class IgcComboComponent<
 
     this.updateValue();
     this._navigation.active = -1;
-  }
-
-  protected handleMainInputKeydown(e: KeyboardEvent) {
-    this._navigation.navigateMainInput(e, this._list);
-  }
-
-  protected handleSearchInputKeydown(e: KeyboardEvent) {
-    this._navigation.navigateSearchInput(e, this._list);
   }
 
   protected toggleCaseSensitivity() {
@@ -875,6 +852,7 @@ export default class IgcComboComponent<
   private renderMainInput() {
     return html`
       <igc-input
+        ${ref(this._inputRef)}
         id="target"
         slot="anchor"
         role="combobox"
@@ -889,7 +867,6 @@ export default class IgcComboComponent<
         label=${ifDefined(this.label)}
         @igcChange=${this._stopPropagation}
         @igcInput=${this.handleMainInput}
-        @keydown=${this.handleMainInputKeydown}
         .value=${this._displayValue}
         .disabled=${this.disabled}
         .required=${this.required}
@@ -917,12 +894,12 @@ export default class IgcComboComponent<
         ?hidden=${this.disableFiltering || this.singleSelect}
       >
         <igc-input
+          ${ref(this._searchRef)}
           .value=${this._state.searchTerm}
           part="search-input"
           placeholder=${this.placeholderSearch}
           exportparts="input: search-input"
           @igcInput=${this.handleSearchInput}
-          @keydown=${this.handleSearchInputKeydown}
         >
           <igc-icon
             slot=${this.caseSensitiveIcon && 'suffix'}
@@ -949,16 +926,13 @@ export default class IgcComboComponent<
 
   private renderList() {
     return html`
-      <div
-        .inert=${!this.open}
-        @keydown=${this.listKeydownHandler}
-        part="list-wrapper"
-      >
+      <div .inert=${!this.open} part="list-wrapper">
         ${this.renderSearchInput()}
         <div part="header">
           <slot name="header"></slot>
         </div>
         <igc-combo-list
+          ${ref(this._listRef)}
           aria-multiselectable=${!this.singleSelect}
           id="dropdown"
           part="list"

--- a/stories/avatar.stories.ts
+++ b/stories/avatar.stories.ts
@@ -63,11 +63,6 @@ interface IgcAvatarArgs {
 }
 type Story = StoryObj<IgcAvatarArgs>;
 
-registerIcon(
-  'home',
-  'https://unpkg.com/material-design-icons@3.0.1/action/svg/production/ic_home_24px.svg'
-);
-
 // endregion
 
 export const Image: Story = {


### PR DESCRIPTION
This commit migrates the combo component to use
the general key-bindings controller from the library. Aside from unifying the implementation across components this also improves several behaviors of the combo:

* Keyboard events inside the combo are no longer "swallowed".
* Tab navigation is more natural, i.e. there are no longer 2 tab stops per combo component.

Updated the combo test suite to accommodate for the changes.