### PR TITLE
chore(deps): pin madge typescript override

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   "overrides": {
     "storybook": "$storybook",
     "madge": {
-      "typescript": "$typescript"
+      "typescript": "6.0.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
   },
   "customElements": "custom-elements.json",
   "overrides": {
-    "storybook": "$storybook",
     "madge": {
       "typescript": "6.0.2"
     }


### PR DESCRIPTION
CI workflows started failing with the latest `typescript` version: 6.0.3 published 12 hours ago, causing:
```text
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error
npm error Invalid: lock file's typescript@6.0.2 does not satisfy typescript@6.0.3
```
https://github.com/IgniteUI/igniteui-webcomponents/actions/runs/24563935871/job/71819180698#step:4:9

Copilot identified the issue is caused by the overrides section in package.json:
https://github.com/IgniteUI/igniteui-webcomponents/blob/30f79fee8b954c383c403966717770628f613a79/package.json#L131-L134

> The $typescript reference tells npm to re-resolve the root ^6.0.2 range for madge's transitive dependency (filing-cabinet). Since typescript@6.0.3 is now published and matches ^6.0.2, npm's ideal tree computation picks 6.0.3 — but the lock file has 6.0.2. npm ci considers this a mismatch and fails.

While a fresh `npm i` will update the dep, that will only resolve the issue until the next patch is released, which is not acceptable. Instead, pinning the version down to match the lock file and that will need to be updated and committed along future package-lock changes.

No, the `^6.0.2` doesn't work as that also seems to trigger re-resolve. Possibly related to https://github.com/npm/cli/issues/4942
~Yes, `storybook` can have the same issue, but can't be pinned as root override (conflicts with the actual dep) and CBA tracing which packages needed the override to begin with.~ Edit: Nvm, seems to be obsolete w/ current deps, removing.
Ideally, we'd drop those overrides as soon as possible.