### PR TITLE
feat(skills): add igniteui-wc-generate-from-image-design skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -13,6 +13,7 @@ Skills are structured instructions that help AI agents understand and execute co
 | [igniteui-wc-choose-components](./igniteui-wc-choose-components/SKILL.md)                   | Identify the right components for a UI pattern and navigate to official docs/demos | Deciding which components to use      |
 | [igniteui-wc-integrate-with-framework](./igniteui-wc-integrate-with-framework/SKILL.md)     | Integrate components into React, Angular, Vue, or vanilla JS applications          | Setting up components in your project |
 | [igniteui-wc-customize-component-theme](./igniteui-wc-customize-component-theme/SKILL.md)   | Customize styling using CSS custom properties, parts, and theming system           | Applying custom brand colors/styles   |
+| [igniteui-wc-generate-from-image-design](./igniteui-wc-generate-from-image-design/SKILL.md) | Implement a view from a screenshot or mockup using Ignite UI Web Components        | Converting a design image into UI     |
 | [igniteui-wc-optimize-bundle-size](./igniteui-wc-optimize-bundle-size/SKILL.md)             | Reduce bundle size by importing only needed components and lazy loading            | Optimizing production performance     |
 
 ## How to Use
@@ -22,12 +23,14 @@ When working with an AI agent like GitHub Copilot, reference skills by name or a
 ### Natural Questions
 - "How do I integrate igniteui-webcomponents with React?"
 - "Help me customize the button colors to match my brand"
+- "Build this screenshot with Ignite UI Web Components"
 - "My bundle size is too large, how can I reduce it?"
 - "Show me how to use these components in Vue"
 
 ### Direct Skill Reference
 - "Follow the integrate-with-framework skill for my Angular app"
 - "Use the customize-component-theme skill to help me style components"
+- "Use the generate-from-image-design skill to implement this mockup"
 - "Apply the optimize-bundle-size skill to reduce my bundle"
 
 ## Skill Structure

--- a/skills/igniteui-wc-generate-from-image-design/SKILL.md
+++ b/skills/igniteui-wc-generate-from-image-design/SKILL.md
@@ -23,7 +23,7 @@ Before writing any implementation code, you must complete these steps in order:
 2. **Confirm package layout if needed** - Web Components packages are split by component family; check package layout or licensing only when package choice, component registration, or theming depend on it.
 3. **Discover components** - Call `list_components` with targeted filters to find matching components for each UI pattern.
 4. **Look up component docs** - Call `get_doc` for every chosen component family before coding.
-5. **Generate theme** - (a) To generate a theme, first extract colors and create a color palette using `create_palette` or `create_custom_palette` depending on the scenario. Then extract elevations and call `create_elevations`. Then extract typography and call `create_typography`. Then call `create_theme` when Sass is configured, or import the closest pre-built theme CSS and layer token overrides when Sass is not configured. (b) After a theme exists, prefer using design tokens or scoped semantic CSS variables over raw literals. (c) For every Ignite UI component family that exposes design tokens, call `get_component_design_tokens`, map extracted image tokens to token roles, then call `create_component_theme` with the tokens differing from the global theme for the specific component.
+5. **Generate theme** - (a) To generate a theme, first extract colors and create a color palette using `create_palette` or `create_custom_palette` depending on the scenario. Then extract elevations and call `create_elevations`. Then extract typography and call `create_typography`. Then call `create_theme` when Sass is configured, or import the closest pre-built theme CSS. (b) After a theme exists, prefer using design tokens or scoped semantic CSS variables over raw literals. (c) For every Ignite UI component family that exposes design tokens, call `get_component_design_tokens`, map extracted image tokens to token roles, then call `create_component_theme` with the tokens differing from the global theme for the specific component.
 6. **Implement** - Build the screenshot-first layout, data, and view components.
 7. **Refine** - Use the `set_size`, `set_spacing`, `set_roundness` tools to refine the view's visual fidelity against the image, then iterate on implementation and theming until the view matches the design closely.
 8. **Validate** - Build, test, run, compare against the image, and fix differences.
@@ -94,17 +94,17 @@ Use this skill for the image-to-view theming workflow only. The dedicated [`igni
 
 ### 5a - Existing app guard (always run first)
 
-Before generating any theme code, inspect the project's entry point and main stylesheet(s) (commonly `main.ts`, `main.js`, `index.ts`, `app.ts`, `styles.css`, or `styles.scss`). Look for:
+Before generating any theme code, inspect the project's entry point and main stylesheet(s) (commonly `main.ts`, `main.js`, `index.ts`, `app.ts`, `styles.css`, or the app's main theme stylesheet). Look for:
 
 - an imported pre-built theme CSS file such as `igniteui-webcomponents/themes/light/material.css`
-- active `@include palette(...)`, `@include typography(...)`, or `@include elevations(...)` calls when Sass is configured
 - existing palette tokens or semantic CSS variables already exposed by the app
+- existing app-level typography or elevation variables already exposed by the app
 
-- **Existing theme found** -> the global theme is already set. Do **not** call `create_theme` or `create_palette` unless the user explicitly wants a global theme change. Instead:
+- **Existing theme found** -> the global theme is already set. Do **not** call `create_palette` unless the user explicitly wants a global theme change. Instead:
   1. Inspect the existing theme import, palette definition, and any exposed semantic CSS variables.
   2. Reuse the current design system, variant, and palette tokens wherever they already match the design image.
   3. Skip to **5c** and apply only minimal scoped overrides for the new view's components.
-- **No theme found / blank theme setup** -> proceed with **5b** to generate a fresh global theme.
+- **No theme found / blank theme setup** -> proceed with **5b** to generate a fresh CSS-based theme baseline.
 
 ### 5b - Global theme generation (new projects only)
 
@@ -113,22 +113,19 @@ Follow this order - MCP guidance first, image extraction second:
 1. **Read MCP guidance first** - call `theming://guidance/colors/rules` (or `get_theming_guidance`) before looking at the image. This tells you the available theme inputs and any luminance or variant constraints.
 2. **Resolve the design system** - infer it from the existing workspace, explicit user request, or the closest visual match in the design. Do not assume one if a stronger signal exists.
 3. **Extract from the image** - now that you know the available slots, extract values only for the inputs you actually need.
-4. **Call `create_theme` or `create_palette`** with the extracted seed values:
+4. **Call `create_palette` or `create_custom_palette`** with the extracted seed values:
 
 ```
-create_theme({
-  primaryColor: "<color extracted from image for primary slot>",
-  secondaryColor: "<color extracted from image for secondary slot>",
-  surfaceColor: "<color extracted from image for surface/background slot>",
+create_palette({
+  primary: "<color extracted from image for primary slot>",
+  secondary: "<color extracted from image for secondary slot>",
+  surface: "<color extracted from image for surface/background slot>",
   variant: "<resolved theme variant>",
-  platform: "webcomponents",
-  licensed: <detected licensing state>,
-  fontFamily: "<font extracted from image or existing app>",
-  designSystem: "<resolved design system>"
+  platform: "webcomponents"
 })
 ```
 
-If Sass is not configured, still use `create_palette`, `get_color`, and component theme generation to derive palette-backed values and import the closest built-in theme CSS instead of assuming a Sass theme file can be dropped into the project.
+Import the closest built-in theme CSS for the resolved design system and variant, then use `get_color` to translate the generated palette into CSS custom properties, semantic app tokens, and component token values. Apply typography decisions with standard CSS `font-family`, `font-size`, and `font-weight` rules, and apply elevations with CSS box-shadow values or semantic shadow variables.
 
 Read and act on any luminance warnings returned. If the design needs multiple surface depths that a single generated surface color does not cover, use `create_custom_palette` or define semantic CSS variables for the additional depths in the main stylesheet.
 
@@ -142,7 +139,7 @@ For **every** chosen Ignite UI component family in Steps 3-4, follow this MCP-fi
 
 1. **Discover (MCP first)** - call `get_component_design_tokens(component)` before looking at the image for that component. Read the full token list with names, types, and descriptions. Identify which tokens correspond to visible surfaces, text, borders, icons, and interaction states.
 2. **Extract (image second)** - now that you know the exact token names, go to the image region for that component and read the exact token value for each relevant token slot. Do not guess; zoom into the component region.
-3. **Generate** - call `create_component_theme(component, platform, licensed, tokens)` passing only the tokens whose resolved value differs from the global theme. This produces scoped CSS or Sass with the minimal override set.
+3. **Generate** - call `create_component_theme(component, platform, licensed, tokens)` passing only the tokens whose resolved value differs from the global theme. This produces the minimal scoped theme override set for the component.
 
 **Example - theming a grid:**
 - `get_component_design_tokens("grid")` returns `header-background`, `content-background`, `row-hover-background` among many others.
@@ -159,11 +156,11 @@ Do not run `create_component_theme` for regions built with custom HTML/CSS only.
 Apply in this exact order:
 
 1. Inspect the entry point and main stylesheet(s) -> existing theme or blank?
-2. Create or update a theme: `create_theme` or pre-built theme import plus token overrides (Step 5b)
+2. Create or update a theme baseline: pre-built theme import plus palette-backed CSS variables and token overrides (Step 5b)
 3. For each Ignite UI component: `get_component_design_tokens` -> map image design tokens -> resolve values to design tokens or semantic CSS variables -> `create_component_theme` (Step 5c)
 4. Use `get_color` after palette generation whenever a palette token can represent the final color intent
 
-If you use typography mixins with a comma-separated font family list, wrap the font families in parentheses as described in [references/gotchas.md](references/gotchas.md).
+Use standard CSS `font-family` lists in stylesheets or CSS variables for typography. Do not emit Sass typography mixins for Ignite UI Web Components apps.
 
 ## Step 6: Install Required Packages
 
@@ -179,7 +176,7 @@ If required packages are missing, identify the exact packages and versions requi
 
 - **Layout**: use Ignite UI layout and data-display components as the starting point for standard regions, then apply CSS Grid/Flexbox and component overrides to match the screenshot. Only substitute plain semantic HTML when an Ignite UI component remains structurally incompatible after a genuine attempt.
 - **Data**: use typed mock data that matches the design's density and domain; add models/services only when they help the implementation.
-- **View**: keep layout, spacing, typography, and surface styling in CSS or SCSS rather than inline attributes.
+- **View**: keep layout, spacing, typography, and surface styling in CSS rather than inline attributes.
 - **Theming**: apply the resolved design system and theme variant from Step 5, and keep color usage aligned with palette tokens or local semantic CSS variables.
 
 ### Implementation Checks

--- a/skills/igniteui-wc-generate-from-image-design/SKILL.md
+++ b/skills/igniteui-wc-generate-from-image-design/SKILL.md
@@ -184,7 +184,7 @@ If required packages are missing, identify the exact packages and versions requi
 
 ### Implementation Checks
 
-- Follow repo conventions from `AGENTS.md` and `.github/copilot-instructions.md`.
+- Follow repo conventions from `.github/copilot-instructions.md` and `.github/CODING_GUIDELINES.md`.
 - Use [references/component-mapping.md](references/component-mapping.md) for component-choice and semantic-fallback rules.
 - Use [references/gotchas.md](references/gotchas.md) for components, theming, registration, and API edge cases instead of re-encoding those rules inline.
 - Favor Ignite UI components over custom HTML when both approaches can reach similar visual fidelity.

--- a/skills/igniteui-wc-generate-from-image-design/SKILL.md
+++ b/skills/igniteui-wc-generate-from-image-design/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: igniteui-wc-generate-from-image-design
+description: Implement application views from design images using Ignite UI Web Components. Uses MCP servers (igniteui-cli, igniteui-theming) to discover components, generate themes, and follow best practices. Triggers when the user provides a design image (screenshot, mockup, wireframe) and wants it built as a working view with Ignite UI Web Components. Also triggers when the user asks to "implement this design", "build this UI", "convert this mockup", or "create a page from this image" in an Ignite UI Web Components project.
+user-invocable: true
+---
+
+# Implementing Ignite UI Web Components Views from Design Images
+
+## MANDATORY AGENT PROTOCOL
+
+Before writing any implementation code, you must complete these steps in order:
+
+1. Analyze the image and identify all visible regions and UI patterns.
+2. Read [references/component-mapping.md](references/component-mapping.md) and [references/gotchas.md](references/gotchas.md).
+3. This skill is Web Components-first. Check package layout or licensing only when package choice, component registration, or theming depend on it.
+4. To apply a theme, use the theming workflow from this skill and the dedicated `igniteui-wc-customize-component-theme` skill; use the `igniteui-theming` MCP tools instead of styling from memory.
+5. Call `get_doc` for every chosen component family before using it.
+6. Only then start coding.
+
+## Workflow
+
+1. **Analyze the design image** - Read the image, identify every UI section, component, layout structure.
+2. **Confirm package layout if needed** - Web Components packages are split by component family; check package layout or licensing only when package choice, component registration, or theming depend on it.
+3. **Discover components** - Call `list_components` with targeted filters to find matching components for each UI pattern.
+4. **Look up component docs** - Call `get_doc` for every chosen component family before coding.
+5. **Generate theme** - (a) To generate a theme, first extract colors and create a color palette using `create_palette` or `create_custom_palette` depending on the scenario. Then extract elevations and call `create_elevations`. Then extract typography and call `create_typography`. Then call `create_theme` when Sass is configured, or import the closest pre-built theme CSS and layer token overrides when Sass is not configured. (b) After a theme exists, prefer using design tokens or scoped semantic CSS variables over raw literals. (c) For every Ignite UI component family that exposes design tokens, call `get_component_design_tokens`, map extracted image tokens to token roles, then call `create_component_theme` with the tokens differing from the global theme for the specific component.
+6. **Implement** - Build the screenshot-first layout, data, and view components.
+7. **Refine** - Use the `set_size`, `set_spacing`, `set_roundness` tools to refine the view's visual fidelity against the image, then iterate on implementation and theming until the view matches the design closely.
+8. **Validate** - Build, test, run, compare against the image, and fix differences.
+
+## Step 1: Analyze the Design Image
+
+Read the input image carefully. For each visual section, identify:
+
+- **Layout structure**: grid rows/columns, sidebar, navbar, content area proportions, and estimated fixed widths or percentages for major regions.
+> Note: Do not guess the exact CSS properties at this stage; just identify the high-level structure and relative proportions. Do not try to fit the view into exact breakpoints or pixel values. Try to generate a flexible layout that preserves the observed proportions and can adapt to different screen sizes. You will refine the exact CSS rules in Step 8 after building a first version of the view.
+- **Component type**: chart, list, card, grid, form, navigation, etc.
+- **Color palette**: primary, secondary, surface/background, accent, text colors.
+- **Typography**: font sizes, weights, letter-spacing patterns.
+- **Surface styling**: borders, border-radius, shadows, elevation, divider treatments.
+- **Data patterns**: what mock data is needed (time series, lists, KPIs, tabular, scheduling).
+- **Spacing system**: translate observed padding and gaps into a small reusable scale derived from the design.
+
+Before writing code, create a decomposition table with one row per visible region containing:
+
+| Region | Visual role | Candidate component | Custom CSS required | Data type |
+|---|---|---|---|---|
+| Example: sidebar item list | repeated rows with icon + label | `IgcListComponent` + `IgcListItemComponent` | yes - item height, icon size | domain-appropriate mock data |
+| Example: top bar | brand + tabs + search | `IgcNavbarComponent` | yes - multi-zone slot layout | n/a |
+| Example: side panel | always-visible navigation | `IgcNavDrawerComponent` | yes - width, item styling | n/a |
+
+Start every region with the most appropriate Ignite UI component from [references/component-mapping.md](references/component-mapping.md). Only fall back to plain semantic HTML when the component DOM structure is fundamentally incompatible with the design after CSS overrides, tokens, slots, and documented `::part(...)` selectors are considered. Document the reason for any plain-HTML fallback in a code comment.
+
+Before writing code, produce a compact implementation brief that captures:
+
+- chosen components per region
+- fallback HTML regions
+- theme strategy
+- package needs
+- component registration needs
+- major assumptions
+
+After the table, translate the image into CSS Grid rows and columns first. Preserve desktop proportions before adding responsive behavior, then define explicit breakpoint stacking rules for smaller screens.
+
+## Step 2-3: Use MCP Tools for Discovery
+
+This skill is Web Components-first. Check package layout or licensing only when package choice, component registration, or theming depend on it.
+
+- If the project is unlicensed or uses trial package layout, do not mark documented trial packages as blocked or licensed-only during implementation.
+- If the result indicates a licensed package layout, follow the licensed import paths shown in the component reference when needed.
+
+Then call `list_components` with `framework: "webcomponents"` and relevant filters to find components matching each UI pattern. Common filters:
+
+- `chart`, `sparkline` - for data visualization
+- `list view`, `card`, `avatar`, `badge` - for data display
+- `nav`, `navbar`, `drawer`, `dock manager` - for navigation and shell layouts
+- `progress` - for metrics
+- `grid lite`, `data grid`, `tree grid` - for tabular data
+- `calendar`, `date picker`, `combo`, `select`, `input` - for forms and scheduling
+
+Use narrow search terms to reduce noisy MCP results. Search for the specific UI pattern you need, such as `list view` instead of `list`.
+
+For component-to-Ignite-UI mapping, see [references/component-mapping.md](references/component-mapping.md).
+
+## Step 4: Look Up Component API
+
+For every chosen component category, call `get_doc` with the doc name from `list_components` results (e.g., `name: "card"`, `framework: "webcomponents"`). Use the doc `name` field from the MCP results, not the result title shown in the list. This is mandatory before coding and gives exact usage patterns, slots, events, registration, and API structure.
+
+Call `search_docs` for feature-based questions (e.g., "how to configure [component] for [specific behavior or styling need]").
+
+## Step 5: Generate Theme with MCP
+
+Use this skill for the image-to-view theming workflow only. The dedicated [`igniteui-wc-customize-component-theme`](../igniteui-wc-customize-component-theme/SKILL.md) skill remains the source of truth for palette-token behavior, global theme rules, and broader theming-system guidance.
+
+### 5a - Existing app guard (always run first)
+
+Before generating any theme code, inspect the project's entry point and main stylesheet(s) (commonly `main.ts`, `main.js`, `index.ts`, `app.ts`, `styles.css`, or `styles.scss`). Look for:
+
+- an imported pre-built theme CSS file such as `igniteui-webcomponents/themes/light/material.css`
+- active `@include palette(...)`, `@include typography(...)`, or `@include elevations(...)` calls when Sass is configured
+- existing palette tokens or semantic CSS variables already exposed by the app
+
+- **Existing theme found** -> the global theme is already set. Do **not** call `create_theme` or `create_palette` unless the user explicitly wants a global theme change. Instead:
+  1. Inspect the existing theme import, palette definition, and any exposed semantic CSS variables.
+  2. Reuse the current design system, variant, and palette tokens wherever they already match the design image.
+  3. Skip to **5c** and apply only minimal scoped overrides for the new view's components.
+- **No theme found / blank theme setup** -> proceed with **5b** to generate a fresh global theme.
+
+### 5b - Global theme generation (new projects only)
+
+Follow this order - MCP guidance first, image extraction second:
+
+1. **Read MCP guidance first** - call `theming://guidance/colors/rules` (or `get_theming_guidance`) before looking at the image. This tells you the available theme inputs and any luminance or variant constraints.
+2. **Resolve the design system** - infer it from the existing workspace, explicit user request, or the closest visual match in the design. Do not assume one if a stronger signal exists.
+3. **Extract from the image** - now that you know the available slots, extract values only for the inputs you actually need.
+4. **Call `create_theme` or `create_palette`** with the extracted seed values:
+
+```
+create_theme({
+  primaryColor: "<color extracted from image for primary slot>",
+  secondaryColor: "<color extracted from image for secondary slot>",
+  surfaceColor: "<color extracted from image for surface/background slot>",
+  variant: "<resolved theme variant>",
+  platform: "webcomponents",
+  licensed: <detected licensing state>,
+  fontFamily: "<font extracted from image or existing app>",
+  designSystem: "<resolved design system>"
+})
+```
+
+If Sass is not configured, still use `create_palette`, `get_color`, and component theme generation to derive palette-backed values and import the closest built-in theme CSS instead of assuming a Sass theme file can be dropped into the project.
+
+Read and act on any luminance warnings returned. If the design needs multiple surface depths that a single generated surface color does not cover, use `create_custom_palette` or define semantic CSS variables for the additional depths in the main stylesheet.
+
+Use `create_palette` for straightforward designs with a small, coherent color system. Use `create_custom_palette` when the design has multiple distinct surface depths, several accent families, or when the generated palette cannot reliably match the screenshot.
+
+### 5c - Per-component token discovery and mapping (always run)
+
+> **Scope:** this step applies to every Ignite UI Web Components family that exposes design tokens. Core components - cards, inputs, select, combo, navbar, nav drawer, list, tabs, date pickers, chips, etc. - are the primary targets. For packages or components that do not expose a practical token surface in the current project, fall back to documented properties, `::part(...)` selectors, or wrapper styles instead of inventing unsupported tokens.
+
+For **every** chosen Ignite UI component family in Steps 3-4, follow this MCP-first loop - query MCP before touching the image:
+
+1. **Discover (MCP first)** - call `get_component_design_tokens(component)` before looking at the image for that component. Read the full token list with names, types, and descriptions. Identify which tokens correspond to visible surfaces, text, borders, icons, and interaction states.
+2. **Extract (image second)** - now that you know the exact token names, go to the image region for that component and read the exact token value for each relevant token slot. Do not guess; zoom into the component region.
+3. **Generate** - call `create_component_theme(component, platform, licensed, tokens)` passing only the tokens whose resolved value differs from the global theme. This produces scoped CSS or Sass with the minimal override set.
+
+**Example - theming a grid:**
+- `get_component_design_tokens("grid")` returns `header-background`, `content-background`, `row-hover-background` among many others.
+- Look at the grid region in the image -> extract the color intent for header, row background, and hover state.
+- Resolve each value to a palette token or local semantic CSS variable.
+- Call `create_component_theme("grid", ...)` with only `{ "header-background": "<resolved token>", "content-background": "<resolved token>", "row-hover-background": "<resolved token>" }`.
+
+Apply the generated theme blocks to the component selector or a scoped wrapper exactly as shown in the `create_component_theme` output.
+
+Do not run `create_component_theme` for regions built with custom HTML/CSS only.
+
+### 5d - Theming sequence summary
+
+Apply in this exact order:
+
+1. Inspect the entry point and main stylesheet(s) -> existing theme or blank?
+2. Create or update a theme: `create_theme` or pre-built theme import plus token overrides (Step 5b)
+3. For each Ignite UI component: `get_component_design_tokens` -> map image design tokens -> resolve values to design tokens or semantic CSS variables -> `create_component_theme` (Step 5c)
+4. Use `get_color` after palette generation whenever a palette token can represent the final color intent
+
+If you use typography mixins with a comma-separated font family list, wrap the font families in parentheses as described in [references/gotchas.md](references/gotchas.md).
+
+## Step 6: Install Required Packages
+
+General UI components ship with `igniteui-webcomponents`. Lightweight tabular data can use `igniteui-grid-lite`. Advanced grids, dock manager, and charts require additional packages and may vary by trial versus licensed package layout. Resolve the selected component families against the current workspace and [references/component-mapping.md](references/component-mapping.md).
+
+After selecting packages, register only the custom elements you actually use with `defineComponents(...)` in the appropriate entry point or setup module, unless the host framework integration already handles registration differently. Use [`igniteui-wc-integrate-with-framework`](../igniteui-wc-integrate-with-framework/SKILL.md) when framework-specific setup details matter.
+
+If required packages are missing, identify the exact packages and versions required first, then ask for approval before installing packages or changing dependency manifests.
+
+## Step 7: Implement
+
+### Structure
+
+- **Layout**: use Ignite UI layout and data-display components as the starting point for standard regions, then apply CSS Grid/Flexbox and component overrides to match the screenshot. Only substitute plain semantic HTML when an Ignite UI component remains structurally incompatible after a genuine attempt.
+- **Data**: use typed mock data that matches the design's density and domain; add models/services only when they help the implementation.
+- **View**: keep layout, spacing, typography, and surface styling in CSS or SCSS rather than inline attributes.
+- **Theming**: apply the resolved design system and theme variant from Step 5, and keep color usage aligned with palette tokens or local semantic CSS variables.
+
+### Implementation Checks
+
+- Follow repo conventions from `AGENTS.md` and `.github/copilot-instructions.md`.
+- Use [references/component-mapping.md](references/component-mapping.md) for component-choice and semantic-fallback rules.
+- Use [references/gotchas.md](references/gotchas.md) for components, theming, registration, and API edge cases instead of re-encoding those rules inline.
+- Favor Ignite UI components over custom HTML when both approaches can reach similar visual fidelity.
+- Register only the custom elements you actually use, and place registration in the project's existing entry-point pattern.
+- Use slots, parts, and documented component APIs before reaching for shadow-DOM workarounds.
+- Preserve spacing, hierarchy, and data density before adding extra interactivity.
+- Avoid generic placeholders when the image shows domain-specific content.
+- Document brief assumptions when the image is ambiguous instead of silently guessing.
+
+## Step 8: Refine
+
+After the first implementation pass, use the `set_size`, `set_spacing`, and `set_roundness` tools to adjust the view's visual properties and close the gap with the image. Focus on the most visually distinctive elements first (e.g., panel proportions, chart shape, button prominence) before tuning smaller details (e.g., row heights, spacing between regions).
+
+## Step 9: Validate
+
+Use this validation loop explicitly:
+
+1. Build
+2. Test
+3. Run the app
+4. Visually compare against the image
+5. Adjust and repeat
+
+In terminal-only environments, the user performs the visual comparison and provides feedback on any mismatches. Only perform the visual check directly when the environment has browser and screenshot capabilities available to the agent.
+
+Use this checklist during the first visual comparison:
+
+- panel proportions
+- control density
+- chart shape
+- legend placement
+- button prominence
+- row heights
+- spacing between regions
+
+Fix TypeScript, registration, markup, or build errors immediately during the build/test steps. Use the build output, component docs, [references/gotchas.md](references/gotchas.md), and the user's visual feedback to close the remaining gaps. Typical adjustments include:
+
+- revisiting chart data density, smoothing, or marker visibility
+- adjusting layout ratios, region spacing, or row heights
+- correcting navigation mode, panel chrome, package choice, or component choice
+- tuning theme tokens, component overrides, and dark-surface hierarchy
+- re-examining the original design for overlooked sections or missing registration/imports
+
+After the build succeeds with zero errors, refine layout proportions, color values, missing sections, and typography until the view matches closely.

--- a/skills/igniteui-wc-generate-from-image-design/references/component-mapping.md
+++ b/skills/igniteui-wc-generate-from-image-design/references/component-mapping.md
@@ -1,0 +1,132 @@
+# Ignite UI Web Components Component Mapping Reference
+
+## Table of Contents
+- [Dashboard & Layout Components](#dashboard--layout-components)
+- [Chart Components](#chart-components)
+- [Data Display Components](#data-display-components)
+- [Form & Input Components](#form--input-components)
+- [Calendar & Scheduling Components](#calendar--scheduling-components)
+- [Map Components](#map-components)
+- [Gauge Components](#gauge-components)
+- [Package Requirements](#package-requirements)
+- [Import Patterns](#import-patterns)
+
+## Dashboard & Layout Components
+
+| UI Pattern | Ignite UI Component | Key Properties |
+|---|---|---|
+| Top navigation bar | `IgcNavbarComponent` | `slot="start"`, default slot, `slot="end"` |
+| Side navigation | `IgcNavDrawerComponent` | `open`, `position`, default slot, `slot="mini"` |
+| Content cards/panels | `IgcCardComponent` | `<igc-card-header>`, `<igc-card-content>`, `<igc-card-actions>` |
+| Tabbed content | `IgcTabsComponent` | `<igc-tab>` children, `alignment`, `activation` |
+| Accordion sections | `IgcAccordionComponent` | `IgcExpansionPanelComponent` children |
+| Split layouts | `IgcSplitterComponent` | pane-based layout, nested split regions |
+| Tile dashboard | `IgcTileManagerComponent` | drag/resize tiles |
+| IDE-style dock layout | `IgcDockManagerComponent` | floating/docking panels (Commercial) |
+
+Decision rule:
+
+- Use `IgcNavbarComponent` for a top horizontal bar when its slot structure and behavior match the screenshot. Use slotted content and CSS flex overrides to achieve multi-zone layouts inside it. Use a plain `<header>` when that is a closer structural fit.
+- Use `IgcNavDrawerComponent` for a sidebar or side-navigation panel when drawer structure and behavior match the screenshot. Configure `open`, `position`, and mini content according to whether the design shows fixed, collapsible, or icon-only navigation. Use a plain `<aside>` when a static custom sidebar matches the screenshot better.
+- Use `IgcTabsComponent` for a horizontal tab strip when the screenshot clearly shows tabbed state switching.
+- Use `IgcDockManagerComponent` only when the screenshot truly shows docked, floating, or IDE-like panels. Do not substitute it for a simple dashboard grid.
+
+Component decision matrix (by visual pattern, domain-neutral):
+
+| Visual Pattern | Recommended Component | Notes |
+|---|---|---|
+| Repeated rows with icon/text/action | `IgcListComponent` + `IgcListItemComponent` | Use when the row anatomy and interaction model match; use `slot="title"`, `slot="subtitle"`, `slot="start"`, `slot="end"`. Use native `<ul>/<li>` or custom containers when that is a closer visual fit |
+| Spreadsheet-like editable or sortable table | `IgcGridComponent` | Use `igniteui-grid-lite` for lightweight tables and advanced grid packages when the screenshot needs built-in editing, paging, filtering, grouping, summaries, hierarchy, or pivoting |
+| Hierarchical or tree-structured table | `IgcTreeGridComponent` or `IgcHierarchicalGridComponent` | Use when rows have parent-child or master-detail relationships |
+| Content blocks / summary cards | `IgcCardComponent` | Use when card chrome helps match the panel shape and structure. Use header/content/actions subcomponents with slotted content. Use plain `<div>` containers for flat or highly custom tiles |
+| Any text input field | `IgcInputComponent` | Use when the input anatomy matches the screenshot, including search fields and inline editors. Apply CSS and tokens to match the screenshot's border/radius style |
+| Dropdown or select | `IgcSelectComponent` | Use when the screenshot clearly shows select/dropdown behavior |
+| Form fields with labels and inputs | `IgcInputComponent`, `IgcSelectComponent`, `IgcComboComponent`, `IgcDatePickerComponent` | Cover text, select, combo, and date inputs |
+| Multi-step form / wizard | `IgcStepperComponent` | Use when a sequence of steps is visually present |
+| Filter chips / tag inputs | `IgcChipComponent` | Use when chip anatomy matches status badges, filter tags, or removable labels in the screenshot |
+| Calendar or date picker as a primary view element | `IgcCalendarComponent`, `IgcDatePickerComponent`, `IgcDateRangePickerComponent` | Use when scheduling or date selection is the core UI |
+| Top icon/action bar | `IgcNavbarComponent` with slotted icon buttons | Use when a navbar structure matches the screenshot; use plain icon buttons or custom containers when that is a closer fit |
+
+## Chart Components
+
+| UI Pattern | Ignite UI Component | Key Properties |
+|---|---|---|
+| Area chart | `IgcCategoryChartComponent` | `chartType`, `markerTypes`, `brushes`, `outlines` |
+| Line chart | `IgcCategoryChartComponent` | `chartType`, `markerTypes`, `brushes` |
+| Column/bar chart | `IgcCategoryChartComponent` or `IgcDataChartComponent` | `chartType`, `markerTypes`, series configuration |
+| Sparkline (mini chart) | `IgcSparklineComponent` | `displayType`, `valueMemberPath` |
+| Pie/donut chart | `IgcPieChartComponent` / `IgcDoughnutChartComponent` | `valueMemberPath`, `labelMemberPath` |
+| Financial chart | `IgcFinancialChartComponent` | OHLC/candlestick data |
+| Complex multi-series | `IgcDataChartComponent` | multiple series plus axes |
+
+Decision rule:
+
+- Financial or OHLC screenshot: prefer `IgcFinancialChartComponent`.
+- Simple or moderate trend panel: prefer `IgcCategoryChartComponent`; move to `IgcDataChartComponent` when you need lower-level per-series control.
+- Highly custom sparkline or microchart: use `IgcSparklineComponent` or a custom fallback if the built-in anatomy is not a close visual match.
+
+## Data Display Components
+
+| UI Pattern | Ignite UI Component | Key Properties |
+|---|---|---|
+| Item list | `IgcListComponent` + `IgcListItemComponent` | `slot="title"`, `slot="subtitle"`, `slot="start"`, `slot="end"` |
+| User avatar | `IgcAvatarComponent` | `initials`, `shape`, `src` |
+| Status badge | `IgcBadgeComponent` | `value`, styling |
+| Icons | `IgcIconComponent` | `name`, `collection`, styling |
+| Progress bar | `IgcLinearProgressComponent` | `value`, `max` |
+| Circular progress | `IgcCircularProgressComponent` | `value`, `max` |
+| Flat data grid | `IgcGridComponent` | Grid Lite or full Data Grid depending features |
+| Hierarchical/tree data grid | `IgcTreeGridComponent` / `IgcHierarchicalGridComponent` | hierarchical data support |
+| Filter/tag chips | `IgcChipComponent` | `removable`, `selectable` |
+
+Decision rule:
+
+- Use `IgcListComponent` for repeated-row content lists when its row structure and interaction model match the screenshot. The component adds accessible keyboard navigation, item structure, and theming when those benefits fit the design. Use native `<ul>/<li>` or custom containers when they are a closer visual fit.
+- Choose `IgcGridComponent` only when the image is truly tabular (flat rows and columns, spreadsheet-style). Resolve whether the lightweight or advanced grid package is the right fit from the required behavior.
+- Choose `IgcTreeGridComponent` or `IgcHierarchicalGridComponent` when rows have parent-child or nested structure.
+- Use `IgcChipComponent` when chip anatomy matches the screenshot's status badges, tags, or label pills. Use custom badge or pill markup when a simpler or more exact visual match is needed.
+
+## Form & Input Components
+
+| UI Pattern | Ignite UI Component | Key Properties |
+|---|---|---|
+| Text input | `IgcInputComponent` | `type`, `value`, prefix/suffix/helper slots |
+| Dropdown select | `IgcSelectComponent` | `<igc-select-item>` children, prefix/suffix slots |
+| Searchable multi-select | `IgcComboComponent` | data binding, display/value keys, selection mode |
+| Date picker | `IgcDatePickerComponent` | `value`, `min`, `max` |
+| Time or date-time entry | `IgcDateTimeInputComponent` | typed editing for date/time fields |
+| Toggle switch | `IgcSwitchComponent` | checked state, change events |
+| Checkbox | `IgcCheckboxComponent` | checked state, validation |
+| Radio button group | `IgcRadioGroupComponent` + `IgcRadioComponent` | grouped selection |
+| Slider | `IgcSliderComponent` | `min`, `max`, labels/ticks |
+| Multi-step wizard | `IgcStepperComponent` + `IgcStepComponent` | orientation, linear step flow |
+| Chip filter bar | `IgcChipComponent` or `IgcButtonGroupComponent` | choose based on chip versus segmented-control anatomy |
+
+## Calendar & Scheduling Components
+
+| UI Pattern | Ignite UI Component | Key Properties |
+|---|---|---|
+| Calendar view | `IgcCalendarComponent` | `value`, selection mode |
+| Date range picker | `IgcDateRangePickerComponent` | `value`, range selection |
+| Month/year picker | `IgcCalendarComponent` | month/year modes when the calendar UI is primary |
+
+## Package Requirements
+
+The main `igniteui-webcomponents` package contains general UI components (list, avatar, navbar, drawer, card, badge, progress, icon, inputs, scheduling, layout, etc.).
+
+Additional packages may be required beyond the main package:
+
+| Capability | Additional packages |
+|---|---|
+| Lightweight tabular data | `igniteui-grid-lite` |
+| Advanced grids | `igniteui-webcomponents-grids` (trial) or `@infragistics/igniteui-webcomponents-grids` (licensed) |
+| Charts / sparklines | `igniteui-webcomponents-core` + `igniteui-webcomponents-charts` (trial) or licensed equivalents |
+| Dock manager | `igniteui-dockmanager` (trial) or `@infragistics/igniteui-dockmanager` (licensed) |
+
+Install only the packages required by the components you actually selected. Resolve the exact package layout from the current workspace before installing or importing.
+
+## Import Patterns
+
+Treat this file as a component selection reference, not as authoritative import guidance for a specific repo. Confirm exact imports and registration from `detect_platform`, the current workspace, framework setup, and `get_doc` results.
+
+For direct Web Components usage, import the component classes from the selected package and register only the needed elements with `defineComponents(...)`. If the host app uses React, Angular, Vue, or another wrapper pattern around Web Components, follow [`igniteui-wc-integrate-with-framework`](../../igniteui-wc-integrate-with-framework/SKILL.md) for the final setup details.

--- a/skills/igniteui-wc-generate-from-image-design/references/component-mapping.md
+++ b/skills/igniteui-wc-generate-from-image-design/references/component-mapping.md
@@ -6,8 +6,6 @@
 - [Data Display Components](#data-display-components)
 - [Form & Input Components](#form--input-components)
 - [Calendar & Scheduling Components](#calendar--scheduling-components)
-- [Map Components](#map-components)
-- [Gauge Components](#gauge-components)
 - [Package Requirements](#package-requirements)
 - [Import Patterns](#import-patterns)
 

--- a/skills/igniteui-wc-generate-from-image-design/references/gotchas.md
+++ b/skills/igniteui-wc-generate-from-image-design/references/gotchas.md
@@ -1,0 +1,181 @@
+# Ignite UI Web Components Gotchas & Pitfalls
+
+## Table of Contents
+- [Sass Conflicts](#sass-conflicts)
+- [Component Registration](#component-registration)
+- [Chart Properties](#chart-properties)
+- [Component Properties](#component-properties)
+- [Theming Pitfalls](#theming-pitfalls)
+- [Missing Direct Mappings](#missing-direct-mappings)
+- [Dark Theme Specifics](#dark-theme-specifics)
+
+## Sass Conflicts
+
+### `contrast()` function collision
+The CSS `contrast()` filter function can collide with `igniteui-theming`'s `contrast()` Sass function. When you need the native CSS function, call it explicitly via `sass:meta`:
+```scss
+@use "sass:meta";
+
+.uses-css-contrast {
+  filter: meta.call(meta.get-function("contrast", $css: true), <contrast-value>);
+}
+```
+Prefer this approach over string escaping when a native CSS function name collides with a Sass function.
+
+### Font family in typography mixin
+Comma-separated font families are parsed as multiple Sass arguments. Wrap in parentheses:
+```scss
+// BAD
+@include typography($font-family: "Primary Font", "Fallback Font", sans-serif);
+
+// GOOD
+@include typography($font-family: ("Primary Font", "Fallback Font", sans-serif));
+```
+Replace `"Primary Font"` and `"Fallback Font"` with the font families extracted from the design image.
+
+## Component Registration
+
+### `defineComponents(...)` is required for direct Web Components usage
+Register only the custom elements you actually use, and register them from the correct package:
+```ts
+import {
+  defineComponents,
+  IgcCardComponent,
+  IgcNavbarComponent,
+} from 'igniteui-webcomponents';
+
+defineComponents(IgcNavbarComponent, IgcCardComponent);
+```
+
+If the current app uses React, Angular, Vue, or another integration layer around Web Components, follow [`igniteui-wc-integrate-with-framework`](../../igniteui-wc-integrate-with-framework/SKILL.md) instead of duplicating registration patterns blindly.
+
+### Package family matters
+Do not assume everything comes from `igniteui-webcomponents`. Advanced grids, charts, and dock manager live in separate packages and may have trial versus licensed package names. Resolve the package first, then register components from that package.
+
+## Chart Properties
+
+### Markers shown by default
+Category charts can show markers by default. If the screenshot does not show markers, set `markerTypes` to the matching no-marker option documented for the component. Confirm the exact value shape from `get_doc`.
+
+### `plotAreaBackground` does NOT exist on `igc-category-chart`
+Use CSS to style the chart container background instead.
+
+### `areaFillOpacity` exists on `IgcCategoryChartComponent`
+It does NOT exist on `IgcSparklineComponent`.
+
+### `includedProperties` must be a real array
+Assign it as an array through JavaScript or TypeScript, not as a serialized string:
+```ts
+const chart = document.querySelector('igc-category-chart');
+chart.includedProperties = ['fieldOne', 'fieldTwo', 'fieldThree'];
+```
+Replace `'fieldOne'`, `'fieldTwo'`, etc. with the actual data property names from your mock data.
+
+### Chart callback properties must be assigned as functions
+Function-valued chart APIs should be assigned on the element instance, not passed as string attributes:
+```ts
+const chart = document.querySelector('igc-category-chart');
+chart.xAxisFormatLabel = labelFormatter;
+```
+
+### Smooth area charts
+For smooth-looking area charts where the data should appear continuous rather than spiky:
+- Increase data density until the line or area reads as continuous at the rendered size.
+- Apply smoothing only when the source shape in the design looks smoothed rather than point-to-point.
+- Hide markers unless the screenshot clearly shows visible data points.
+- Tune fill opacity and label density to match the screenshot instead of relying on a fixed default.
+
+### Charts inside CSS Grid can collapse
+In a flexible CSS Grid track, set the grid cell and chart sizing values explicitly so the chart does not collapse:
+```scss
+.chart-panel {
+  min-height: <resolved-grid-cell-min-height>;
+}
+
+igc-category-chart {
+  display: <resolved-chart-display>;
+  height: <resolved-chart-height>;
+}
+```
+
+## Component Properties
+
+### Avatar shape is controlled by `shape`
+Use the supported `shape` API (`circle`, `rounded`, `square`, etc. as documented for the component).
+
+### List item title and subtitle are slots
+Use the Web Components slot anatomy:
+```html
+<igc-list-item>
+  <span slot="start"><resolved-leading-content></span>
+  <span slot="title"><resolved-title></span>
+  <span slot="subtitle"><resolved-subtitle></span>
+  <span slot="end"><resolved-trailing-content></span>
+</igc-list-item>
+```
+
+### Avatar background color via CSS
+```html
+<igc-avatar style="--ig-avatar-background: <resolved-avatar-background-token>;"></igc-avatar>
+```
+
+### Nav drawer width
+The drawer sizing hooks in the current implementation are `--menu-full-width` and `--menu-mini-width`:
+```css
+igc-nav-drawer {
+  --menu-full-width: <extracted-sidebar-width>;
+  --menu-mini-width: <extracted-mini-drawer-width>;
+}
+```
+
+## Theming Pitfalls
+
+### Never hardcode colors after palette generation
+Once a palette or theme exists, use `get_color` and palette-backed CSS custom properties such as `<resolved-palette-token-reference>` or semantic CSS variables derived from them. Do not leave raw hex values in component styles, theme overrides, or one-off CSS rules unless the value is intentionally outside the theme system.
+
+### Compound components require child theming
+`igc-select`, `igc-combo`, `igc-date-picker`, and `igc-date-range-picker` are compound components. Follow the related-theme chain returned by `get_component_design_tokens` instead of styling only the parent selector.
+
+### Component theme functions
+For core UI component theming, prefer `create_component_theme` and apply the returned theme block as generated by the MCP server.
+
+### Grid theming is package-specific
+`igniteui-grid-lite` and the advanced grid packages do not map to Angular's `igx-grid__*` internal class structure. Use `get_component_design_tokens("grid")`, the exact grid package docs, and exposed tokens or parts for the package present in the workspace.
+
+### Read luminance warnings from theme generation
+If `create_theme` returns a luminance warning for a generated surface, do not ignore it. If the design needs multiple surface depths, use `create_custom_palette` or define semantic CSS variables such as `--surface-1` and `--surface-2` in the main stylesheet instead of relying on a single generated surface color.
+
+
+## Dark Theme Specifics
+
+### Use the resolved dark variant for dark themes
+If the project uses pre-built CSS themes, import the dark variant that matches the chosen design system. If Sass is configured, apply the dark schema explicitly:
+```scss
+@use 'igniteui-theming' as *;
+
+$dark-palette: palette(
+  $primary: <resolved-primary-color>,
+  $secondary: <resolved-secondary-color>,
+  $surface: <resolved-surface-color>
+);
+
+@include palette($dark-palette, $schema: <resolved-dark-schema>);
+```
+
+### CSS custom properties for dark panels
+When the design uses multiple dark surface depths (panels, sidebars, cards on a dark background), define reusable semantic tokens using palette references or values derived from the design intent:
+
+```css
+:root {
+  --surface-primary: <resolved-surface-primary-token>;
+  --surface-secondary: <resolved-surface-secondary-token>;
+  --accent-strong: <resolved-accent-token>;
+  --text-primary: <resolved-text-primary-token>;
+  --text-secondary: <resolved-text-secondary-token>;
+}
+```
+
+If `create_theme` returns a single surface color that does not cover all depth levels visible in the design, define additional surface tokens (`--surface-1`, `--surface-2`, etc.) for each distinct depth.
+
+### Use `::part(...)` only when tokens are not enough
+When a visual adjustment goes beyond component design tokens, target documented `::part(...)` selectors from the current component docs or source. Scope the selector to the smallest practical wrapper so the override stays local to the generated view.

--- a/skills/igniteui-wc-generate-from-image-design/references/gotchas.md
+++ b/skills/igniteui-wc-generate-from-image-design/references/gotchas.md
@@ -1,36 +1,11 @@
 # Ignite UI Web Components Gotchas & Pitfalls
 
 ## Table of Contents
-- [Sass Conflicts](#sass-conflicts)
 - [Component Registration](#component-registration)
 - [Chart Properties](#chart-properties)
 - [Component Properties](#component-properties)
 - [Theming Pitfalls](#theming-pitfalls)
 - [Dark Theme Specifics](#dark-theme-specifics)
-
-## Sass Conflicts
-
-### `contrast()` function collision
-The CSS `contrast()` filter function can collide with `igniteui-theming`'s `contrast()` Sass function. When you need the native CSS function, call it explicitly via `sass:meta`:
-```scss
-@use "sass:meta";
-
-.uses-css-contrast {
-  filter: meta.call(meta.get-function("contrast", $css: true), <contrast-value>);
-}
-```
-Prefer this approach over string escaping when a native CSS function name collides with a Sass function.
-
-### Font family in typography mixin
-Comma-separated font families are parsed as multiple Sass arguments. Wrap in parentheses:
-```scss
-// BAD
-@include typography($font-family: "Primary Font", "Fallback Font", sans-serif);
-
-// GOOD
-@include typography($font-family: ("Primary Font", "Fallback Font", sans-serif));
-```
-Replace `"Primary Font"` and `"Fallback Font"` with the font families extracted from the design image.
 
 ## Component Registration
 
@@ -86,7 +61,7 @@ For smooth-looking area charts where the data should appear continuous rather th
 
 ### Charts inside CSS Grid can collapse
 In a flexible CSS Grid track, set the grid cell and chart sizing values explicitly so the chart does not collapse:
-```scss
+```css
 .chart-panel {
   min-height: <resolved-grid-cell-min-height>;
 }
@@ -141,24 +116,16 @@ For core UI component theming, prefer `create_component_theme` and apply the ret
 ### Grid theming is package-specific
 `igniteui-grid-lite` and the advanced grid packages do not map to Angular's `igx-grid__*` internal class structure. Use `get_component_design_tokens("grid")`, the exact grid package docs, and exposed tokens or parts for the package present in the workspace.
 
-### Read luminance warnings from theme generation
-If `create_theme` returns a luminance warning for a generated surface, do not ignore it. If the design needs multiple surface depths, use `create_custom_palette` or define semantic CSS variables such as `--surface-1` and `--surface-2` in the main stylesheet instead of relying on a single generated surface color.
+### Read luminance warnings from palette generation
+If palette generation returns a luminance warning for a generated surface, do not ignore it. If the design needs multiple surface depths, use `create_custom_palette` or define semantic CSS variables such as `--surface-1` and `--surface-2` in the main stylesheet instead of relying on a single generated surface color.
 
 
 ## Dark Theme Specifics
 
 ### Use the resolved dark variant for dark themes
-If the project uses pre-built CSS themes, import the dark variant that matches the chosen design system. If Sass is configured, apply the dark schema explicitly:
-```scss
-@use 'igniteui-theming' as *;
-
-$dark-palette: palette(
-  $primary: <resolved-primary-color>,
-  $secondary: <resolved-secondary-color>,
-  $surface: <resolved-surface-color>
-);
-
-@include palette($dark-palette, $schema: <resolved-dark-schema>);
+If the project uses pre-built CSS themes, import the dark variant that matches the chosen design system in the app entry point:
+```ts
+import 'igniteui-webcomponents/themes/dark/material.css';
 ```
 
 ### CSS custom properties for dark panels
@@ -174,7 +141,7 @@ When the design uses multiple dark surface depths (panels, sidebars, cards on a 
 }
 ```
 
-If `create_theme` returns a single surface color that does not cover all depth levels visible in the design, define additional surface tokens (`--surface-1`, `--surface-2`, etc.) for each distinct depth.
+If palette generation returns a single surface color that does not cover all depth levels visible in the design, define additional surface tokens (`--surface-1`, `--surface-2`, etc.) for each distinct depth.
 
 ### Use `::part(...)` only when tokens are not enough
 When a visual adjustment goes beyond component design tokens, target documented `::part(...)` selectors from the current component docs or source. Scope the selector to the smallest practical wrapper so the override stays local to the generated view.

--- a/skills/igniteui-wc-generate-from-image-design/references/gotchas.md
+++ b/skills/igniteui-wc-generate-from-image-design/references/gotchas.md
@@ -6,7 +6,6 @@
 - [Chart Properties](#chart-properties)
 - [Component Properties](#component-properties)
 - [Theming Pitfalls](#theming-pitfalls)
-- [Missing Direct Mappings](#missing-direct-mappings)
 - [Dark Theme Specifics](#dark-theme-specifics)
 
 ## Sass Conflicts


### PR DESCRIPTION
## Description

Adds a new `igniteui-wc-generate-from-image-design` skill for building Ignite UI Web Components views from screenshots, mockups, and wireframes.  
The skill provides a structured image-to-implementation workflow, Web Components-specific component mapping, and focused guidance for theming, package selection, registration, and visual refinement.

## Included

- New `igniteui-wc-generate-from-image-design` skill
- Web Components-specific `component-mapping.md`
- Web Components-specific `gotchas.md`
- README update to surface the new skill in the repo skill index

## Why

This adds a dedicated workflow for turning design images into working Ignite UI Web Components UI with guidance that is consistent with the repo’s component model and theming approach.  
It also makes this workflow easier to discover and reuse for screenshot-to-view tasks across Web Components projects.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (code improvements without functional changes)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have tested my changes locally
- [x] I have updated documentation if needed
- [ ] Breaking changes are documented in the description
