### PR TITLE
fix(adopt-root-styles): preserve rules and overrides order

### DIFF
--- a/src/components/chat/chat.spec.ts
+++ b/src/components/chat/chat.spec.ts
@@ -1072,6 +1072,11 @@ describe('Chat', () => {
       styles.setAttribute('id', 'adopt-styles-test');
       styles.innerHTML = `
         .custom-background {
+          background-color: rgb(255, 255, 0);
+        }
+
+        /* override */
+        .custom-background {
           background-color: rgb(255, 0, 0);
         }
       `;

--- a/src/components/common/controllers/adopt-styles.ts
+++ b/src/components/common/controllers/adopt-styles.ts
@@ -172,7 +172,8 @@ class AdoptedStylesController implements ReactiveController {
           }
 
           try {
-            constructed.insertRule(rule.cssText);
+            // insert last to keep rules/override order:
+            constructed.insertRule(rule.cssText, constructed.cssRules.length);
             hasRules = true;
           } catch {
             // Skip rules that cannot be cloned (e.g., invalid syntax)


### PR DESCRIPTION
Note: Apparently, [`insertRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule)'s default index is `0` which essentially reverses the order of the rules, breaking order-based overrides.