### PR TITLE
docs(skills): add package-routing guidance to Ignite UI Web Components AI skills

### DIFF
--- a/skills/igniteui-wc-choose-components/SKILL.md
+++ b/skills/igniteui-wc-choose-components/SKILL.md
@@ -8,6 +8,11 @@ user-invocable: true
 
 This skill helps AI agents and developers identify the best Ignite UI components for any UI requirement, then provides direct links to official documentation, usage examples, and API references.
 
+## Before You Answer
+
+- Choose the package before writing imports or install steps.
+- If the user also needs setup or code, then load [igniteui-wc-integrate-with-framework](../igniteui-wc-integrate-with-framework/SKILL.md).
+
 ## Example Usage
 
 - "What component should I use to display a list of items with actions?"
@@ -46,9 +51,22 @@ Ignite UI for Web Components is distributed across several packages depending on
 | [`igniteui-webcomponents-grids`](https://www.npmjs.com/package/igniteui-webcomponents-grids) | Commercial | `npm install igniteui-webcomponents-grids` (trial) | Advanced data grids (Data Grid, Tree Grid, Hierarchical Grid, Pivot Grid) with many built-in functionalities  |
 | [`igniteui-grid-lite`](https://www.npmjs.com/package/igniteui-grid-lite) | MIT | `npm install igniteui-grid-lite` | Lightweight data grid for simpler tabular data |
 | [`igniteui-dockmanager`](https://www.npmjs.com/package/igniteui-dockmanager) | Commercial | `npm install igniteui-dockmanager` (trial) | Windowing / docking layouts (IDE-style panels) |
-| [`igniteui-webcomponents-charts`](https://www.npmjs.com/package/igniteui-webcomponents-charts) | Commercial | `npm install igniteui-webcomponents-core igniteui-webcomponents-charts` (trial) | Charts and data visualizations (65+ chart types) |
 
 ---
+
+## Package Routing
+
+| Component family | Package |
+|---|---|
+| General UI components | `igniteui-webcomponents` |
+| Advanced grids | `igniteui-webcomponents-grids` |
+| Grid Lite | `igniteui-grid-lite` |
+| Dock Manager | `igniteui-dockmanager` |
+
+If the request only says "grid", choose by features:
+
+- Advanced features such as editing, paging, summaries, grouping, hierarchical data, or pivot behavior -> `igniteui-webcomponents-grids`
+- Lightweight table -> `igniteui-grid-lite`
 
 ## Component Catalogue by UI Pattern
 
@@ -146,30 +164,6 @@ All inputs are form-associated and integrate natively with `<form>`.
 | Parent-child relational tree grid | Tree Grid | `<igc-tree-grid>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/grids/tree-grid/overview) |
 | Cross-tabulation / BI pivot table | Pivot Grid | `<igc-pivot-grid>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/web-components/components/grids/pivot-grid/overview) |
 
-### Charting & Visualization
-
-> Charts are provided by the **`igniteui-webcomponents-charts`** package (commercial). Use `IgcCategoryChartComponent` or `IgcFinancialChartComponent` for simpler domain-specific scenarios; use `IgcDataChartComponent` for full flexibility (mixed series, numeric/time axes, scatter, polar, etc.).
-
-| UI Need | Component | Tag | Docs |
-|---|---|---|---|
-| Column chart (vertical bars, category comparison) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/column-chart) |
-| Line chart (continuous data over time) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/line-chart) |
-| Area chart (filled line, change over time) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/area-chart) |
-| Spline chart (smooth curved lines) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/spline-chart) |
-| Step chart (stepped line or area) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/step-chart) |
-| Pie chart (part-to-whole, small data sets) | Pie Chart | `<igc-pie-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/pie-chart) |
-| Doughnut chart (part-to-whole with center label) | Doughnut Chart | `<igc-doughnut-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/donut-chart) |
-| Financial / stock chart (OHLC, candlestick, price series) | Financial Chart | `<igc-financial-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/stock-chart) |
-| Bar chart (horizontal bars, category comparison) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/bar-chart) |
-| Scatter chart (X/Y data correlation) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/scatter-chart) |
-| Bubble chart (3-value scatter with size dimension) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/bubble-chart) |
-| Polar chart (angle/radius coordinate system) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/polar-chart) |
-| Composite / combo chart (mixed series types) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/composite-chart) |
-| Shape chart (polygons / polylines on a Cartesian plane) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/shape-chart) |
-| Sparkline (word-sized inline mini-chart) | Sparkline | `<igc-sparkline>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/sparkline-chart) |
-| Treemap (hierarchical data as proportional nested nodes) | Treemap | `<igc-treemap>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/treemap-chart) |
-
-
 ### Conversational / AI
 
 | UI Need | Component | Tag | Docs |
@@ -216,7 +210,6 @@ Confirm which package provides the component:
 - **Advanced grids** (Data Grid, Tree Grid, Hierarchical Grid, Pivot Grid) → `igniteui-webcomponents-grids` *(commercial)*
 - **Lightweight grid** (Grid Lite) → `igniteui-grid-lite` *(MIT)*
 - **Docking layout** → `igniteui-dockmanager` *(commercial)*
-- **Charts & visualizations** (Category Chart, Data Chart, Financial Chart, Pie Chart, Sparkline, Treemap, etc.) → `igniteui-webcomponents-charts` *(commercial)*
 
 ### Step 4 — Link to official resources
 

--- a/skills/igniteui-wc-choose-components/SKILL.md
+++ b/skills/igniteui-wc-choose-components/SKILL.md
@@ -51,6 +51,7 @@ Ignite UI for Web Components is distributed across several packages depending on
 | [`igniteui-webcomponents-grids`](https://www.npmjs.com/package/igniteui-webcomponents-grids) | Commercial | `npm install igniteui-webcomponents-grids` (trial) | Advanced data grids (Data Grid, Tree Grid, Hierarchical Grid, Pivot Grid) with many built-in functionalities  |
 | [`igniteui-grid-lite`](https://www.npmjs.com/package/igniteui-grid-lite) | MIT | `npm install igniteui-grid-lite` | Lightweight data grid for simpler tabular data |
 | [`igniteui-dockmanager`](https://www.npmjs.com/package/igniteui-dockmanager) | Commercial | `npm install igniteui-dockmanager` (trial) | Windowing / docking layouts (IDE-style panels) |
+| [`igniteui-webcomponents-charts`](https://www.npmjs.com/package/igniteui-webcomponents-charts) | Commercial | `npm install igniteui-webcomponents-core igniteui-webcomponents-charts` (trial) | Charts and data visualizations (65+ chart types) |
 
 ---
 
@@ -62,6 +63,7 @@ Ignite UI for Web Components is distributed across several packages depending on
 | Advanced grids | `igniteui-webcomponents-grids` |
 | Grid Lite | `igniteui-grid-lite` |
 | Dock Manager | `igniteui-dockmanager` |
+| Charts | `igniteui-webcomponents-charts` |
 
 If the request only says "grid", choose by features:
 
@@ -164,6 +166,30 @@ All inputs are form-associated and integrate natively with `<form>`.
 | Parent-child relational tree grid | Tree Grid | `<igc-tree-grid>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/grids/tree-grid/overview) |
 | Cross-tabulation / BI pivot table | Pivot Grid | `<igc-pivot-grid>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/web-components/components/grids/pivot-grid/overview) |
 
+### Charting & Visualization
+
+> Charts are provided by the **`igniteui-webcomponents-charts`** package (commercial). Use `IgcCategoryChartComponent` or `IgcFinancialChartComponent` for simpler domain-specific scenarios; use `IgcDataChartComponent` for full flexibility (mixed series, numeric/time axes, scatter, polar, etc.).
+
+| UI Need | Component | Tag | Docs |
+|---|---|---|---|
+| Column chart (vertical bars, category comparison) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/column-chart) |
+| Line chart (continuous data over time) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/line-chart) |
+| Area chart (filled line, change over time) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/area-chart) |
+| Spline chart (smooth curved lines) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/spline-chart) |
+| Step chart (stepped line or area) | Category Chart | `<igc-category-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/step-chart) |
+| Pie chart (part-to-whole, small data sets) | Pie Chart | `<igc-pie-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/pie-chart) |
+| Doughnut chart (part-to-whole with center label) | Doughnut Chart | `<igc-doughnut-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/donut-chart) |
+| Financial / stock chart (OHLC, candlestick, price series) | Financial Chart | `<igc-financial-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/stock-chart) |
+| Bar chart (horizontal bars, category comparison) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/bar-chart) |
+| Scatter chart (X/Y data correlation) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/scatter-chart) |
+| Bubble chart (3-value scatter with size dimension) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/bubble-chart) |
+| Polar chart (angle/radius coordinate system) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/polar-chart) |
+| Composite / combo chart (mixed series types) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/composite-chart) |
+| Shape chart (polygons / polylines on a Cartesian plane) | Data Chart | `<igc-data-chart>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/shape-chart) |
+| Sparkline (word-sized inline mini-chart) | Sparkline | `<igc-sparkline>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/sparkline-chart) |
+| Treemap (hierarchical data as proportional nested nodes) | Treemap | `<igc-treemap>` | [Docs](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/charts/types/treemap-chart) |
+
+
 ### Conversational / AI
 
 | UI Need | Component | Tag | Docs |
@@ -210,6 +236,7 @@ Confirm which package provides the component:
 - **Advanced grids** (Data Grid, Tree Grid, Hierarchical Grid, Pivot Grid) → `igniteui-webcomponents-grids` *(commercial)*
 - **Lightweight grid** (Grid Lite) → `igniteui-grid-lite` *(MIT)*
 - **Docking layout** → `igniteui-dockmanager` *(commercial)*
+- **Charts & visualizations** (Category Chart, Data Chart, Financial Chart, Pie Chart, Sparkline, Treemap, etc.) → `igniteui-webcomponents-charts` *(commercial)*
 
 ### Step 4 — Link to official resources
 

--- a/skills/igniteui-wc-choose-components/SKILL.md
+++ b/skills/igniteui-wc-choose-components/SKILL.md
@@ -66,10 +66,10 @@ Ignite UI for Web Components is distributed across several packages depending on
 | Component family | Package |
 |---|---|
 | General UI components | `igniteui-webcomponents` |
-| Advanced grids | `igniteui-webcomponents-grids` |
+| Advanced grids | `igniteui-webcomponents-grids` (trial) `@infragistics/igniteui-webcomponents-grids` (licensed) |
 | Grid Lite | `igniteui-grid-lite` |
-| Dock Manager | `igniteui-dockmanager` |
-| Charts | `igniteui-webcomponents-charts` |
+| Dock Manager | `igniteui-dockmanager` (trial) `@infragistics/igniteui-dockmanager` (licensed) |
+| Charts | `igniteui-webcomponents-charts` (trial) `@infragistics/igniteui-webcomponents-charts` (licensed) |
 
 If the request only says "grid", choose by features:
 

--- a/skills/igniteui-wc-choose-components/SKILL.md
+++ b/skills/igniteui-wc-choose-components/SKILL.md
@@ -11,6 +11,7 @@ This skill helps AI agents and developers identify the best Ignite UI components
 ## Before You Answer
 
 - Choose the package before writing imports or install steps.
+- If the required package is not present in `package.json`, add or install the correct Ignite UI dependency first. Absence from `package.json` does not mean the package is invalid.
 - If the user also needs setup or code, then load [igniteui-wc-integrate-with-framework](../igniteui-wc-integrate-with-framework/SKILL.md).
 
 ## Example Usage

--- a/skills/igniteui-wc-choose-components/SKILL.md
+++ b/skills/igniteui-wc-choose-components/SKILL.md
@@ -51,7 +51,13 @@ Ignite UI for Web Components is distributed across several packages depending on
 | [`igniteui-webcomponents-grids`](https://www.npmjs.com/package/igniteui-webcomponents-grids) | Commercial | `npm install igniteui-webcomponents-grids` (trial) | Advanced data grids (Data Grid, Tree Grid, Hierarchical Grid, Pivot Grid) with many built-in functionalities  |
 | [`igniteui-grid-lite`](https://www.npmjs.com/package/igniteui-grid-lite) | MIT | `npm install igniteui-grid-lite` | Lightweight data grid for simpler tabular data |
 | [`igniteui-dockmanager`](https://www.npmjs.com/package/igniteui-dockmanager) | Commercial | `npm install igniteui-dockmanager` (trial) | Windowing / docking layouts (IDE-style panels) |
+| [`igniteui-webcomponents-grids`](https://www.npmjs.com/package/igniteui-webcomponents-grids) | Commercial | `npm install igniteui-webcomponents-grids` (trial) | Advanced data grids (Data Grid, Tree Grid, Hierarchical Grid, Pivot Grid) with many built-in functionalities  |
+| [`@infragistics/igniteui-webcomponents-grids`](https://packages.infragistics.com/feeds/js-licensed/@infragistics/igniteui-webcomponents-grids) | Commercial | `npm install @infragistics/igniteui-webcomponents-grids` (licensed) | Advanced data grids (Data Grid, Tree Grid, Hierarchical Grid, Pivot Grid) with many built-in functionalities  |
+| [`igniteui-grid-lite`](https://www.npmjs.com/package/igniteui-grid-lite) | MIT | `npm install igniteui-grid-lite` | Lightweight data grid for simpler tabular data |
+| [`igniteui-dockmanager`](https://www.npmjs.com/package/igniteui-dockmanager) | Commercial | `npm install igniteui-dockmanager` (trial) | Windowing / docking layouts (IDE-style panels) |
+| [`@infragistics/igniteui-dockmanager`](https://packages.infragistics.com/feeds/js-licensed/@infragistics/igniteui-dockmanager) | Commercial | `npm install @infragistics/igniteui-dockmanager` (licensed) | Windowing / docking layouts (IDE-style panels) |
 | [`igniteui-webcomponents-charts`](https://www.npmjs.com/package/igniteui-webcomponents-charts) | Commercial | `npm install igniteui-webcomponents-core igniteui-webcomponents-charts` (trial) | Charts and data visualizations (65+ chart types) |
+| [`@infragistics/igniteui-webcomponents-charts`](https://packages.infragistics.com/feeds/js-licensed/@infragistics/igniteui-webcomponents-charts) | Commercial | `npm install @infragistics/igniteui-webcomponents-core @infragistics/igniteui-webcomponents-charts` (licensed) | Charts and data visualizations (65+ chart types) |
 
 ---
 

--- a/skills/igniteui-wc-integrate-with-framework/SKILL.md
+++ b/skills/igniteui-wc-integrate-with-framework/SKILL.md
@@ -18,10 +18,10 @@ This skill helps users integrate Ignite UI Web Components into their application
 | Component family | Package |
 |---|---|
 | General UI components | `igniteui-webcomponents` |
-| Advanced grids | `igniteui-webcomponents-grids` |
+| Advanced grids | `igniteui-webcomponents-grids` (trial) `@infragistics/igniteui-webcomponents-grids` (licensed) |
 | Grid Lite | `igniteui-grid-lite` |
-| Dock Manager | `igniteui-dockmanager` |
-| Charts | `igniteui-webcomponents-charts` |
+| Dock Manager | `igniteui-dockmanager` (trial) `@infragistics/igniteui-dockmanager` (licensed) |
+| Charts | `igniteui-webcomponents-charts` (trial) `@infragistics/igniteui-webcomponents-charts` (licensed) |
 
 If the request only says "grid", infer the package from the requested features:
 

--- a/skills/igniteui-wc-integrate-with-framework/SKILL.md
+++ b/skills/igniteui-wc-integrate-with-framework/SKILL.md
@@ -8,6 +8,25 @@ user-invocable: true
 
 This skill helps users integrate Ignite UI Web Components into their application. It detects the framework or platform in use and loads the appropriate step-by-step integration reference.
 
+## Before You Answer
+
+- Choose the package first, then load the framework reference.
+- Do not assume every setup flow uses `igniteui-webcomponents`.
+
+### Package Routing
+
+| Component family | Package |
+|---|---|
+| General UI components | `igniteui-webcomponents` |
+| Advanced grids | `igniteui-webcomponents-grids` |
+| Grid Lite | `igniteui-grid-lite` |
+| Dock Manager | `igniteui-dockmanager` |
+
+If the request only says "grid", infer the package from the requested features:
+
+- Use `igniteui-webcomponents-grids` for editing, paging, sorting, filtering, summaries, grouping, hierarchical data, or pivot features.
+- Use `igniteui-grid-lite` for lightweight tabular data.
+
 ## Example Usage
 
 - "How do I use igniteui-webcomponents in my React app?"

--- a/skills/igniteui-wc-integrate-with-framework/SKILL.md
+++ b/skills/igniteui-wc-integrate-with-framework/SKILL.md
@@ -12,6 +12,7 @@ This skill helps users integrate Ignite UI Web Components into their application
 
 - Choose the package first, then load the framework reference.
 - Do not assume every setup flow uses `igniteui-webcomponents`.
+- If the required package is not present in `package.json`, add or install the correct Ignite UI dependency first. Absence from `package.json` does not mean the package is invalid.
 
 ### Package Routing
 

--- a/skills/igniteui-wc-integrate-with-framework/SKILL.md
+++ b/skills/igniteui-wc-integrate-with-framework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: igniteui-wc-integrate-with-framework
-description: Integrate igniteui-webcomponents into React, Angular, Vue, or vanilla JS applications with framework-specific configurations
+description: Integrate Ignite UI Web Components packages into React, Angular, Vue, or vanilla JS applications with framework-specific configurations
 user-invocable: true
 ---
 
@@ -21,6 +21,7 @@ This skill helps users integrate Ignite UI Web Components into their application
 | Advanced grids | `igniteui-webcomponents-grids` |
 | Grid Lite | `igniteui-grid-lite` |
 | Dock Manager | `igniteui-dockmanager` |
+| Charts | `igniteui-webcomponents-charts` |
 
 If the request only says "grid", infer the package from the requested features:
 

--- a/skills/igniteui-wc-integrate-with-framework/references/angular.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/angular.md
@@ -1,6 +1,6 @@
 # Integrating Ignite UI Web Components — Angular
 
-> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-charts`, `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
 
 ## Installation
 

--- a/skills/igniteui-wc-integrate-with-framework/references/angular.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/angular.md
@@ -1,6 +1,6 @@
 # Integrating Ignite UI Web Components — Angular
 
-> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the install, import, and registration steps below with the setup for the selected package instead of the default one. Use that package's own setup instructions as the source of truth.
 
 ## Installation
 

--- a/skills/igniteui-wc-integrate-with-framework/references/angular.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/angular.md
@@ -1,5 +1,7 @@
 # Integrating Ignite UI Web Components — Angular
 
+> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+
 ## Installation
 
 ```bash

--- a/skills/igniteui-wc-integrate-with-framework/references/react.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/react.md
@@ -11,6 +11,8 @@ React integration uses the **`igniteui-react`** package, which provides React-na
 
 Components use the `Igr` prefix (e.g. `IgrButton`, `IgrInput`, `IgrCombo`).
 
+> Package note: This page shows the default React wrapper setup for general UI components. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, do not reuse the `igniteui-react` and `Igr*` guidance below as-is; switch to the selected package's setup instead.
+
 ### Installation
 
 ```bash

--- a/skills/igniteui-wc-integrate-with-framework/references/react.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/react.md
@@ -11,7 +11,7 @@ React integration uses the **`igniteui-react`** package, which provides React-na
 
 Components use the `Igr` prefix (e.g. `IgrButton`, `IgrInput`, `IgrCombo`).
 
-> Package note: This page shows the default React wrapper setup for general UI components. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, do not reuse the `igniteui-react` and `Igr*` guidance below as-is; switch to the selected package's setup instead.
+> Package note: This page shows the default React wrapper setup for general UI components. If the routing step selected `igniteui-webcomponents-charts`, `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, do not reuse the `igniteui-react` and `Igr*` guidance below as-is; switch to the selected package's setup instead.
 
 ### Installation
 

--- a/skills/igniteui-wc-integrate-with-framework/references/vanilla-js.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/vanilla-js.md
@@ -1,6 +1,6 @@
 # Integrating Ignite UI Web Components — Vanilla JavaScript / HTML
 
-> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-charts`, `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
 
 ## Installation
 

--- a/skills/igniteui-wc-integrate-with-framework/references/vanilla-js.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/vanilla-js.md
@@ -1,5 +1,7 @@
 # Integrating Ignite UI Web Components — Vanilla JavaScript / HTML
 
+> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+
 ## Installation
 
 ```bash

--- a/skills/igniteui-wc-integrate-with-framework/references/vanilla-js.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/vanilla-js.md
@@ -1,6 +1,9 @@
 # Integrating Ignite UI Web Components — Vanilla JavaScript / HTML
 
-> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+> Package note: The installation and setup steps on this page are the default instructions for `igniteui-webcomponents`. If you selected a different package in the routing step, use that package's reference instead:
+> - [`igniteui-webcomponents-grids`](./vanilla-js-grids.md)
+> - [`igniteui-grid-lite`](./vanilla-js-grid-lite.md)
+> - [`igniteui-dockmanager`](./vanilla-js-dockmanager.md)
 
 ## Installation
 

--- a/skills/igniteui-wc-integrate-with-framework/references/vue.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/vue.md
@@ -1,5 +1,7 @@
 # Integrating Ignite UI Web Components — Vue 3
 
+> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+
 ## Installation
 
 ```bash

--- a/skills/igniteui-wc-integrate-with-framework/references/vue.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/vue.md
@@ -1,6 +1,6 @@
 # Integrating Ignite UI Web Components — Vue 3
 
-> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+> Package note: This page shows the default Vue 3 setup for `igniteui-webcomponents`, and the steps below apply to that package. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, use the selected package's Vue setup reference instead of this default setup. See the [package-specific Vue setup references](./) for the install, import, and registration steps for the package you selected.
 
 ## Installation
 

--- a/skills/igniteui-wc-integrate-with-framework/references/vue.md
+++ b/skills/igniteui-wc-integrate-with-framework/references/vue.md
@@ -1,6 +1,6 @@
 # Integrating Ignite UI Web Components — Vue 3
 
-> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
+> Package note: This page shows the default setup for `igniteui-webcomponents`. If the routing step selected `igniteui-webcomponents-charts`, `igniteui-webcomponents-grids`, `igniteui-grid-lite`, or `igniteui-dockmanager`, replace the package-specific install, import, and registration steps below with that package's setup instead of the default one.
 
 ## Installation
 


### PR DESCRIPTION
## Description

Adds concise package-routing guidance to the Ignite UI Web Components skills and small guardrail notes in framework setup references. This helps AI agents avoid defaulting to the generic package for grids, Grid Lite, and Dock Manager.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (code improvements without functional changes)

## Related Issues

Closes #https://github.com/IgniteUI/igniteui-cli/pull/1639

## Testing

Documentation-only change; no runtime testing required.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
- [ ] Breaking changes are documented in the description
