### PR TITLE
fix(card): default avatar size not correct in all themes bar indigo

### DIFF
--- a/src/components/card/themes/card.content.base.scss
+++ b/src/components/card/themes/card.content.base.scss
@@ -13,3 +13,7 @@
 ::slotted(*) {
     margin: 0;
 }
+
+::slotted(igc-avatar) {
+    --ig-size: 1;
+}

--- a/src/components/card/themes/card.header.base.scss
+++ b/src/components/card/themes/card.header.base.scss
@@ -17,6 +17,10 @@
     opacity: inherit;
 }
 
+::slotted(igc-avatar) {
+    --ig-size: 1;
+}
+
 header {
     display: flex;
     flex-flow: column nowrap;


### PR DESCRIPTION
This PR fixes the behavior of sizing the avatar in the context of the Card component for all themes, except Indigo, where it's already being sized correctly.