### PR TITLE
fix(calendar): aria-hidden for days in perfect month

### DIFF
--- a/src/components/calendar/days-view/days-view.ts
+++ b/src/components/calendar/days-view/days-view.ts
@@ -542,7 +542,7 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
       const isLast = idx === lastIndex;
 
       const hidden = week.every(
-        (day) => dayPropertiesMap.get(day.timestamp)?.hidden
+        (day) => dayPropertiesMap.get(day.timestamp)!.hidden
       );
 
       yield html`


### PR DESCRIPTION
When the month is [perfect](https://en.wikipedia.org/wiki/Perfect_month), apply the `aria-hidden` attribute based on whether all days in the week are hidden, not just the edge weeks.