### PR TITLE
refactor(animation): Animation controller cleanups

### DIFF
--- a/src/animations/player.spec.ts
+++ b/src/animations/player.spec.ts
@@ -63,7 +63,7 @@ describe('Animations Player', () => {
   it('should cancel running animations', async () => {
     const [playbackEvent] = (await Promise.all([
       el.player.play(fade),
-      el.player.stopAll(),
+      el.player.cancelAll(),
     ])) as AnimationPlaybackEvent[];
 
     expect(playbackEvent.type).to.equal('cancel');

--- a/src/components/banner/banner.spec.ts
+++ b/src/components/banner/banner.spec.ts
@@ -8,7 +8,7 @@ import {
 import { spy } from 'sinon';
 
 import { defineComponents } from '../common/definitions/defineComponents.js';
-import { finishAnimationsFor } from '../common/utils.spec.js';
+import { finishAnimationsFor, simulateClick } from '../common/utils.spec.js';
 import IgcIconComponent from '../icon/icon.js';
 import IgcBannerComponent from './banner.js';
 
@@ -231,15 +231,15 @@ describe('Banner', () => {
 
   describe('Action Tests', () => {
     it('should close the banner when clicking the default button', async () => {
+      const button = banner.renderRoot.querySelector('igc-button')!;
+
       expect(banner.open).to.be.false;
 
       await banner.show();
-
       expect(banner.open).to.be.true;
 
-      const button = banner.shadowRoot!.querySelector('igc-button');
-
-      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      simulateClick(button);
+      await elementUpdated(banner);
       await clickHideComplete();
 
       expect(banner.open).to.be.false;
@@ -247,20 +247,20 @@ describe('Banner', () => {
 
     it('should emit correct event sequence for the default action button', async () => {
       const eventSpy = spy(banner, 'emitEvent');
+      const button = banner.renderRoot.querySelector('igc-button')!;
 
       expect(banner.open).to.be.false;
 
       await banner.show();
-
       expect(banner.open).to.be.true;
 
-      const button = banner.shadowRoot!.querySelector('igc-button');
-      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      simulateClick(button);
 
       expect(eventSpy.callCount).to.equal(1);
       expect(eventSpy).calledWith('igcClosing', { cancelable: true });
 
       eventSpy.resetHistory();
+      await elementUpdated(banner);
       await clickHideComplete();
 
       expect(eventSpy).calledWith('igcClosed');
@@ -269,17 +269,17 @@ describe('Banner', () => {
 
     it('can cancel `igcClosing` event', async () => {
       const eventSpy = spy(banner, 'emitEvent');
-      const button = banner.shadowRoot!.querySelector('igc-button');
+      const button = banner.renderRoot.querySelector('igc-button')!;
 
       banner.addEventListener('igcClosing', (event) => {
         event.preventDefault();
       });
 
       await banner.show();
-
       expect(banner.open).to.be.true;
 
-      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      simulateClick(button);
+      await elementUpdated(banner);
       await clickHideComplete();
 
       expect(eventSpy).calledWith('igcClosing');

--- a/src/components/banner/banner.ts
+++ b/src/components/banner/banner.ts
@@ -104,13 +104,7 @@ export default class IgcBannerComponent extends EventEmitterMixin<
 
   private async toggleAnimation(dir: 'open' | 'close') {
     const animation = dir === 'open' ? growVerIn : growVerOut;
-
-    const [_, event] = await Promise.all([
-      this._animationPlayer.stopAll(),
-      this._animationPlayer.play(animation()),
-    ]);
-
-    return event.type === 'finish';
+    return this._animationPlayer.playExclusive(animation());
   }
 
   private async handleClick() {

--- a/src/components/expansion-panel/expansion-panel.ts
+++ b/src/components/expansion-panel/expansion-panel.ts
@@ -125,13 +125,7 @@ export default class IgcExpansionPanelComponent extends EventEmitterMixin<
 
   private async _toggleAnimation(dir: 'open' | 'close'): Promise<boolean> {
     const animation = dir === 'open' ? growVerIn : growVerOut;
-
-    const [_, event] = await Promise.all([
-      this._player.stopAll(),
-      this._player.play(animation()),
-    ]);
-
-    return event.type === 'finish';
+    return this._player.playExclusive(animation());
   }
 
   private async _openWithEvent(): Promise<void> {

--- a/src/components/stepper/step.ts
+++ b/src/components/stepper/step.ts
@@ -184,16 +184,16 @@ export default class IgcStepComponent extends LitElement {
       height: bodyHeight,
     };
 
-    const [_, event] = await Promise.all([
-      this.bodyAnimationPlayer.stopAll(),
-      this.bodyAnimationPlayer.play(bodyAnimation({ keyframe: options, step })),
-      this.contentAnimationPlayer.stopAll(),
-      this.contentAnimationPlayer.play(
+    const result = await Promise.all([
+      this.bodyAnimationPlayer.playExclusive(
+        bodyAnimation({ keyframe: options, step })
+      ),
+      this.contentAnimationPlayer.playExclusive(
         contentAnimation({ keyframe: options, step })
       ),
     ]);
 
-    return event.type;
+    return result.every(Boolean);
   }
 
   @watch('active', { waitUntilFirstUpdate: true })

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -410,7 +410,7 @@ export default class IgcTooltipComponent extends EventEmitterMixin<
 
   private _stopTimeoutAndAnimation(): void {
     clearTimeout(this._timeoutId);
-    this._player.stopAll();
+    this._player.cancelAll();
   }
 
   private _setAutoHide(): void {

--- a/src/components/tree/tree-item.ts
+++ b/src/components/tree/tree-item.ts
@@ -152,13 +152,7 @@ export default class IgcTreeItemComponent extends LitElement {
 
   private async toggleAnimation(dir: 'open' | 'close') {
     const animation = dir === 'open' ? growVerIn : growVerOut;
-
-    const [_, event] = await Promise.all([
-      this.animationPlayer.stopAll(),
-      this.animationPlayer.play(animation()),
-    ]);
-
-    return event.type === 'finish';
+    return this.animationPlayer.playExclusive(animation());
   }
 
   @watch('expanded', { waitUntilFirstUpdate: true })

--- a/stories/textarea.stories.ts
+++ b/stories/textarea.stories.ts
@@ -95,9 +95,9 @@ const metadata: Meta<IgcTextareaComponent> = {
     rows: {
       type: 'number',
       description:
-        'The number of visible text lines for the control. If it is specified, it must be a positive integer.\nIf it is not specified, the default value is 2.',
+        'The number of visible text lines for the control. If it is specified, it must be a positive integer.\nIf it is not specified, the default value is 3.',
       control: 'number',
-      table: { defaultValue: { summary: '2' } },
+      table: { defaultValue: { summary: '3' } },
     },
     value: {
       type: 'string',
@@ -209,7 +209,7 @@ interface IgcTextareaArgs {
   resize: 'vertical' | 'auto' | 'none';
   /**
    * The number of visible text lines for the control. If it is specified, it must be a positive integer.
-   * If it is not specified, the default value is 2.
+   * If it is not specified, the default value is 3.
    */
   rows: number;
   /** The value of the component */


### PR DESCRIPTION
* Added API documentation
* Renamed 'stopAll' to 'cancelAll' and simplified cancelation logic
* General code cleanup in the controller
* Use 'playExclusive' in relevant components
* Fixed some issues with banner tests not waiting for the its update complete logic