### PR TITLE
fix(textarea): remove height override

### DIFF
--- a/src/components/textarea/themes/shared/textarea.indigo.scss
+++ b/src/components/textarea/themes/shared/textarea.indigo.scss
@@ -76,7 +76,6 @@ $theme: $indigo;
     transition: background .25s $out-cubic;
     overflow: hidden;
     padding-inline-start: 0;
-    height: calc(100% - #{rem(2px)});
     top: rem(1px);
 
     &::after {


### PR DESCRIPTION
We have predefined heights from the schema for all three sizes. We have also exposed a prop for textarea-height, so the line I am removing is completely unnecessary.

Closes #1679
