### PR TITLE
refactor(popover): Improved popover rendering

### DIFF
--- a/src/components/common/util.ts
+++ b/src/components/common/util.ts
@@ -496,3 +496,10 @@ export function equal<T>(a: unknown, b: T, visited = new WeakSet()): boolean {
 export type RequiredProps<T, K extends keyof T> = T & {
   [P in K]-?: T[P];
 };
+
+export function setStyles(
+  element: HTMLElement,
+  styles: Partial<CSSStyleDeclaration>
+): void {
+  Object.assign(element.style, styles);
+}

--- a/src/components/popover/popover.spec.ts
+++ b/src/components/popover/popover.spec.ts
@@ -16,7 +16,7 @@ async function waitForPaint(popover: IgcPopoverComponent) {
 }
 
 function getFloater(popover: IgcPopoverComponent) {
-  return popover.shadowRoot!.querySelector('#container') as HTMLElement;
+  return popover.renderRoot.querySelector('#container') as HTMLElement;
 }
 
 function togglePopover() {
@@ -173,7 +173,6 @@ describe('Popover', () => {
         const root = await fixture<HTMLElement>(createNonSlottedPopover(true));
         popover = root.querySelector('igc-popover') as IgcPopoverComponent;
         anchor = root.querySelector('#btn') as HTMLButtonElement;
-        // await waitForPaint(popover);
       });
 
       it('should render a component', async () => {


### PR DESCRIPTION
* Skip visibility state re-render when popover properties are being changed. Now, only the position tracking callback is re-created.
* Use the slot controller API for handling slot changes.
* Abstracted some code around open state and state updates.
* Dropped `watch` decorator and moved relevant logic inside Lit `update` hook where the DOM does exist.