### PR TITLE
feat(forms): resolve external labels to inner control of form controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- #### Form associated custom elements
+  - External `<label>` associations are now resolved to the underlying native input of form-associated controls. Associating a label with `IgcInput`, `IgcMaskInput`, `IgcTextarea`, `IgcDateTimeInput`, `IgcSelect`, `IgcCombo`, `IgcDatePicker`, or `IgcDateRangePicker` — either through the `for`/`id` IDREF mechanism or by nesting the component inside the `<label>` — now correctly exposes the label to assistive technologies and focuses the inner input on label activation.
+
 ## [7.2.3] - 2026-06-18
 ### Fixed
 - #### Popover based components

--- a/src/components/combo/combo.spec.ts
+++ b/src/components/combo/combo.spec.ts
@@ -17,6 +17,7 @@ import { first } from '../common/util.js';
 import {
   createFormAssociatedTestBed,
   isFocused,
+  runExternalLabelAssociationTests,
   simulateBlur,
   simulateClick,
   simulateKeyboard,
@@ -1794,5 +1795,13 @@ describe('Combo', () => {
 
       runValidationContainerTests(IgcComboComponent, testParameters);
     });
+  });
+
+  runExternalLabelAssociationTests({
+    tagName: IgcComboComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcComboComponent).renderRoot
+        .querySelector<IgcInputComponent>('#target')!
+        .renderRoot.querySelector('input')!,
   });
 });

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -12,6 +12,7 @@ import { addRootClickController } from '../common/controllers/root-click.js';
 import { addSlotController, setSlots } from '../common/controllers/slot.js';
 import { blazorAdditionalDependencies } from '../common/decorators/blazorAdditionalDependencies.js';
 import { blazorIndirectRender } from '../common/decorators/blazorIndirectRender.js';
+import { shadowOptions } from '../common/decorators/shadow-options.js';
 import { registerComponent } from '../common/definitions/register.js';
 import { addI18nController } from '../common/i18n/i18n-controller.js';
 import { IgcBaseComboBoxComponent } from '../common/mixins/combo-box.js';
@@ -125,6 +126,7 @@ const SLOTS = setSlots(
  */
 @blazorAdditionalDependencies('IgcIconComponent, IgcInputComponent')
 @blazorIndirectRender
+@shadowOptions({ delegatesFocus: true })
 export default class IgcComboComponent<
   T extends object = any,
 > extends FormAssociatedRequiredMixin(
@@ -585,6 +587,13 @@ export default class IgcComboComponent<
       this._syncSelectionFromValue();
       this._formValue.setValueAndFormState(this.value);
       this._pristine = pristine;
+    }
+  }
+
+  protected override updated(props: PropertyValues<this>): void {
+    super.updated(props);
+    if (this._inputRef.value) {
+      this._inputRef.value._labelElements = this._internals.labels;
     }
   }
 

--- a/src/components/common/controllers/internals.ts
+++ b/src/components/common/controllers/internals.ts
@@ -65,6 +65,19 @@ class ElementInternalsController {
     return this._internals.willValidate;
   }
 
+  /**
+   * Returns a read-only array of the `<label>` elements associated with the host element, or `null` if there are no associated labels.
+   * The association is determined by the `for` attribute of `<label>` elements or by nesting the host element inside a `<label>`.
+   *
+   * @remarks
+   * The host element must be form associated, that is, it should have
+   * `static formAssociated = true` in order to return associated labels.
+   */
+  public get labels(): ReadonlyArray<Element> | null {
+    const labels = this._internals.labels as NodeListOf<Element> | null;
+    return labels && labels.length > 0 ? Array.from(labels) : null;
+  }
+
   constructor(
     host: ReactiveControllerHost & LitElement,
     config?: ElementInternalsConfig

--- a/src/components/common/mixins/forms/associated.ts
+++ b/src/components/common/mixins/forms/associated.ts
@@ -36,7 +36,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
 
     //#region Internal state and properties
 
-    private readonly __internals = addInternalsController(this);
+    protected readonly _internals = addInternalsController(this);
     protected readonly _formValue!: FormValue<unknown>;
 
     /**
@@ -122,7 +122,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
 
     /** Returns the HTMLFormElement associated with this element. */
     public get form(): HTMLFormElement | null {
-      return this.__internals.form;
+      return this._internals.form;
     }
 
     /**
@@ -130,12 +130,12 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
      * the element can be in, with respect to constraint validation.
      */
     public get validity(): ValidityState {
-      return this.__internals.validity;
+      return this._internals.validity;
     }
 
     /** A string containing the validation message of this element. */
     public get validationMessage(): string {
-      return this.__internals.validationMessage;
+      return this._internals.validationMessage;
     }
 
     /**
@@ -143,7 +143,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
      * that is a candidate for constraint validation.
      */
     public get willValidate(): boolean {
-      return this.__internals.willValidate;
+      return this._internals.willValidate;
     }
     //#endregion
 
@@ -203,7 +203,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     }
 
     private _setInvalidStyles(): void {
-      this.__internals.setState(INVALID_STATE, this._shouldApplyStyles);
+      this._internals.setState(INVALID_STATE, this._shouldApplyStyles);
     }
 
     /**
@@ -272,9 +272,9 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
         message = userMessage;
       }
 
-      this.__internals.setValidity(validity, message);
+      this._internals.setValidity(validity, message);
       this._isInternalValidation = true;
-      this._invalid = !this.__internals.checkValidity();
+      this._invalid = !this._internals.checkValidity();
       this._resolveInternalValidation();
     }
 
@@ -301,7 +301,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
 
     protected _setFormValue(value: FormValueType, state?: FormValueType): void {
       this._pristine = false;
-      this.__internals.setFormValue(value, state);
+      this._internals.setFormValue(value, state);
       this._validate();
       this._setInvalidStyles();
     }
@@ -336,7 +336,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
 
     /** Checks for validity of the control and shows the browser message if it invalid. */
     public reportValidity(): boolean {
-      const state = this.__internals.reportValidity();
+      const state = this._internals.reportValidity();
       this._invalid = !state;
       return state;
     }
@@ -344,7 +344,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     /** Checks for validity of the control and emits the invalid event if it invalid. */
     public checkValidity(): boolean {
       this._isInternalValidation = true;
-      const state = this.__internals.checkValidity();
+      const state = this._internals.checkValidity();
       this._invalid = !state;
       this._resolveInternalValidation();
       return state;

--- a/src/components/common/mixins/forms/types.ts
+++ b/src/components/common/mixins/forms/types.ts
@@ -12,7 +12,7 @@ declare class BaseFormAssociatedElement {
 
   //#region Properties
 
-  private readonly __internals: ElementInternalsController;
+  protected readonly _internals: ElementInternalsController;
   protected readonly _formValue: unknown;
 
   protected _pristine: boolean;

--- a/src/components/common/templates/masked-input.ts
+++ b/src/components/common/templates/masked-input.ts
@@ -23,6 +23,8 @@ export interface MaskedInputOptions {
   tabindex?: number;
   /** When provided, sets the `aria-describedby` attribute. */
   ariaDescribedBy?: string;
+  /** When provided, sets the `aria-labelledby` attribute using the provided elements. */
+  ariaLabelledByElements?: ReadonlyArray<Element> | null;
 
   // Required mask handlers
   onInput: (event: InputEvent) => void;
@@ -61,8 +63,9 @@ export function renderMaskedNativeInput(
       ?disabled=${opts.disabled}
       ?autofocus=${opts.autofocus}
       inputmode=${ifDefined(opts.inputMode)}
-      tabindex=${bindIf(opts.tabindex !== undefined, opts.tabindex)}
+      tabindex=${bindIf(opts.tabindex != null, opts.tabindex)}
       aria-describedby=${bindIf(!!opts.ariaDescribedBy, opts.ariaDescribedBy)}
+      .ariaLabelledByElements=${opts.ariaLabelledByElements}
       @input=${opts.onInput}
       @focus=${opts.onFocus}
       @blur=${opts.onBlur}

--- a/src/components/common/utils.spec.ts
+++ b/src/components/common/utils.spec.ts
@@ -488,3 +488,77 @@ export function compareStyles(
 export function checkDatesEqual(a: CalendarDay | Date, b: CalendarDay | Date) {
   expect(toCalendarDay(a).equalTo(toCalendarDay(b))).to.be.true;
 }
+
+export interface ExternalLabelAssociationConfig {
+  /** The host custom element tag name (e.g. `igc-select`). */
+  tagName: string;
+  /**
+   * Locates the AT-exposed native form control (`<input>`/`<textarea>`) that should
+   * receive the forwarded `aria-labelledby` association within the given host element.
+   */
+  getNativeInput: (host: HTMLElement) => HTMLInputElement | HTMLTextAreaElement;
+  /** Optional additional attributes to set on the rendered host element. */
+  hostAttributes?: string;
+}
+
+/**
+ * Shared test suite asserting that a form associated component is correctly linked to an
+ * external `<label>` element, both through an `IDREF` (`<label for>`) and by nesting the
+ * component inside the `<label>`.
+ *
+ * The association is verified through:
+ * - the forwarded `aria-labelledby` element reference on the inner native input, and
+ * - focus state, since accessibility tooling does not currently resolve `ElementInternals`
+ *   based labelling across shadow roots.
+ */
+export function runExternalLabelAssociationTests(
+  config: ExternalLabelAssociationConfig
+): void {
+  const { tagName, getNativeInput, hostAttributes = '' } = config;
+
+  describe('External label association', () => {
+    async function createLabelledFixture(nested: boolean) {
+      const container = await fixture<HTMLElement>(html`<div></div>`);
+
+      container.innerHTML = nested
+        ? `<label>External label <${tagName} ${hostAttributes}></${tagName}></label>`
+        : `<label for="labelled-host">External label</label><${tagName} id="labelled-host" ${hostAttributes}></${tagName}>`;
+
+      const label = container.querySelector('label')!;
+      const host = container.querySelector<HTMLElement>(tagName)!;
+
+      await elementUpdated(host);
+      await nextFrame();
+
+      return { label, host };
+    }
+
+    it('links an external label through an IDREF (`for` attribute)', async () => {
+      const { label, host } = await createLabelledFixture(false);
+      const native = getNativeInput(host);
+
+      expect(native.ariaLabelledByElements).to.have.lengthOf(1);
+      expect(native.ariaLabelledByElements?.[0]).to.equal(label);
+
+      simulateClick(label);
+      await elementUpdated(host);
+
+      expect(document.activeElement).to.equal(host);
+      expect(isFocused(native)).to.be.true;
+    });
+
+    it('links an external label by nesting the component inside it', async () => {
+      const { label, host } = await createLabelledFixture(true);
+      const native = getNativeInput(host);
+
+      expect(native.ariaLabelledByElements).to.have.lengthOf(1);
+      expect(native.ariaLabelledByElements?.[0]).to.equal(label);
+
+      simulateClick(label);
+      await elementUpdated(host);
+
+      expect(document.activeElement).to.equal(host);
+      expect(isFocused(native)).to.be.true;
+    });
+  });
+}

--- a/src/components/date-picker/date-picker.spec.ts
+++ b/src/components/date-picker/date-picker.spec.ts
@@ -18,6 +18,7 @@ import { defineComponents } from '../common/definitions/defineComponents.js';
 import { equal } from '../common/util.js';
 import {
   isFocused,
+  runExternalLabelAssociationTests,
   simulateClick,
   simulateKeyboard,
 } from '../common/utils.spec.js';
@@ -26,6 +27,16 @@ import IgcDatePickerComponent from './date-picker.js';
 
 describe('Date picker', () => {
   before(() => defineComponents(IgcDatePickerComponent));
+
+  runExternalLabelAssociationTests({
+    tagName: IgcDatePickerComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcDatePickerComponent).renderRoot
+        .querySelector<IgcDateTimeInputComponent>(
+          IgcDateTimeInputComponent.tagName
+        )!
+        .renderRoot.querySelector('input')!,
+  });
 
   const pickerShowIcon = 'today';
   const pickerClearIcon = 'input_clear';

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -4,7 +4,7 @@ import {
   type ICalendarResourceStrings,
   type IDatePickerResourceStrings,
 } from 'igniteui-i18n-core';
-import { html, nothing, type TemplateResult } from 'lit';
+import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { addThemingController } from '../../theming/theming-controller.js';
@@ -519,6 +519,13 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
       .set([altKey, arrowDown], this._handleAnchorClick)
       .set([altKey, arrowUp], this._onEscapeKey)
       .set(escapeKey, this._onEscapeKey);
+  }
+
+  protected override updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    if (this._input) {
+      this._input._labelElements = this._internals.labels;
+    }
   }
 
   //#endregion

--- a/src/components/date-range-picker/date-range-picker-single.spec.ts
+++ b/src/components/date-range-picker/date-range-picker-single.spec.ts
@@ -20,6 +20,7 @@ import {
 import { defineComponents } from '../common/definitions/defineComponents.js';
 import {
   isFocused,
+  runExternalLabelAssociationTests,
   simulateClick,
   simulateInput,
   simulateKeyboard,
@@ -36,6 +37,16 @@ import {
 
 describe('Date range picker - single input', () => {
   before(() => defineComponents(IgcDateRangePickerComponent));
+
+  runExternalLabelAssociationTests({
+    tagName: IgcDateRangePickerComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcDateRangePickerComponent).renderRoot
+        .querySelector<IgcDateRangeInputComponent>(
+          IgcDateRangeInputComponent.tagName
+        )!
+        .renderRoot.querySelector('input')!,
+  });
 
   let picker: IgcDateRangePickerComponent;
   let rangeInput: IgcDateRangeInputComponent;

--- a/src/components/date-range-picker/date-range-picker-two-inputs.spec.ts
+++ b/src/components/date-range-picker/date-range-picker-two-inputs.spec.ts
@@ -18,6 +18,7 @@ import { defineComponents } from '../common/definitions/defineComponents.js';
 import {
   checkDatesEqual,
   isFocused,
+  runExternalLabelAssociationTests,
   simulateClick,
   simulateInput,
   simulateKeyboard,
@@ -36,6 +37,17 @@ describe('Date range picker - two inputs', () => {
   before(() =>
     defineComponents(IgcDateRangePickerComponent, IgcDateRangeInputComponent)
   );
+
+  runExternalLabelAssociationTests({
+    tagName: IgcDateRangePickerComponent.tagName,
+    hostAttributes: 'use-two-inputs',
+    getNativeInput: (host) =>
+      (host as IgcDateRangePickerComponent).renderRoot
+        .querySelector<IgcDateTimeInputComponent>(
+          IgcDateTimeInputComponent.tagName
+        )!
+        .renderRoot.querySelector('input')!,
+  });
 
   let picker: IgcDateRangePickerComponent;
   let dateTimeInputs: Array<IgcDateTimeInputComponent>;

--- a/src/components/date-range-picker/date-range-picker.ts
+++ b/src/components/date-range-picker/date-range-picker.ts
@@ -5,7 +5,7 @@ import {
   type ICalendarResourceStrings,
   type IDateRangePickerResourceStrings,
 } from 'igniteui-i18n-core';
-import { html, nothing, type TemplateResult } from 'lit';
+import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import {
   property,
   query,
@@ -644,6 +644,15 @@ export default class IgcDateRangePickerComponent extends FormAssociatedRequiredM
   protected override firstUpdated() {
     this._setCalendarRangeValues();
     this._delegateInputsValidity();
+  }
+
+  protected override updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    // Forward the host's associated labels only to the start input.
+    const target = this._input ?? this._inputs?.[0];
+    if (target) {
+      target._labelElements = this._internals.labels;
+    }
   }
 
   protected override formResetCallback() {

--- a/src/components/date-time-input/date-time-input.base.ts
+++ b/src/components/date-time-input/date-time-input.base.ts
@@ -1,6 +1,6 @@
 import { getDateFormatter } from 'igniteui-i18n-core';
 import { LitElement, type PropertyValues, type TemplateResult } from 'lit';
-import { eventOptions, property, query } from 'lit/decorators.js';
+import { eventOptions, property, query, state } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import type { ThemingController } from '../../theming/theming-controller.js';
 import { convertToDate } from '../calendar/helpers.js';
@@ -62,6 +62,26 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
 
   @query('input')
   protected override readonly _input?: HTMLInputElement;
+
+  /**
+   * Externally supplied label elements forwarded by a composite host (e.g. `igc-date-picker`)
+   * so that the host's associated labels reach the inner native input. When set, these take
+   * precedence over the component's own `ElementInternals` labels.
+   *
+   * @hidden @internal
+   */
+  @state()
+  public _labelElements: ReadonlyArray<Element> | null = null;
+
+  /**
+   * Resolves the label elements applied to the native input as `aria-labelledby` targets,
+   * preferring forwarded labels over the component's own `ElementInternals` labels.
+   *
+   * @hidden @internal
+   */
+  protected get _resolvedLabelElements(): ReadonlyArray<Element> | null {
+    return this._labelElements ?? this._internals.labels;
+  }
 
   protected override get __validators() {
     return dateTimeInputValidators;
@@ -439,6 +459,7 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
       disabled: this.disabled,
       tabindex: hasNegativeTabIndex ? -1 : undefined,
       ariaDescribedBy: hasHelperText ? 'helper-text' : undefined,
+      ariaLabelledByElements: this._resolvedLabelElements,
       onInput: this._handleInput,
       onFocus: this._handleFocus,
       onBlur: this._handleBlur,

--- a/src/components/date-time-input/date-time-input.spec.ts
+++ b/src/components/date-time-input/date-time-input.spec.ts
@@ -15,6 +15,7 @@ import { defineComponents } from '../common/definitions/defineComponents.js';
 import {
   createFormAssociatedTestBed,
   isFocused,
+  runExternalLabelAssociationTests,
   simulateInput,
   simulateKeyboard,
   simulateWheel,
@@ -1209,6 +1210,12 @@ describe('Date Time Input component', () => {
 
       runValidationContainerTests(IgcDateTimeInputComponent, testParameters);
     });
+  });
+
+  runExternalLabelAssociationTests({
+    tagName: IgcDateTimeInputComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcDateTimeInputComponent).renderRoot.querySelector('input')!,
   });
 });
 

--- a/src/components/input/input-base.ts
+++ b/src/components/input/input-base.ts
@@ -1,5 +1,5 @@
 import { LitElement, nothing, type TemplateResult } from 'lit';
-import { property, query } from 'lit/decorators.js';
+import { property, query, state } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import type { ThemingController } from '../../theming/theming-controller.js';
 import type { SlotController } from '../common/controllers/slot.js';
@@ -41,6 +41,26 @@ export abstract class IgcInputBaseComponent extends FormAssociatedRequiredMixin(
 
   @query('input')
   protected readonly _input?: HTMLInputElement;
+
+  /**
+   * Externally supplied label elements forwarded by a composite host (e.g. `igc-select`)
+   * so that the host's associated labels reach the inner native input. When set, these take
+   * precedence over the component's own `ElementInternals` labels.
+   *
+   * @hidden @internal
+   */
+  @state()
+  public _labelElements: ReadonlyArray<Element> | null = null;
+
+  /**
+   * Resolves the label elements applied to the native input as `aria-labelledby` targets,
+   * preferring forwarded labels over the component's own `ElementInternals` labels.
+   *
+   * @hidden @internal
+   */
+  protected get _resolvedLabelElements(): ReadonlyArray<Element> | null {
+    return this._labelElements ?? this._internals.labels;
+  }
 
   /* blazorSuppress */
   /** The value attribute of the control. */

--- a/src/components/input/input.spec.ts
+++ b/src/components/input/input.spec.ts
@@ -12,6 +12,7 @@ import { defineComponents } from '../common/definitions/defineComponents.js';
 import {
   createFormAssociatedTestBed,
   isFocused,
+  runExternalLabelAssociationTests,
   simulateInput,
 } from '../common/utils.spec.js';
 import {
@@ -749,5 +750,11 @@ describe('Input component', () => {
 
       runValidationContainerTests(IgcInputComponent, testParameters);
     });
+  });
+
+  runExternalLabelAssociationTests({
+    tagName: IgcInputComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcInputComponent).renderRoot.querySelector('input')!,
   });
 });

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -311,6 +311,7 @@ export default class IgcInputComponent extends IgcInputBaseComponent {
         minlength=${ifDefined(this.minLength)}
         maxlength=${bindIf(!this.validateOnly, this.maxLength)}
         step=${ifDefined(this.step)}
+        .ariaLabelledByElements=${this._resolvedLabelElements}
         aria-describedby=${bindIf(hasHelperText, 'helper-text')}
         @keydown=${this._handleEnterKeydown}
         @change=${this._handleChange}

--- a/src/components/mask-input/mask-input.spec.ts
+++ b/src/components/mask-input/mask-input.spec.ts
@@ -4,6 +4,7 @@ import { spy } from 'sinon';
 import { defineComponents } from '../common/definitions/defineComponents.js';
 import {
   createFormAssociatedTestBed,
+  runExternalLabelAssociationTests,
   simulateInput,
   simulateKeyboard,
 } from '../common/utils.spec.js';
@@ -880,6 +881,12 @@ describe('Masked input', () => {
 
       runValidationContainerTests(IgcMaskInputComponent, testParameters);
     });
+  });
+
+  runExternalLabelAssociationTests({
+    tagName: IgcMaskInputComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcMaskInputComponent).renderRoot.querySelector('input')!,
   });
 });
 

--- a/src/components/mask-input/mask-input.ts
+++ b/src/components/mask-input/mask-input.ts
@@ -282,6 +282,7 @@ export default class IgcMaskInputComponent extends MaskBehaviorMixin(
       inputMode: this.inputMode,
       tabindex: hasNegativeTabIndex ? -1 : undefined,
       ariaDescribedBy: hasHelperText ? 'helper-text' : undefined,
+      ariaLabelledByElements: this._resolvedLabelElements,
       onInput: this._handleInput,
       onFocus: this._handleFocus,
       onBlur: this._handleBlur,

--- a/src/components/select/select.spec.ts
+++ b/src/components/select/select.spec.ts
@@ -15,6 +15,7 @@ import { defineComponents } from '../common/definitions/defineComponents.js';
 import {
   createFormAssociatedTestBed,
   isFocused,
+  runExternalLabelAssociationTests,
   simulateClick,
   simulateKeyboard,
   simulateScroll,
@@ -1379,5 +1380,13 @@ describe('Select', () => {
 
       runValidationContainerTests(IgcSelectComponent, testParameters);
     });
+  });
+
+  runExternalLabelAssociationTests({
+    tagName: IgcSelectComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcSelectComponent).renderRoot
+        .querySelector<IgcInputComponent>(IgcInputComponent.tagName)!
+        .renderRoot.querySelector('input')!,
   });
 });

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -1,4 +1,4 @@
-import { html, type TemplateResult } from 'lit';
+import { html, type PropertyValues, type TemplateResult } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { addThemingController } from '../../theming/theming-controller.js';
@@ -20,6 +20,7 @@ import { addRootClickController } from '../common/controllers/root-click.js';
 import { addRootScrollHandler } from '../common/controllers/root-scroll.js';
 import { addSlotController, setSlots } from '../common/controllers/slot.js';
 import { blazorAdditionalDependencies } from '../common/decorators/blazorAdditionalDependencies.js';
+import { shadowOptions } from '../common/decorators/shadow-options.js';
 import { watch } from '../common/decorators/watch.js';
 import { registerComponent } from '../common/definitions/register.js';
 import {
@@ -116,6 +117,7 @@ const Slots = setSlots(
 @blazorAdditionalDependencies(
   'IgcIconComponent, IgcInputComponent, IgcSelectGroupComponent, IgcSelectHeaderComponent, IgcSelectItemComponent'
 )
+@shadowOptions({ delegatesFocus: true })
 export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
   EventEmitterMixin<
     IgcSelectComponentEventMap,
@@ -332,6 +334,11 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
     this._validate();
   }
 
+  protected override updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    this._forwardLabelElements();
+  }
+
   //#endregion
 
   //#region Keyboard event handlers
@@ -544,6 +551,16 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
 
   private _getItem(value: string): IgcSelectItemComponent | undefined {
     return this.items.find((item) => item.value === value);
+  }
+
+  /**
+   * Forwards the host's associated label elements to the inner input so that an external
+   * `<label for>` (or a wrapping `<label>`) labels the AT-exposed native input.
+   */
+  private _forwardLabelElements(): void {
+    if (this._input) {
+      this._input._labelElements = this._internals.labels;
+    }
   }
 
   //#endregion

--- a/src/components/textarea/textarea.spec.ts
+++ b/src/components/textarea/textarea.spec.ts
@@ -12,6 +12,7 @@ import { defineComponents } from '../common/definitions/defineComponents.js';
 import {
   createFormAssociatedTestBed,
   isFocused,
+  runExternalLabelAssociationTests,
   simulateInput,
 } from '../common/utils.spec.js';
 import {
@@ -446,5 +447,11 @@ describe('Textarea component', () => {
 
       runValidationContainerTests(IgcTextareaComponent, testParameters);
     });
+  });
+
+  runExternalLabelAssociationTests({
+    tagName: IgcTextareaComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcTextareaComponent).renderRoot.querySelector('textarea')!,
   });
 });

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -484,6 +484,7 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
         ?required=${this.required}
         ?readonly=${this.readOnly}
         aria-describedby=${describedBy}
+        .ariaLabelledByElements=${this._internals.labels}
       ></textarea>
     `;
   }


### PR DESCRIPTION
## Description

Form-associated controls are the labellable element, so external <label> associations target the host rather than the inner native control (`<input>/<textarea>`) that assistive technologies expose. Resolve the host's ElementInternals.labels onto the inner control so external labels (via for/id IDREF or by nesting) reach the AT-exposed element and focus delegation works on label activation.

- input-base / date-time-input.base: add internal _labelElements state and a _resolvedLabelElements getter feeding the native input's ariaLabelledByElements (igc-input, igc-mask-input, igc-date-time-input)
- textarea: forward _internals.labels to the inner native <textarea>
- select, combo, date-picker, date-range-picker: forward _internals.labels to the inner input in updated(); date-range two-input mode targets the start input
- combo: add delegatesFocus so label activation focuses the inner input
- tests: add shared runExternalLabelAssociationTests covering IDREF and nested label association plus focus delegation


## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
