### PR TITLE
refactor(chat)!: rework styling internals for messages

### DIFF
--- a/src/components/chat/chat-message.ts
+++ b/src/components/chat/chat-message.ts
@@ -287,6 +287,7 @@ export default class IgcChatMessageComponent extends LitElement {
 
     const parts = {
       'message-container': true,
+      received: !this._state.isCurrentUserMessage(this.message),
       sent: this._state.isCurrentUserMessage(this.message),
     };
 

--- a/src/components/chat/themes/message.base.scss
+++ b/src/components/chat/themes/message.base.scss
@@ -2,47 +2,44 @@
 @use 'styles/utilities' as *;
 
 :host {
-    --igc-chat-message-padding: #{rem(12px) rem(16px)};
-    --igc-chat-sent-message-start-margin: auto;
-    --igc-chat-sent-message-end-margin: unset;
-    --igc-chat-message-container-end-margin: auto;
+    --ig-chat-message-padding-block: #{pad-block(12px)};
+    --ig-chat-message-padding-inline: #{pad-inline(16px)};
+    --ig-chat-message-padding: var(--ig-chat-message-padding-block)
+        var(--ig-chat-message-padding-inline);
+    --ig-chat-sent-message-start-margin: auto;
+    --ig-chat-sent-message-end-margin: unset;
+    --ig-chat-message-container-end-margin: auto;
 
     display: flex;
     flex-direction: column;
     width: 100%;
 }
 
-[part~='message-container'],
-[part='plain-text'] {  
-    @include type-style('body-1') {
-      margin: 0;
-    };
-}
-
 [part~='message-container'] {
     display: flex;
-    margin-inline-end: var(--igc-chat-message-container-end-margin);
+    margin-inline-end: var(--ig-chat-message-container-end-margin);
     flex-direction: column;
+    padding: var(--ig-chat-message-padding);
     gap: rem(16px);
 
     p {
-      margin: 0;
-      padding: 0;
+        margin: 0;
+        padding: 0;
     }
 
     a {
-      overflow-wrap: anywhere;
-      color: color(primary, 500);
+        overflow-wrap: anywhere;
+        color: color(primary, 500);
     }
 
     pre.shiki {
-      font-size: rem(14px);
-      line-height: rem(24px);
-      padding: rem(16px);
-      border-radius: rem(4px);
-      max-height: rem(320px);
-      max-width: rem(680px);
-      overflow-y: auto;
+        font-size: rem(14px);
+        line-height: rem(24px);
+        padding: rem(16px);
+        border-radius: rem(4px);
+        max-height: rem(320px);
+        max-width: rem(680px);
+        overflow-y: auto;
     }
 }
 
@@ -51,14 +48,13 @@
 [part~='message-actions'],
 [part~='plain-text'] {
     &:empty {
-      display: none;
+        display: none;
     }
 }
 
 [part~='sent'] {
-    margin-inline: var(--igc-chat-sent-message-start-margin, 0) var(--igc-chat-sent-message-end-margin, 0);
-    padding: var(--igc-chat-message-padding);
-    border-radius: rem(24px) rem(24px) 0;
+    margin-inline: var(--ig-chat-sent-message-start-margin, 0)
+        var(--ig-chat-sent-message-end-margin, 0);
     max-width: rem(576px);
     width: fit-content;
 }

--- a/src/components/chat/themes/message.ts
+++ b/src/components/chat/themes/message.ts
@@ -1,32 +1,17 @@
 import { css } from 'lit';
 
 import type { Themes } from '../../../theming/types.js';
-// Shared Styles
-import { styles as bootstrap } from './shared/chat-message/chat-message.bootstrap.css.js';
-import { styles as fluent } from './shared/chat-message/chat-message.fluent.css.js';
 import { styles as indigo } from './shared/chat-message/chat-message.indigo.css.js';
 
 const light = {
-  bootstrap: css`
-    ${bootstrap}
-  `,
   indigo: css`
     ${indigo}
-  `,
-  fluent: css`
-    ${fluent}
   `,
 };
 
 const dark = {
-  bootstrap: css`
-    ${bootstrap}
-  `,
   indigo: css`
     ${indigo}
-  `,
-  fluent: css`
-    ${fluent}
   `,
 };
 

--- a/src/components/chat/themes/shared/chat-message/chat-message.bootstrap.scss
+++ b/src/components/chat/themes/shared/chat-message/chat-message.bootstrap.scss
@@ -1,5 +1,0 @@
-@use 'styles/utilities' as *;
-
-[part~='sent'] {
-    border-radius: rem(8px) rem(8px) 0;
-}

--- a/src/components/chat/themes/shared/chat-message/chat-message.common.scss
+++ b/src/components/chat/themes/shared/chat-message/chat-message.common.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use 'styles/utilities' as *;
 @use '../../light/themes' as *;
 
@@ -5,18 +6,29 @@ $theme: $material;
 
 :host {
     --shiki-bg: #{var-get($theme, 'code-background')};
-}
-
-[part~='sent'] {
-    background: var-get($theme, 'message-background');
+    --message-corner-radius: 0;
 }
 
 [part~='message-container'] {
-    color: var-get($theme, 'message-color');
+    @include type-style('body-1');
+
+    border-radius: var-get($theme, 'message-border-radius');
 
     pre.shiki {
         border: rem(1px) solid var-get($theme, 'code-border');
     }
+}
+
+[part~='sent'] {
+    background: var-get($theme, 'sent-message-background');
+    color: var-get($theme, 'sent-message-color');
+    border-end-end-radius: var(--message-corner-radius);
+}
+
+[part~='received'] {
+    background: var-get($theme, 'received-message-background');
+    color: var-get($theme, 'received-message-color');
+    border-start-start-radius: var(--message-corner-radius);
 }
 
 [part~='message-actions'] {

--- a/src/components/chat/themes/shared/chat-message/chat-message.fluent.scss
+++ b/src/components/chat/themes/shared/chat-message/chat-message.fluent.scss
@@ -1,5 +1,0 @@
-@use 'styles/utilities' as *;
-
-// [part~='sent'] {
-//     border-radius: rem(2px);
-// }

--- a/src/components/chat/themes/shared/chat-message/chat-message.indigo.scss
+++ b/src/components/chat/themes/shared/chat-message/chat-message.indigo.scss
@@ -1,7 +1,7 @@
 @use 'styles/utilities' as *;
 @use '../../light/themes' as *;
 
-$theme: $material;
+$theme: $indigo;
 
 :host {
     --message-corner-radius: #{var-get($theme, 'message-border-radius')};

--- a/src/components/chat/themes/shared/chat-message/chat-message.indigo.scss
+++ b/src/components/chat/themes/shared/chat-message/chat-message.indigo.scss
@@ -1,5 +1,8 @@
 @use 'styles/utilities' as *;
+@use '../../light/themes' as *;
 
-[part~='sent'] {
-    border-radius: rem(8px);
+$theme: $material;
+
+:host {
+    --message-corner-radius: #{var-get($theme, 'message-border-radius')};
 }


### PR DESCRIPTION
Depends on https://github.com/IgniteUI/igniteui-theming/pull/566
Closes #2150 

## Description

Improve the styling of the chat messages via updated properties coming from the latest Ignite UI Theming. This is a breaking change since some of the `message`-related CSS custom properties have been replaced with specific ones that carry different names.

## Type of Change

<!-- Keep only the relevant type(s), remove the rest -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that causes existing functionality to change)
- [x] Refactoring (code improvements without functional changes)


## Testing

Open the chat component sample and try modifying the theme using: 

1. Plain CSS variables
2. By generating a Sass theme for the Chat Component

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] Breaking changes are documented in the description
