### PR TITLE
fix(Calendar) disabled date foreground color in range preview for material and indigo themes

### DIFF
--- a/src/components/calendar/themes/shared/indigo/days-view.indigo.scss
+++ b/src/components/calendar/themes/shared/indigo/days-view.indigo.scss
@@ -456,7 +456,7 @@ $week-number-radius: var-get($theme, 'week-number-border-radius');
         }
     }
 
-    &[part~='disabled'][part~='range'] {
+    &[part~='disabled'][part~='range']:not([part~='preview']) {
         color: var-get($theme, 'date-disabled-range-foreground');
     }
 

--- a/src/components/calendar/themes/shared/material/days-view.material.scss
+++ b/src/components/calendar/themes/shared/material/days-view.material.scss
@@ -225,7 +225,7 @@ $week-number-radius: var-get($theme, 'week-number-border-radius');
         }
     }
 
-    &[part~='disabled'][part~='range'] {
+    &[part~='disabled'][part~='range']:not([part~='preview']) {
         color: var-get($theme, 'date-disabled-range-foreground');
     }
 


### PR DESCRIPTION
Closes [#1589](https://github.com/IgniteUI/igniteui-webcomponents/issues/1589)