### PR TITLE
[calendar] - Fix date text color in range selection when the current date is also the last or first in range

### DIFF
--- a/src/components/calendar/themes/shared/material/days-view.material.scss
+++ b/src/components/calendar/themes/shared/material/days-view.material.scss
@@ -144,7 +144,7 @@ $week-number-radius: var-get($theme, 'week-number-border-radius');
             }
         }
 
-        &[part~='current'][part~='range'] {
+        &[part~='current'][part~='range']:not([part~='last'], [part~='first']) {
             color: var-get($theme, 'date-current-foreground');
 
             &:focus {


### PR DESCRIPTION
closes: #1626