### PR TITLE
chore: add .envrc and .direnv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ custom-elements.json
 
 # Localization data
 i18nRepo
+
+# Development environment
+.envrc
+.direnv


### PR DESCRIPTION
This PR adds some common files and folders to .gitignore used when creating local development environments, useful for testing the package with different Node.js versions without relying on nvm or similar packages.