### PR TITLE
Add tag for blazor gen as indirect render for date range picker.

### DIFF
--- a/src/components/date-range-picker/date-range-picker.ts
+++ b/src/components/date-range-picker/date-range-picker.ts
@@ -182,6 +182,7 @@ export interface IgcDateRangePickerComponentEventMap {
  * @csspart selected - The calendar selected state for element(s). Applies to date, month and year elements.
  * @csspart current - The calendar current state for element(s). Applies to date, month and year elements.
  */
+/** blazorElement */
 
 @themes(all)
 @blazorAdditionalDependencies(


### PR DESCRIPTION
Adding it now, so I don't forget later when it's merged and we want to generate it for Blazor.