### PR TITLE
feat: set line-height to the expansion-panel title and subtitle

### DIFF
--- a/src/components/expansion-panel/themes/expansion-panel.base.scss
+++ b/src/components/expansion-panel/themes/expansion-panel.base.scss
@@ -37,12 +37,15 @@
     @include line-clamp(var(--lines-clamped), true, true);
 
     margin: 0;
+    line-height: normal;
 }
 
 [part='subtitle'] {
     &::slotted(*) {
         @include type-style('subtitle-2');
         @include ellipsis();
+
+        line-height: normal;
     }
 }
 


### PR DESCRIPTION
Closes: #1978 

There were actually two separate issues in this bug.

The first issue came from the Bootstrap CDN import, which applies global styles to all `heading` elements. 
<img width="1176" height="642" alt="Screenshot 2026-05-29 at 20 09 54" src="https://github.com/user-attachments/assets/364eef25-690f-43fa-a4c0-ec4b9e7dd899" />

As a result, in the sample, our slotted `h1` and `h6` elements received a fixed `line-height` of 1.2. This value was too small for some of the used fonts (mainly noticeable with the default Windows OS font), causing parts of the text to overflow outside of the element.
<img width="306" height="376" alt="Screenshot 2026-05-29 at 20 08 41" src="https://github.com/user-attachments/assets/8350d8c5-7d44-4ba5-ba6e-088ef1cdec5f" />

The only way to make our component styles override those externally applied styles would be to add `!important` to our title and subtitle classes, which we prefer to avoid.

If we still want to use external styles such as the Bootstrap CDN import, we should be more mindful of which elements we are slotting into the component slots. For the Expansion Panel `title` and `subtitle` specifically, the best approach is to use `span` elements. (We are currently working on another task to improve the documentation for slotted elements and clarify which elements are recommended to use in each slot.)


However, regarding the second issue, I tried removing the Bootstrap CDN import, and after doing so, I noticed that the title still had the same problem. The set `font-size` and `line-height` values were too close, which again caused some fonts (mostly the default Windows OS font) to overflow outside of the element. Because of this, I changed the `line-height` to `normal` instead of using a fixed value. This ensures that the text always renders correctly regardless of the font being used.