### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/IgniteUI/igniteui-webcomponents/security/code-scanning/3](https://github.com/IgniteUI/igniteui-webcomponents/security/code-scanning/3)

The best way to fix the problem is to add a `permissions` block at the top level of the workflow, just after the `name:` and before `on:`. Since the workflow only necessitates reading repository contents (for checkout, lint, and builds), the recommended minimal setting is:

```yaml
permissions:
  contents: read
```

If future write access is required for another step (for example, publishing releases), it can be scoped more tightly by setting `permissions` per job or step. For the current workflow, only the above block is strictly required. Edit `.github/workflows/node.js.yml` by inserting the block after `name: Node.js CI`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
