### PR TITLE
fix(dialog): `keepOpenOnEscape` should prevent dialog from closing on Escape key press

### DIFF
--- a/src/components/dialog/dialog.spec.ts
+++ b/src/components/dialog/dialog.spec.ts
@@ -266,6 +266,17 @@ describe('Dialog', () => {
       await waitUntil(() => eventSpy.calledWith('igcClosed'));
       expect(dialog.open).to.be.false;
     });
+
+    it('issue 1983 - does not close the dialog when keepOpenOnEscape is true and a non-cancelable close event is fired', async () => {
+      dialog.keepOpenOnEscape = true;
+      await dialog.show();
+
+      nativeDialog.dispatchEvent(new Event('close'));
+      await elementUpdated(dialog);
+
+      expect(dialog.open).to.be.true;
+      expect(nativeDialog.open).to.be.true;
+    });
   });
 
   describe('Form', () => {


### PR DESCRIPTION
Chromium based browsers have a default behavior of firing a `close` event when the Escape key is repeatedly pressed. Since that event cannot be cancelled, keep the dialog open when `keepOpenOnEscape` is set to true.

A better fix would be to use the `closedby` property but unfortunately that is not supported in Safari.

Closes #1983