### PR TITLE
chore: mark defineComponents call as pure to avoid tree-shake bailouts

### DIFF
--- a/src/components/common/definitions/defineAllComponents.ts
+++ b/src/components/common/definitions/defineAllComponents.ts
@@ -143,5 +143,5 @@ const allComponents: IgniteComponent[] = [
 ];
 
 export function defineAllComponents() {
-  defineComponents(...allComponents);
+  /*@__PURE__*/ defineComponents(...allComponents);
 }


### PR DESCRIPTION
Attempt to mark the `defineComponents` call in `defineAllComponents` as pure to avoid tree-shaking bailout dragging the entire lib (through `...allComponent`) into the bundle.