### PR TITLE
fix(mask): Correct auto-fill handling with literals

### DIFF
--- a/src/components/mask-input/mask-input-base.ts
+++ b/src/components/mask-input/mask-input-base.ts
@@ -119,8 +119,9 @@ export abstract class IgcMaskInputBaseComponent extends IgcInputBaseComponent {
 
       // Potential browser auto-fill behavior
       case undefined:
+      case '':
         return this._updateInput(
-          value.substring(start, this._inputSelection.end),
+          this._parser.parse(value.substring(start, this._inputSelection.end)),
           {
             start,
             end: this._inputSelection.end,

--- a/src/components/mask-input/mask-input.spec.ts
+++ b/src/components/mask-input/mask-input.spec.ts
@@ -622,6 +622,23 @@ describe('Masked input', () => {
       expect(element.value).to.equal('xxba');
       expect(input.value).to.equal(parser.apply(element.value));
     });
+
+    it('auto-fill behavior for mask with literals', async () => {
+      element.mask = '(+35\\9) CCC-CCC';
+
+      await elementUpdated(element);
+      syncParser();
+
+      simulateInput(input, {
+        inputType: undefined, // auto-fill event
+        skipValueProperty: false,
+        value: '(+359) 123-456',
+      });
+      await elementUpdated(element);
+
+      expect(element.value).to.equal('123456');
+      expect(input.value).to.equal(parser.apply(element.value));
+    });
   });
 
   describe('Form integration', () => {


### PR DESCRIPTION
When the browser auto-fills a masked input field, it may include literal characters as part of the filled value. The previous implementation did not correctly handle such cases, leading to incorrect parsing and display of the input value.