### PR TITLE
fix(tabs): scroll buttons behavior in iOS Safari

### DIFF
--- a/src/components/tabs/tab-dom.ts
+++ b/src/components/tabs/tab-dom.ts
@@ -108,7 +108,9 @@ class TabsHelpers {
   private _getEndOffset(container: HTMLElement): number {
     const factor = isLTR(this._host) ? 1 : -1;
     const delta =
-      container.scrollWidth - container.clientWidth - container.scrollLeft;
+      container.scrollWidth -
+      container.clientWidth -
+      Math.abs(container.scrollLeft);
     return (delta < SCROLL_AMOUNT ? delta : SCROLL_AMOUNT) * factor;
   }
 

--- a/src/components/tabs/tab-dom.ts
+++ b/src/components/tabs/tab-dom.ts
@@ -3,8 +3,9 @@ import { getScaleFactor, isLTR, setStyles } from '../common/util.js';
 import type IgcTabComponent from './tab.js';
 import type IgcTabsComponent from './tabs.js';
 
+const SCROLL_AMOUNT = 180;
+
 class TabsHelpers {
-  private static readonly SCROLL_AMOUNT = 180;
   private readonly _host: IgcTabsComponent;
   private readonly _container: Ref<HTMLElement>;
   private readonly _indicator: Ref<HTMLElement>;
@@ -98,6 +99,19 @@ class TabsHelpers {
     }
   }
 
+  private _getStartOffset(container: HTMLElement): number {
+    const factor = isLTR(this._host) ? -1 : 1;
+    const delta = Math.abs(container.scrollLeft);
+    return (delta < SCROLL_AMOUNT ? delta : SCROLL_AMOUNT) * factor;
+  }
+
+  private _getEndOffset(container: HTMLElement): number {
+    const factor = isLTR(this._host) ? 1 : -1;
+    const delta =
+      container.scrollWidth - container.clientWidth - container.scrollLeft;
+    return (delta < SCROLL_AMOUNT ? delta : SCROLL_AMOUNT) * factor;
+  }
+
   /**
    * Scrolls the tabs header strip in the given direction with `scroll-snap-align` set.
    */
@@ -106,14 +120,13 @@ class TabsHelpers {
       return;
     }
 
-    const factor = isLTR(this._host) ? 1 : -1;
     const amount =
       direction === 'start'
-        ? -TabsHelpers.SCROLL_AMOUNT
-        : TabsHelpers.SCROLL_AMOUNT;
+        ? this._getStartOffset(this.container)
+        : this._getEndOffset(this.container);
 
     this.setScrollSnap(direction);
-    this.container.scrollBy({ left: factor * amount, behavior: 'smooth' });
+    this.container.scrollBy({ left: amount, behavior: 'smooth' });
   }
 
   /**
@@ -157,7 +170,7 @@ class TabsHelpers {
       const scaledWidth =
         header.getBoundingClientRect().width * getScaleFactor(header).x;
 
-      const offset = this._isLeftToRight
+      const offset = isLTR(this._host)
         ? header.offsetLeft - containerLeft
         : header.offsetLeft + scaledWidth - containerWidth;
 


### PR DESCRIPTION
## Description

Clamp the scroll amount to the scrollable width of the tabs container, so that the tabs container does not "overscroll" in iOS Safari.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Closes #1852

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
