### PR TITLE
chore: replace private jsdoc tags

### DIFF
--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -486,7 +486,7 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
 
   //#region Internal API
 
-  /** @private @hidden @internal */
+  /** @hidden @internal */
   public async [focusActiveDate](options?: FocusOptions): Promise<void> {
     await this.updateComplete;
 

--- a/src/components/common/mixins/event-emitter.ts
+++ b/src/components/common/mixins/event-emitter.ts
@@ -41,7 +41,7 @@ export function EventEmitterMixin<E, T extends Constructor<LitElement>>(
 ) {
   class EventEmitterElement extends superClass {
     /**
-     * @private
+     * @hidden
      */
     public override addEventListener<
       K extends keyof M,
@@ -60,7 +60,7 @@ export function EventEmitterMixin<E, T extends Constructor<LitElement>>(
     }
 
     /**
-     * @private
+     * @hidden
      */
     public override removeEventListener<
       K extends keyof M,
@@ -79,7 +79,7 @@ export function EventEmitterMixin<E, T extends Constructor<LitElement>>(
     }
 
     /**
-     * @private
+     * @hidden @internal
      */
     public emitEvent<K extends keyof E, D extends UnpackCustomEvent<E[K]>>(
       type: K,

--- a/src/components/tree/tree-item.ts
+++ b/src/components/tree/tree-item.ts
@@ -75,20 +75,20 @@ export default class IgcTreeItemComponent extends LitElement {
   /** The parent item of the current tree item (if any) */
   public parent: IgcTreeItemComponent | null = null;
 
-  /** @private @hidden @internal */
+  /** @hidden @internal */
   public init = false;
 
   @queryAssignedElements({ slot: 'label', flatten: true })
   private contentList!: Array<HTMLElement>;
 
-  /** @private @hidden @internal */
+  /** @hidden @internal */
   @query('#wrapper')
   public wrapper!: HTMLElement;
 
   @state()
   private isFocused = false;
 
-  /** @private @hidden @internal */
+  /** @hidden @internal */
   @state()
   public hasChildren = false;
 
@@ -96,7 +96,7 @@ export default class IgcTreeItemComponent extends LitElement {
   @state()
   public level = 0;
 
-  /** @private @hidden @internal */
+  /** @hidden @internal */
   @state()
   public indeterminate = false;
 
@@ -432,7 +432,7 @@ export default class IgcTreeItemComponent extends LitElement {
   }
 
   /**
-   * @private
+   * @hidden @internal
    * Expands the tree item.
    */
   public async expandWithEvent() {
@@ -466,7 +466,7 @@ export default class IgcTreeItemComponent extends LitElement {
   }
 
   /**
-   * @private
+   * @hidden @internal
    * Collapses the tree item.
    */
   public async collapseWithEvent() {

--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -55,10 +55,10 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     }
   );
 
-  /** @private @hidden @internal */
+  /** @hidden @internal */
   public selectionService!: IgcTreeSelectionService;
 
-  /** @private @hidden @internal */
+  /** @hidden @internal */
   public navService!: IgcTreeNavigationService;
 
   /**
@@ -181,7 +181,7 @@ export default class IgcTreeComponent extends EventEmitterMixin<
   }
 
   /* blazorSuppress */
-  /** @private */
+  /** @hidden @internal */
   public expandToItem(item: IgcTreeItemComponent): void {
     if (item?.parent) {
       item.path.forEach((i) => {


### PR DESCRIPTION
The `@private` tag is not part of [TSDoc](https://tsdoc.org) and [TypeDoc doesn't recommend its usage](https://typedoc.org/documents/Tags._private.html), plus I find it redundant in TypeScript environment anyway.

Assuming this doesn't affect much else, but check CEM perhaps.

Tempted to slap `@internal` on `EventEmitterInterface.emitEvent` as well, since that's mostly for us to dispatch events internally and has no reason for being user-facing.
Also strongly suggest turning [`stripInternal`](https://www.typescriptlang.org/tsconfig/#stripInternal) if not on already :)