### PR TITLE
fix(popover): Use absolute position and strategy

### DIFF
--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -276,7 +276,7 @@ export default class IgcPopoverComponent extends LitElement {
       {
         placement: this.placement ?? 'bottom-start',
         middleware: this._createMiddleware(),
-        strategy: 'fixed',
+        strategy: 'absolute',
       }
     );
 

--- a/src/components/popover/themes/light/popover.base.scss
+++ b/src/components/popover/themes/light/popover.base.scss
@@ -6,7 +6,7 @@
 }
 
 :popover-open {
-    position: fixed;
+    position: absolute;
     overflow: visible;
     isolation: isolate;
     height: fit-content;


### PR DESCRIPTION
This fix minimizes the amount of jitter when an
open popover tries to reposition against its
target while scrolling or resizing.

**Before - Fixed position**:

https://github.com/user-attachments/assets/a00159b2-fa7d-48ac-87c5-351d6020d76b

**After - Absolute position**

https://github.com/user-attachments/assets/416a4801-969e-45e2-b86f-44ece79c2720

