### PR TITLE
refactor(animations): added view transition module

### DIFF
--- a/src/animations/player.ts
+++ b/src/animations/player.ts
@@ -9,7 +9,10 @@ const LISTENER_OPTIONS = { once: true } as const;
  * Checks the user's preference for reduced motion.
  */
 export function getPrefersReducedMotion(): boolean {
-  return globalThis?.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  return (
+    globalThis?.matchMedia?.('(prefers-reduced-motion: reduce)').matches ??
+    false
+  );
 }
 
 /**

--- a/src/animations/player.ts
+++ b/src/animations/player.ts
@@ -3,24 +3,17 @@ import type { Ref } from 'lit/directives/ref.js';
 import { isElement } from '../components/common/util.js';
 import type { AnimationReferenceMetadata } from './types.js';
 
-/**
- * Defines the result of an optional View Transition start.
- */
-type ViewTransitionResult = {
-  transition?: ViewTransition;
-};
-
 const LISTENER_OPTIONS = { once: true } as const;
 
 /**
  * Checks the user's preference for reduced motion.
  */
-function getPrefersReducedMotion(): boolean {
+export function getPrefersReducedMotion(): boolean {
   return globalThis?.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 /**
- * A ReactiveController for managing Web Animation API (WAAPI) playback
+ * A ReactiveController for managing Web Animation API (WA-API) playback
  * on a host element or a specified target element.
  *
  * It provides methods to play, stop, and coordinate animations, including
@@ -76,7 +69,7 @@ class AnimationController implements ReactiveController {
   }
 
   /**
-   * Plays a sequence of keyframes using WAAPI.
+   * Plays a sequence of keyframes using WA-API.
    * Automatically sets duration to 0 if 'prefers-reduced-motion' is set.
    */
   public async play(
@@ -120,22 +113,6 @@ export function addAnimationController(
   target?: Ref<HTMLElement> | HTMLElement
 ): AnimationController {
   return new AnimationController(host, target);
-}
-
-/**
- * Initiates a View Transition if supported by the browser and not suppressed by
- * the 'prefers-reduced-motion' setting.
- */
-export function startViewTransition(
-  callback?: ViewTransitionUpdateCallback
-): ViewTransitionResult {
-  /* c8 ignore next 4 */
-  if (getPrefersReducedMotion() || !document.startViewTransition) {
-    callback?.();
-    return {};
-  }
-
-  return { transition: document.startViewTransition(callback) };
 }
 
 export type { AnimationController };

--- a/src/animations/view-transition.spec.ts
+++ b/src/animations/view-transition.spec.ts
@@ -1,0 +1,213 @@
+import {
+  defineCE,
+  expect,
+  fixture,
+  html,
+  unsafeStatic,
+} from '@open-wc/testing';
+import { LitElement, render } from 'lit';
+import sinon from 'sinon';
+import {
+  clearTransitionName,
+  getActiveScopedViewTransition,
+  getActiveViewTransition,
+  scopedViewTransition,
+  setTransitionName,
+  startScopedViewTransition,
+  startViewTransition,
+} from './view-transition.js';
+
+describe('View Transitions helpers and directive', () => {
+  let matchMediaStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    matchMediaStub = sinon.stub(window, 'matchMedia');
+    matchMediaStub.withArgs('(prefers-reduced-motion: reduce)').returns({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: sinon.stub(),
+      removeEventListener: sinon.stub(),
+      dispatchEvent: sinon.stub(),
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('startViewTransition', () => {
+    it('should start a document view transition', async () => {
+      const callback = sinon.spy();
+      const transition = startViewTransition(callback);
+
+      expect(transition).to.be.instanceOf(ViewTransition);
+      await transition.finished;
+    });
+
+    it('should skip the transition if prefers-reduced-motion is enabled', () => {
+      matchMediaStub.withArgs('(prefers-reduced-motion: reduce)').returns({
+        matches: true,
+        media: '(prefers-reduced-motion: reduce)',
+      });
+      const callback = sinon.spy();
+      const transition = startViewTransition(callback);
+
+      expect(transition).to.be.instanceOf(ViewTransition);
+      transition.ready.catch(() => {});
+    });
+  });
+
+  describe('startScopedViewTransition', () => {
+    let mockElement: HTMLElement;
+
+    beforeEach(() => {
+      mockElement = document.createElement('div');
+    });
+
+    it('should return null if the element does not support scoped view transitions', () => {
+      const result = startScopedViewTransition(
+        document.createDocumentFragment() as unknown as HTMLElement,
+        sinon.spy()
+      );
+      expect(result).to.be.null;
+      expect(
+        getActiveScopedViewTransition(document.createDocumentFragment() as any)
+      ).to.be.null;
+    });
+
+    it('should start a scoped view transition on the target element', async () => {
+      const fakeTransition = {
+        finished: Promise.resolve(),
+        ready: Promise.resolve(),
+        skipTransition: sinon.spy(),
+      } as unknown as ViewTransition;
+
+      (mockElement as any).startViewTransition = sinon
+        .stub()
+        .returns(fakeTransition);
+
+      const callback = sinon.spy();
+      const transition = startScopedViewTransition(mockElement, callback);
+
+      expect(
+        (mockElement as any).startViewTransition
+      ).to.have.been.calledOnceWith(callback);
+      expect(transition).to.equal(fakeTransition);
+    });
+
+    it('should skip the transition if prefers-reduced-motion is enabled', () => {
+      matchMediaStub.withArgs('(prefers-reduced-motion: reduce)').returns({
+        matches: true,
+        media: '(prefers-reduced-motion: reduce)',
+      });
+
+      const fakeTransition = {
+        finished: Promise.resolve(),
+        ready: Promise.resolve(),
+        skipTransition: sinon.spy(),
+      } as unknown as ViewTransition;
+
+      (mockElement as any).startViewTransition = sinon
+        .stub()
+        .returns(fakeTransition);
+
+      const callback = sinon.spy();
+      const transition = startScopedViewTransition(mockElement, callback);
+
+      expect(
+        (mockElement as any).startViewTransition
+      ).to.have.been.calledOnceWith(callback);
+      expect(transition).to.equal(fakeTransition);
+      expect(fakeTransition.skipTransition).to.have.been.calledOnce;
+    });
+  });
+
+  describe('setTransitionName & clearTransitionName', () => {
+    it('should set and clear view transition names correctly', () => {
+      const el1 = document.createElement('div');
+      const el2 = document.createElement('div');
+
+      setTransitionName(el1, 'main-header');
+      expect(el1.style.viewTransitionName).to.equal('main-header');
+
+      clearTransitionName(el1, el2);
+      expect(el1.style.viewTransitionName).to.equal('');
+    });
+  });
+
+  describe('getActiveViewTransition & getActiveScopedViewTransition', () => {
+    it('should fetch the active document view transition', () => {
+      expect(getActiveViewTransition()).to.be.null;
+
+      startViewTransition(sinon.spy());
+      expect(getActiveViewTransition()).to.be.instanceOf(ViewTransition);
+    });
+
+    it('should fetch scoped active view transitions if supported', () => {
+      const mockElement = document.createElement('div') as any;
+      expect(getActiveScopedViewTransition(mockElement)).to.be.null;
+
+      try {
+        startScopedViewTransition(mockElement, sinon.spy());
+        expect(getActiveScopedViewTransition(mockElement)).to.be.instanceOf(
+          ViewTransition
+        );
+      } catch {}
+    });
+  });
+
+  describe('scopedViewTransition directive', () => {
+    it('should render the initial template directly without any transitions', async () => {
+      const container = await fixture(html`
+        <div>${scopedViewTransition(html`<span id="test">Initial</span>`)}</div>
+      `);
+
+      expect(getActiveScopedViewTransition(container as any)).to.be.null;
+      expect(container.querySelector('#test')?.textContent).to.equal('Initial');
+    });
+
+    it('should start a scoped view transition when the template changes', async () => {
+      const fakeTransition = {
+        skipTransition: sinon.spy(),
+        ready: Promise.resolve(),
+      };
+      const startSpy = sinon.stub().returns(fakeTransition);
+
+      const tagName = unsafeStatic(
+        defineCE(
+          class extends LitElement {
+            public startViewTransition = startSpy;
+            constructor() {
+              super();
+              // Bypasses the read-only prototype getter safely
+              Object.defineProperty(this, 'activeViewTransition', {
+                value: fakeTransition,
+                writable: true,
+                enumerable: true,
+                configurable: true,
+              });
+            }
+          }
+        )
+      );
+
+      function renderTemplate(text: string) {
+        return html`<${tagName}>${scopedViewTransition(html`<span id="content">${text}</span>`)}</${tagName}>`;
+      }
+
+      const container = await fixture<LitElement>(renderTemplate('First'));
+      expect(container.querySelector('#content')?.textContent).to.equal(
+        'First'
+      );
+      expect(startSpy.called).to.be.false;
+
+      render(renderTemplate('Second'), container.parentNode as HTMLElement);
+
+      expect(startSpy).to.have.been.calledOnce;
+      expect(getActiveScopedViewTransition(container as any)).to.equal(
+        fakeTransition
+      );
+    });
+  });
+});

--- a/src/animations/view-transition.spec.ts
+++ b/src/animations/view-transition.spec.ts
@@ -146,14 +146,23 @@ describe('View Transitions helpers and directive', () => {
 
     it('should fetch scoped active view transitions if supported', () => {
       const mockElement = document.createElement('div') as any;
-      expect(getActiveScopedViewTransition(mockElement)).to.be.null;
+      const fakeTransition = {
+        finished: Promise.resolve(),
+        ready: Promise.resolve(),
+        updateCallbackDone: Promise.resolve(),
+        skipTransition: sinon.spy(),
+      } as unknown as ViewTransition;
 
-      try {
-        startScopedViewTransition(mockElement, sinon.spy());
-        expect(getActiveScopedViewTransition(mockElement)).to.be.instanceOf(
-          ViewTransition
-        );
-      } catch {}
+      mockElement.startViewTransition = sinon.stub().returns(fakeTransition);
+      Object.defineProperty(mockElement, 'activeViewTransition', {
+        value: fakeTransition,
+        writable: true,
+        configurable: true,
+      });
+      startScopedViewTransition(mockElement, sinon.spy());
+      expect(getActiveScopedViewTransition(mockElement)).to.equal(
+        fakeTransition
+      );
     });
   });
 

--- a/src/animations/view-transition.ts
+++ b/src/animations/view-transition.ts
@@ -29,7 +29,22 @@ function hasScopedViewTransition(
 export function startViewTransition(
   callback: ViewTransitionUpdateCallback
 ): ViewTransition {
-  const transition = document.startViewTransition(callback);
+  const init = globalThis.document?.startViewTransition;
+
+  /* c8 ignore next 11 */
+  if (!init) {
+    callback();
+    const resolved = Promise.resolve();
+
+    return {
+      finished: resolved,
+      ready: resolved,
+      updateCallbackDone: resolved,
+      skipTransition: () => {},
+    } as ViewTransition;
+  }
+
+  const transition = init.call(globalThis.document, callback);
 
   if (getPrefersReducedMotion()) {
     transition.skipTransition();

--- a/src/animations/view-transition.ts
+++ b/src/animations/view-transition.ts
@@ -1,0 +1,143 @@
+import { type ChildPart, noChange, type TemplateResult } from 'lit';
+import {
+  AsyncDirective,
+  type DirectiveParameters,
+  directive,
+} from 'lit/async-directive.js';
+import { isFunction } from '../components/common/util.js';
+import { getPrefersReducedMotion } from './player.js';
+
+type ScopedViewTransitionElement = HTMLElement & {
+  startViewTransition: (
+    callback: () => Promise<unknown> | unknown
+  ) => ViewTransition;
+  activeViewTransition?: ViewTransition | null;
+};
+
+/**
+ * Returns true if the specified node supports scoped view transitions, false otherwise.
+ */
+function hasScopedViewTransition(
+  node: Node
+): node is ScopedViewTransitionElement {
+  return 'startViewTransition' in node && isFunction(node.startViewTransition);
+}
+
+/**
+ * Starts a document view transition and skips it if the user has requested reduced motion.
+ */
+export function startViewTransition(
+  callback: ViewTransitionUpdateCallback
+): ViewTransition {
+  const transition = document.startViewTransition(callback);
+
+  if (getPrefersReducedMotion()) {
+    transition.skipTransition();
+  }
+
+  return transition;
+}
+
+/**
+ * Starts a scoped view transition on the specified target element and skips it if the user has requested reduced motion.
+ */
+export function startScopedViewTransition(
+  target: HTMLElement,
+  callback: ViewTransitionUpdateCallback
+): ViewTransition | null {
+  if (!hasScopedViewTransition(target)) {
+    return null;
+  }
+
+  const transition = target.startViewTransition(callback);
+
+  if (getPrefersReducedMotion()) {
+    transition.skipTransition();
+  }
+
+  return transition;
+}
+
+/**
+ * Sets the view transition name for the specified target element.
+ */
+export function setTransitionName(target: HTMLElement, name: string): void {
+  target.style.viewTransitionName = name;
+}
+
+/**
+ * Clears the view transition name for the specified target elements.
+ */
+export function clearTransitionName(...targets: HTMLElement[]): void {
+  for (const target of targets) {
+    target.style.viewTransitionName = '';
+  }
+}
+
+/**
+ * Returns the active view transition if one is currently in progress, or null otherwise.
+ */
+export function getActiveViewTransition(): ViewTransition | null {
+  return document.activeViewTransition ?? null;
+}
+
+/**
+ * Returns the active scoped view transition for the specified target element if one is currently in progress, or null otherwise.
+ */
+export function getActiveScopedViewTransition(
+  target: ScopedViewTransitionElement
+): ViewTransition | null {
+  if (!hasScopedViewTransition(target)) {
+    return null;
+  }
+
+  return target.activeViewTransition ?? null;
+}
+
+class ScopedViewTransitionDirective extends AsyncDirective {
+  private _isFirstRender = true;
+
+  public override render(template: TemplateResult): TemplateResult {
+    return template;
+  }
+
+  public override update(
+    part: ChildPart,
+    [template]: DirectiveParameters<this>
+  ) {
+    if (this._isFirstRender) {
+      this._isFirstRender = false;
+      return this.render(template);
+    }
+
+    const parent = part.parentNode;
+
+    if (!hasScopedViewTransition(parent)) {
+      return this.render(template);
+    }
+
+    const transition = parent.startViewTransition(() => {
+      this.setValue(template);
+      return new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+
+    if (getPrefersReducedMotion()) {
+      transition.skipTransition();
+    }
+
+    return noChange;
+  }
+}
+
+/**
+ * A directive that enables scoped view transitions for a template.
+ *
+ * When applied, it will start a view transition whenever the template is updated,
+ * provided that the parent node supports view transitions.
+ * If the user has requested reduced motion, the transition will be skipped.
+ *
+ * @remarks
+ * This directive is intended to be used with Lit templates inside a component that supports view transitions.
+ * It will not work if the parent node does not support view transitions (e.g., if the parent is not a document or element that implements the ViewTransition interface).
+ */
+export const scopedViewTransition = directive(ScopedViewTransitionDirective);

--- a/src/animations/view-transition.ts
+++ b/src/animations/view-transition.ts
@@ -78,14 +78,14 @@ export function clearTransitionName(...targets: HTMLElement[]): void {
  * Returns the active view transition if one is currently in progress, or null otherwise.
  */
 export function getActiveViewTransition(): ViewTransition | null {
-  return document.activeViewTransition ?? null;
+  return globalThis.document?.activeViewTransition ?? null;
 }
 
 /**
  * Returns the active scoped view transition for the specified target element if one is currently in progress, or null otherwise.
  */
 export function getActiveScopedViewTransition(
-  target: ScopedViewTransitionElement
+  target: Node
 ): ViewTransition | null {
   if (!hasScopedViewTransition(target)) {
     return null;

--- a/src/components/tile-manager/tile.ts
+++ b/src/components/tile-manager/tile.ts
@@ -366,7 +366,9 @@ export default class IgcTileComponent extends EventEmitterMixin<
   public override connectedCallback(): void {
     super.connectedCallback();
     this.id = this.id || `tile-${nextId++}`;
-    setTransitionName(this, `tile-transition-${this.id}`);
+    if (!this.style.viewTransitionName) {
+      setTransitionName(this, `tile-transition-${this.id}`);
+    }
   }
 
   private _setDragState(state = true) {

--- a/src/components/tile-manager/tile.ts
+++ b/src/components/tile-manager/tile.ts
@@ -1,7 +1,10 @@
 import { html, LitElement, nothing } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { startViewTransition } from '../../animations/player.js';
+import {
+  setTransitionName,
+  startViewTransition,
+} from '../../animations/view-transition.js';
 import { addThemingController } from '../../theming/theming-controller.js';
 import IgcIconButtonComponent from '../button/icon-button.js';
 import {
@@ -363,9 +366,7 @@ export default class IgcTileComponent extends EventEmitterMixin<
   public override connectedCallback(): void {
     super.connectedCallback();
     this.id = this.id || `tile-${nextId++}`;
-
-    this.style.viewTransitionName =
-      this.style.viewTransitionName || `tile-transition-${this.id}`;
+    setTransitionName(this, `tile-transition-${this.id}`);
   }
 
   private _setDragState(state = true) {
@@ -529,7 +530,7 @@ export default class IgcTileComponent extends EventEmitterMixin<
       await startViewTransition(() => {
         this.colSpan = colSpan;
         this.rowSpan = rowSpan;
-      }).transition?.updateCallbackDone;
+      }).updateCallbackDone;
 
       this._setResizeState(false);
       this.emitEvent('igcTileResizeEnd', { detail: this });
@@ -554,7 +555,7 @@ export default class IgcTileComponent extends EventEmitterMixin<
 
     await startViewTransition(() => {
       this.maximized = !this.maximized;
-    }).transition?.finished;
+    }).finished;
 
     this.style.zIndex = '';
   }


### PR DESCRIPTION
## Description

Added a new view transitions module with preliminary support for scoped transitions as
well as a Lit directive for scoped view transitions.

Since document view transitions are now supported in our target browsers, cleaned up and removed
the old workarounds.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (code improvements without functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
