### PR TITLE
refactor(tree): rewrite internals for performance, fix scroll/animaton regressions

### DIFF
--- a/src/components/tree/themes/container.base.scss
+++ b/src/components/tree/themes/container.base.scss
@@ -10,4 +10,5 @@ $theme: $bootstrap;
     display: block;
     overflow: auto;
     font-family: var(--ig-font-family);
+    contain: layout style;
 }

--- a/src/components/tree/themes/item.base.scss
+++ b/src/components/tree/themes/item.base.scss
@@ -6,6 +6,7 @@
     display: flex;
     flex-direction: column;
     font-family: inherit;
+    contain: layout;
 
     igc-circular-progress {
         --diameter: #{sizable(rem(18px), rem(20px), rem(24px))};
@@ -18,6 +19,7 @@
 
 [role~='group'] {
     overflow: hidden;
+    contain: layout;
 }
 
 :host(:not([expanded])) [role~='group'] {

--- a/src/components/tree/tree-item.ts
+++ b/src/components/tree/tree-item.ts
@@ -592,6 +592,7 @@ export default class IgcTreeItemComponent extends LitElement {
             ? html`
                 <div part="select" aria-hidden="true">
                   <igc-checkbox
+                    tabindex="-1"
                     @click=${this._selectorClick}
                     .checked=${this.selected}
                     .indeterminate=${this.indeterminate}

--- a/src/components/tree/tree-item.ts
+++ b/src/components/tree/tree-item.ts
@@ -1,4 +1,3 @@
-import { consume } from '@lit/context';
 import { html, LitElement, nothing, type PropertyValues } from 'lit';
 import {
   property,
@@ -25,12 +24,12 @@ import IgcCircularProgressComponent from '../progress/circular-progress.js';
 import { styles } from './themes/item.base.css.js';
 import { all } from './themes/item.js';
 import { styles as shared } from './themes/shared/item.common.css.js';
-import { treeContext } from './tree.context.js';
 import type IgcTreeComponent from './tree.js';
 import type { IgcTreeNavigationService } from './tree.navigation.js';
 import type { IgcTreeSelectionService } from './tree.selection.js';
 
 const TREE_ITEM_TAG = 'igc-tree-item';
+const TREE_TAG = 'igc-tree';
 
 /**
  * The tree-item component represents a child item of the tree component or another tree item.
@@ -73,12 +72,15 @@ export default class IgcTreeItemComponent extends LitElement {
 
   private _animationPlayer = addAnimationController(this, this._groupRef);
 
+  private _tree?: IgcTreeComponent;
+
   /* blazorSuppress */
   /**
    * A reference to the tree the item is a part of.
    */
-  @consume({ context: treeContext, subscribe: true })
-  public tree?: IgcTreeComponent;
+  public get tree(): IgcTreeComponent | undefined {
+    return this._tree;
+  }
 
   /** The parent item of the current tree item (if any) */
   public parent: IgcTreeItemComponent | null = null;
@@ -88,6 +90,41 @@ export default class IgcTreeItemComponent extends LitElement {
 
   @queryAssignedElements({ slot: 'label', flatten: true })
   private _contentList!: Array<HTMLElement>;
+
+  private get _selectionService(): IgcTreeSelectionService | undefined {
+    return this.tree?.selectionService;
+  }
+
+  private get _navService(): IgcTreeNavigationService | undefined {
+    return this.tree?.navService;
+  }
+
+  private get _parts() {
+    return {
+      wrapper: true,
+      selected: this.selected,
+      focused: this._isFocused,
+      active: this.active,
+    };
+  }
+
+  /**
+   * Direct `igc-tree-item` light-DOM children. Tree items are expected to be nested directly
+   * (wrapping a nested item in another element, e.g. a `<div>`, is not supported) — this keeps
+   * child resolution a cheap, native `.children` scan instead of a subtree-wide DOM query.
+   */
+  private get _directChildren(): IgcTreeItemComponent[] {
+    return Array.from(this.children).filter(
+      (el): el is IgcTreeItemComponent =>
+        el.tagName.toLowerCase() === TREE_ITEM_TAG
+    );
+  }
+
+  private get _allChildren(): IgcTreeItemComponent[] {
+    const result: IgcTreeItemComponent[] = [];
+    this._collectAllChildren(result);
+    return result;
+  }
 
   /** @hidden @internal */
   @query('#wrapper')
@@ -158,9 +195,42 @@ export default class IgcTreeItemComponent extends LitElement {
   @property({ attribute: true })
   public value: any = undefined;
 
-  private async _toggleAnimation(dir: 'open' | 'close') {
-    const animation = dir === 'open' ? growVerIn : growVerOut;
-    return this._animationPlayer.playExclusive(animation());
+  constructor() {
+    super();
+
+    addThemingController(this, all);
+
+    addSafeEventListener(this, 'click', this._itemClick);
+    addSafeEventListener(this, 'focus', this._onFocus);
+    addSafeEventListener(this, 'blur', this._onBlur);
+  }
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this._tree =
+      (this.closest(TREE_TAG) as IgcTreeComponent | null) ?? undefined;
+    this.parent =
+      this.parentElement?.tagName.toLowerCase() === TREE_ITEM_TAG
+        ? (this.parentElement as IgcTreeItemComponent)
+        : null;
+    this.level = this.parent ? this.parent.level + 1 : 0;
+    this.setAttribute('role', 'treeitem');
+    this._activeChange();
+    // if the item is not added/moved runtime
+    if (this.init) {
+      this._selectedChange();
+    } else {
+      // re-trigger the item selection state in order to update the collections within the selectionService
+      // and to handle correctly the itemParents recursively to the top-most ancestor
+      this._selectionService?.retriggerItemState(this);
+    }
+    this.init = false;
+  }
+
+  public override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._selectionService?.ensureStateOnItemDelete(this);
+    this._navService?.handleItemDisconnect(this);
   }
 
   protected override willUpdate(changed: PropertyValues<this>): void {
@@ -193,126 +263,6 @@ export default class IgcTreeItemComponent extends LitElement {
         this._selectedChange();
       }
     }
-  }
-
-  private _bothChange(): void {
-    if (this.hasChildren) {
-      this.setAttribute('aria-expanded', this.expanded.toString());
-    } else {
-      this.removeAttribute('aria-expanded');
-    }
-  }
-
-  private _expandedChange(oldValue: boolean): void {
-    if (!oldValue) {
-      return;
-    }
-    // await for load on demand children
-    Promise.resolve().then(() => {
-      if (this._navService?.focusedItem !== this && !this._isFocused) {
-        scrollIntoView(this._navService?.focusedItem?.wrapper, {
-          behavior: 'smooth',
-        });
-      }
-    });
-  }
-
-  private _activeChange(): void {
-    if (
-      (this.active && this._navService?.activeItem === this) ||
-      !this.active
-    ) {
-      return;
-    }
-    if (this._navService) {
-      this._navService.setActiveItem(this, false);
-    }
-    // Expand and scroll to the newly active item
-    this.tree?.expandToItem(this);
-    // Await for expanding
-    Promise.resolve().then(() => {
-      scrollIntoView(this.wrapper, { behavior: 'smooth' });
-    });
-  }
-
-  private _selectedChange(): void {
-    if (this.selected && !this._selectionService?.isItemSelected(this)) {
-      this._selectionService?.selectItemsWithNoEvent([this]);
-    }
-    if (!this.selected && this._selectionService?.isItemSelected(this)) {
-      this._selectionService?.deselectItemsWithNoEvent([this]);
-    }
-  }
-
-  constructor() {
-    super();
-
-    addThemingController(this, all);
-
-    addSafeEventListener(this, 'click', this._itemClick);
-    addSafeEventListener(this, 'focus', this._onFocus);
-    addSafeEventListener(this, 'blur', this._onBlur);
-  }
-
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    this.parent =
-      this.parentElement?.tagName.toLowerCase() === TREE_ITEM_TAG
-        ? (this.parentElement as IgcTreeItemComponent)
-        : null;
-    this.level = this.parent ? this.parent.level + 1 : 0;
-    this.setAttribute('role', 'treeitem');
-    this._activeChange();
-    // if the item is not added/moved runtime
-    if (this.init) {
-      this._selectedChange();
-    } else {
-      // re-trigger the item selection state in order to update the collections within the selectionService
-      // and to handle correctly the itemParents recursively to the top-most ancestor
-      this._selectionService?.retriggerItemState(this);
-    }
-    this.init = false;
-  }
-
-  public override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._selectionService?.ensureStateOnItemDelete(this);
-    this._navService?.handleItemDisconnect(this);
-  }
-
-  private get _selectionService(): IgcTreeSelectionService | undefined {
-    return this.tree?.selectionService;
-  }
-
-  private get _navService(): IgcTreeNavigationService | undefined {
-    return this.tree?.navService;
-  }
-
-  private get _parts() {
-    return {
-      wrapper: true,
-      selected: this.selected,
-      focused: this._isFocused,
-      active: this.active,
-    };
-  }
-
-  /**
-   * Direct `igc-tree-item` light-DOM children. Tree items are expected to be nested directly
-   * (wrapping a nested item in another element, e.g. a `<div>`, is not supported) — this keeps
-   * child resolution a cheap, native `.children` scan instead of a subtree-wide DOM query.
-   */
-  private get _directChildren(): IgcTreeItemComponent[] {
-    return Array.from(this.children).filter(
-      (el): el is IgcTreeItemComponent =>
-        el.tagName.toLowerCase() === TREE_ITEM_TAG
-    );
-  }
-
-  private get _allChildren(): IgcTreeItemComponent[] {
-    const result: IgcTreeItemComponent[] = [];
-    this._collectAllChildren(result);
-    return result;
   }
 
   /**
@@ -438,6 +388,60 @@ export default class IgcTreeItemComponent extends LitElement {
       });
     } else {
       this.setAttribute('role', 'treeitem');
+    }
+  }
+
+  private async _toggleAnimation(dir: 'open' | 'close') {
+    const animation = dir === 'open' ? growVerIn : growVerOut;
+    return this._animationPlayer.playExclusive(animation());
+  }
+
+  private _bothChange(): void {
+    if (this.hasChildren) {
+      this.setAttribute('aria-expanded', this.expanded.toString());
+    } else {
+      this.removeAttribute('aria-expanded');
+    }
+  }
+
+  private _expandedChange(oldValue: boolean): void {
+    if (!oldValue) {
+      return;
+    }
+    // await for load on demand children
+    Promise.resolve().then(() => {
+      if (this._navService?.focusedItem !== this && !this._isFocused) {
+        scrollIntoView(this._navService?.focusedItem?.wrapper, {
+          behavior: 'smooth',
+        });
+      }
+    });
+  }
+
+  private _activeChange(): void {
+    if (
+      (this.active && this._navService?.activeItem === this) ||
+      !this.active
+    ) {
+      return;
+    }
+    if (this._navService) {
+      this._navService.setActiveItem(this, false);
+    }
+    // Expand and scroll to the newly active item
+    this.tree?.expandToItem(this);
+    // Await for expanding
+    Promise.resolve().then(() => {
+      scrollIntoView(this.wrapper, { behavior: 'smooth' });
+    });
+  }
+
+  private _selectedChange(): void {
+    if (this.selected && !this._selectionService?.isItemSelected(this)) {
+      this._selectionService?.selectItemsWithNoEvent([this]);
+    }
+    if (!this.selected && this._selectionService?.isItemSelected(this)) {
+      this._selectionService?.deselectItemsWithNoEvent([this]);
     }
   }
 

--- a/src/components/tree/tree-item.ts
+++ b/src/components/tree/tree-item.ts
@@ -1,4 +1,5 @@
-import { html, LitElement, nothing } from 'lit';
+import { consume } from '@lit/context';
+import { html, LitElement, nothing, type PropertyValues } from 'lit';
 import {
   property,
   query,
@@ -11,22 +12,25 @@ import { addAnimationController } from '../../animations/player.js';
 import { growVerIn, growVerOut } from '../../animations/presets/grow/index.js';
 import { addThemingController } from '../../theming/theming-controller.js';
 import IgcCheckboxComponent from '../checkbox/checkbox.js';
-import { watch } from '../common/decorators/watch.js';
 import { registerComponent } from '../common/definitions/register.js';
 import { partMap } from '../common/part-map.js';
 import {
   addSafeEventListener,
   getElementFromPath,
   isLTR,
+  scrollIntoView,
 } from '../common/util.js';
 import IgcIconComponent from '../icon/icon.js';
 import IgcCircularProgressComponent from '../progress/circular-progress.js';
 import { styles } from './themes/item.base.css.js';
 import { all } from './themes/item.js';
 import { styles as shared } from './themes/shared/item.common.css.js';
+import { treeContext } from './tree.context.js';
 import type IgcTreeComponent from './tree.js';
 import type { IgcTreeNavigationService } from './tree.navigation.js';
 import type { IgcTreeSelectionService } from './tree.selection.js';
+
+const TREE_ITEM_TAG = 'igc-tree-item';
 
 /**
  * The tree-item component represents a child item of the tree component or another tree item.
@@ -49,7 +53,7 @@ import type { IgcTreeSelectionService } from './tree.selection.js';
  * @csspart select - The checkbox of the tree item when selection is enabled.
  */
 export default class IgcTreeItemComponent extends LitElement {
-  public static readonly tagName = 'igc-tree-item';
+  public static readonly tagName = TREE_ITEM_TAG;
   public static override styles = [styles, shared];
 
   /* blazorSuppress */
@@ -62,16 +66,20 @@ export default class IgcTreeItemComponent extends LitElement {
     );
   }
 
-  private tabbableEl?: HTMLElement[];
-  private focusedProgrammatically = false;
+  private _tabbableEl?: HTMLElement[];
+  private _focusedProgrammatically = false;
 
-  private groupRef: Ref<HTMLElement> = createRef();
+  private _groupRef: Ref<HTMLElement> = createRef();
 
-  private animationPlayer = addAnimationController(this, this.groupRef);
+  private _animationPlayer = addAnimationController(this, this._groupRef);
 
   /* blazorSuppress */
-  /** A reference to the tree the item is a part of. */
+  /**
+   * A reference to the tree the item is a part of.
+   */
+  @consume({ context: treeContext, subscribe: true })
   public tree?: IgcTreeComponent;
+
   /** The parent item of the current tree item (if any) */
   public parent: IgcTreeItemComponent | null = null;
 
@@ -79,14 +87,14 @@ export default class IgcTreeItemComponent extends LitElement {
   public init = false;
 
   @queryAssignedElements({ slot: 'label', flatten: true })
-  private contentList!: Array<HTMLElement>;
+  private _contentList!: Array<HTMLElement>;
 
   /** @hidden @internal */
   @query('#wrapper')
   public wrapper!: HTMLElement;
 
   @state()
-  private isFocused = false;
+  private _isFocused = false;
 
   /** @hidden @internal */
   @state()
@@ -150,14 +158,44 @@ export default class IgcTreeItemComponent extends LitElement {
   @property({ attribute: true })
   public value: any = undefined;
 
-  private async toggleAnimation(dir: 'open' | 'close') {
+  private async _toggleAnimation(dir: 'open' | 'close') {
     const animation = dir === 'open' ? growVerIn : growVerOut;
-    return this.animationPlayer.playExclusive(animation());
+    return this._animationPlayer.playExclusive(animation());
   }
 
-  @watch('expanded', { waitUntilFirstUpdate: true })
-  @watch('hasChildren', { waitUntilFirstUpdate: true })
-  protected bothChange(): void {
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+
+    if (
+      this.hasUpdated &&
+      (changed.has('expanded') || changed.has('hasChildren'))
+    ) {
+      this._bothChange();
+    }
+
+    if (changed.has('expanded')) {
+      const oldValue = changed.get('expanded') as boolean;
+      if (oldValue !== this.expanded) {
+        this._expandedChange(oldValue);
+      }
+    }
+
+    if (this.hasUpdated && changed.has('active')) {
+      const oldValue = changed.get('active') as boolean;
+      if (oldValue !== this.active) {
+        this._activeChange();
+      }
+    }
+
+    if (this.hasUpdated && changed.has('selected')) {
+      const oldValue = changed.get('selected') as boolean;
+      if (oldValue !== this.selected) {
+        this._selectedChange();
+      }
+    }
+  }
+
+  private _bothChange(): void {
     if (this.hasChildren) {
       this.setAttribute('aria-expanded', this.expanded.toString());
     } else {
@@ -165,57 +203,44 @@ export default class IgcTreeItemComponent extends LitElement {
     }
   }
 
-  @watch('expanded')
-  protected expandedChange(oldValue: boolean): void {
-    // always update the visible cache
-    this.navService?.update_visible_cache(this, this.expanded);
+  private _expandedChange(oldValue: boolean): void {
     if (!oldValue) {
       return;
     }
     // await for load on demand children
     Promise.resolve().then(() => {
-      if (this.navService?.focusedItem !== this && !this.isFocused) {
-        this.navService?.focusedItem?.wrapper?.scrollIntoView({
+      if (this._navService?.focusedItem !== this && !this._isFocused) {
+        scrollIntoView(this._navService?.focusedItem?.wrapper, {
           behavior: 'smooth',
-          block: 'nearest',
-          inline: 'nearest',
         });
       }
     });
   }
 
-  @watch('active', { waitUntilFirstUpdate: true })
-  protected activeChange(): void {
-    if ((this.active && this.navService?.activeItem === this) || !this.active) {
+  private _activeChange(): void {
+    if (
+      (this.active && this._navService?.activeItem === this) ||
+      !this.active
+    ) {
       return;
     }
-    if (this.navService) {
-      this.navService.setActiveItem(this, false);
+    if (this._navService) {
+      this._navService.setActiveItem(this, false);
     }
     // Expand and scroll to the newly active item
     this.tree?.expandToItem(this);
     // Await for expanding
     Promise.resolve().then(() => {
-      this.wrapper?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
-      });
+      scrollIntoView(this.wrapper, { behavior: 'smooth' });
     });
   }
 
-  @watch('disabled')
-  protected disabledChange(): void {
-    this.navService?.update_disabled_cache(this);
-  }
-
-  @watch('selected', { waitUntilFirstUpdate: true })
-  protected selectedChange(): void {
-    if (this.selected && !this.selectionService?.isItemSelected(this)) {
-      this.selectionService?.selectItemsWithNoEvent([this]);
+  private _selectedChange(): void {
+    if (this.selected && !this._selectionService?.isItemSelected(this)) {
+      this._selectionService?.selectItemsWithNoEvent([this]);
     }
-    if (!this.selected && this.selectionService?.isItemSelected(this)) {
-      this.selectionService?.deselectItemsWithNoEvent([this]);
+    if (!this.selected && this._selectionService?.isItemSelected(this)) {
+      this._selectionService?.deselectItemsWithNoEvent([this]);
     }
   }
 
@@ -224,62 +249,84 @@ export default class IgcTreeItemComponent extends LitElement {
 
     addThemingController(this, all);
 
-    addSafeEventListener(this, 'click', this.itemClick);
-    addSafeEventListener(this, 'focus', this.onFocus);
-    addSafeEventListener(this, 'blur', this.onBlur);
+    addSafeEventListener(this, 'click', this._itemClick);
+    addSafeEventListener(this, 'focus', this._onFocus);
+    addSafeEventListener(this, 'blur', this._onBlur);
   }
 
   public override connectedCallback(): void {
     super.connectedCallback();
-    this.tree = this.closest('igc-tree') as IgcTreeComponent;
-    this.parent = this.parentElement?.closest(
-      'igc-tree-item'
-    ) as IgcTreeItemComponent | null;
+    this.parent =
+      this.parentElement?.tagName.toLowerCase() === TREE_ITEM_TAG
+        ? (this.parentElement as IgcTreeItemComponent)
+        : null;
     this.level = this.parent ? this.parent.level + 1 : 0;
     this.setAttribute('role', 'treeitem');
-    this.activeChange();
+    this._activeChange();
     // if the item is not added/moved runtime
     if (this.init) {
-      this.selectedChange();
+      this._selectedChange();
     } else {
-      // retriger the item selection state in order to update the collections within the selectionService
+      // re-trigger the item selection state in order to update the collections within the selectionService
       // and to handle correctly the itemParents recursively to the top-most ancestor
-      this.selectionService?.retriggerItemState(this);
+      this._selectionService?.retriggerItemState(this);
     }
     this.init = false;
   }
 
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.selectionService?.ensureStateOnItemDelete(this);
-    this.navService?.delete_item(this);
+    this._selectionService?.ensureStateOnItemDelete(this);
+    this._navService?.handleItemDisconnect(this);
   }
 
-  private get selectionService(): IgcTreeSelectionService | undefined {
+  private get _selectionService(): IgcTreeSelectionService | undefined {
     return this.tree?.selectionService;
   }
 
-  private get navService(): IgcTreeNavigationService | undefined {
+  private get _navService(): IgcTreeNavigationService | undefined {
     return this.tree?.navService;
   }
 
-  private get parts() {
+  private get _parts() {
     return {
       wrapper: true,
       selected: this.selected,
-      focused: this.isFocused,
+      focused: this._isFocused,
       active: this.active,
     };
   }
 
-  private get directChildren(): Array<IgcTreeItemComponent> {
-    return this.allChildren.filter(
-      (x) => (x.parent ?? x.parentElement?.closest('igc-tree-item')) === this
-    ) as IgcTreeItemComponent[];
+  /**
+   * Direct `igc-tree-item` light-DOM children. Tree items are expected to be nested directly
+   * (wrapping a nested item in another element, e.g. a `<div>`, is not supported) — this keeps
+   * child resolution a cheap, native `.children` scan instead of a subtree-wide DOM query.
+   */
+  private get _directChildren(): IgcTreeItemComponent[] {
+    return Array.from(this.children).filter(
+      (el): el is IgcTreeItemComponent =>
+        el.tagName.toLowerCase() === TREE_ITEM_TAG
+    );
   }
 
-  private get allChildren(): Array<IgcTreeItemComponent> {
-    return Array.from(this.querySelectorAll('igc-tree-item'));
+  private get _allChildren(): IgcTreeItemComponent[] {
+    const result: IgcTreeItemComponent[] = [];
+    this._collectAllChildren(result);
+    return result;
+  }
+
+  /**
+   * Appends every descendant (pre-order) into `out` in a single pass.
+   *
+   * Building this iteratively (rather than the more obvious `flatMap` + spread recursion)
+   * avoids repeatedly copying already-collected arrays at every level of the tree, which would
+   * otherwise turn a deeply nested tree's flatten cost from linear into quadratic.
+   */
+  private _collectAllChildren(out: IgcTreeItemComponent[]): void {
+    for (const child of this._directChildren) {
+      out.push(child);
+      child._collectAllChildren(out);
+    }
   }
 
   /** The full path to the tree item, starting from the top-most ancestor. */
@@ -287,122 +334,106 @@ export default class IgcTreeItemComponent extends LitElement {
     return this.parent?.path ? [...this.parent.path, this] : [this];
   }
 
-  private itemClick(event: MouseEvent): void {
+  private _itemClick(event: MouseEvent): void {
     if (this.disabled || this !== getElementFromPath(this.tagName, event)) {
       return;
     }
     this.tabIndex = 0;
     if (this.tree?.toggleNodeOnClick && event.button === 0) {
-      if (this.expanded) {
-        this.collapseWithEvent();
-      } else {
-        this.expandWithEvent();
-      }
+      this.expanded ? this.collapseWithEvent() : this.expandWithEvent();
     }
-    this.navService?.setFocusedAndActiveItem(this, true, true);
+    this._navService?.setFocusedAndActiveItem(this, true, true);
   }
 
-  private expandIndicatorClick(): void {
-    if (this.disabled) {
-      return;
-    }
-    if (this.expanded) {
-      this.collapseWithEvent();
-    } else {
-      this.expandWithEvent();
-    }
+  private _expandIndicatorClick(): void {
+    if (this.disabled) return;
+    this.expanded ? this.collapseWithEvent() : this.expandWithEvent();
   }
 
-  private selectorClick(event: MouseEvent): void {
+  private _selectorClick(event: MouseEvent): void {
     event.preventDefault();
     if (this.tree?.toggleNodeOnClick) {
       event.stopPropagation();
     }
     if (event.shiftKey) {
-      this.selectionService?.selectMultipleItems(this);
+      this._selectionService?.selectMultipleItems(this);
       return;
     }
-    if (this.selected) {
-      this.selectionService?.deselectItem(this);
-    } else {
-      this.selectionService?.selectItem(this);
-    }
+    this.selected
+      ? this._selectionService?.deselectItem(this)
+      : this._selectionService?.selectItem(this);
   }
 
-  private onFocus(): void {
+  private _onFocus(): void {
     if (this.disabled) {
       return;
     }
-    if (this.navService?.focusedItem !== this) {
-      this.navService?.focusItem(this, false);
-      this.wrapper?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
-      });
+    if (this._navService?.focusedItem !== this) {
+      this._navService?.focusItem(this, false);
+      scrollIntoView(this.wrapper, { behavior: 'smooth' });
     }
-    if (this.tabbableEl?.length) {
+    if (this._tabbableEl?.length) {
       // set tabIndex = 0 to all tabbable elements
       // focus the first one
-      this.tabbableEl.forEach((element: HTMLElement) => {
+      this._tabbableEl.forEach((element: HTMLElement) => {
         element.tabIndex = 0;
       });
-      this.focusedProgrammatically = true;
-      this.tabbableEl[0].focus();
+      this._focusedProgrammatically = true;
+      this._tabbableEl[0].focus();
       return;
     }
-    this.isFocused = true;
+    this._isFocused = true;
   }
 
-  private onBlur(): void {
-    this.isFocused = false;
+  private _onBlur(): void {
+    this._isFocused = false;
   }
 
-  private onFocusIn(ev: Event): void {
+  private _onFocusIn(ev: Event): void {
     ev?.stopPropagation();
     if (!this.disabled) {
       // clicking directly over tabbable element when the item is not focused
-      if (!this.focusedProgrammatically) {
-        this.tabbableEl?.forEach((element: HTMLElement) => {
+      if (!this._focusedProgrammatically) {
+        this._tabbableEl?.forEach((element: HTMLElement) => {
           element.tabIndex = 0;
         });
       }
       this.removeAttribute('tabIndex');
-      this.isFocused = true;
-      this.focusedProgrammatically = false;
+      this._isFocused = true;
+      this._focusedProgrammatically = false;
     }
   }
 
-  private onFocusOut(ev: Event): void {
+  private _onFocusOut(ev: Event): void {
     ev?.stopPropagation();
-    this.isFocused = false;
-    this.tabbableEl?.forEach((element: HTMLElement) => {
+    this._isFocused = false;
+    this._tabbableEl?.forEach((element: HTMLElement) => {
       element.tabIndex = -1;
     });
 
-    if (this.navService?.focusedItem === this) {
+    if (this._navService?.focusedItem === this) {
       // called twice when clicking on already focused item with link (itemClick handler)
       this.setAttribute('tabindex', '0');
     }
   }
 
-  private labelChange(): void {
-    const firstElement = this.contentList[0];
+  private _labelChange(): void {
+    const firstElement = this._contentList[0];
     const tabbableSelector =
       'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 
-    this.tabbableEl = [
+    this._tabbableEl = [
       ...firstElement.querySelectorAll<HTMLElement>(tabbableSelector),
     ];
     if (firstElement.matches(tabbableSelector)) {
-      this.tabbableEl.splice(0, 0, firstElement);
+      this._tabbableEl.splice(0, 0, firstElement);
     }
 
-    if (this.tabbableEl?.length) {
+    if (this._tabbableEl?.length) {
       this.setAttribute('role', 'none');
-      this.tabbableEl[0].setAttribute('role', 'treeitem');
+      this._tabbableEl[0].setAttribute('role', 'treeitem');
 
-      this.tabbableEl.forEach((element: HTMLElement) => {
+      this._tabbableEl.forEach((element: HTMLElement) => {
         element.tabIndex = -1;
       });
     } else {
@@ -410,10 +441,8 @@ export default class IgcTreeItemComponent extends LitElement {
     }
   }
 
-  private handleChange(): void {
-    this.hasChildren = !!this.directChildren.length;
-    // there is no need to update nested children beacuse they're state is already up to date
-    this.navService?.update_visible_cache(this, this.expanded, false);
+  private _handleChange(): void {
+    this.hasChildren = !!this._directChildren.length;
   }
 
   /* blazorSuppress */
@@ -425,10 +454,7 @@ export default class IgcTreeItemComponent extends LitElement {
   public getChildren(
     options: { flatten: boolean } = { flatten: false }
   ): IgcTreeItemComponent[] {
-    if (options.flatten) {
-      return this.allChildren;
-    }
-    return this.directChildren;
+    return options.flatten ? this._allChildren : this._directChildren;
   }
 
   /**
@@ -452,15 +478,15 @@ export default class IgcTreeItemComponent extends LitElement {
 
     if (this.tree?.singleBranchExpand) {
       const pathSet = new Set(this.path.splice(0, this.path.length - 1));
-      this.tree.items.forEach((item: IgcTreeItemComponent) => {
+      for (const item of this.tree.items) {
         if (!pathSet.has(item)) {
           item.collapseWithEvent();
         }
-      });
+      }
     }
 
     this.expanded = true;
-    if (await this.toggleAnimation('open')) {
+    if (await this._toggleAnimation('open')) {
       this.tree?.emitEvent('igcItemExpanded', { detail: this });
     }
   }
@@ -485,7 +511,7 @@ export default class IgcTreeItemComponent extends LitElement {
     }
 
     this.expanded = false;
-    if (await this.toggleAnimation('close')) {
+    if (await this._toggleAnimation('close')) {
       this.tree?.emitEvent('igcItemCollapsed', { detail: this });
     }
   }
@@ -512,7 +538,7 @@ export default class IgcTreeItemComponent extends LitElement {
     };
 
     return html`
-      <div id="wrapper" part=${partMap(this.parts)}>
+      <div id="wrapper" part=${partMap(this._parts)}>
         <div
           style="width: calc(${this.level} * var(--igc-tree-indentation-size))"
           part="indentation"
@@ -536,7 +562,7 @@ export default class IgcTreeItemComponent extends LitElement {
                     @click=${
                       this.tree?.toggleNodeOnClick
                         ? nothing
-                        : this.expandIndicatorClick
+                        : this._expandIndicatorClick
                     }
                   >
                     ${
@@ -566,11 +592,10 @@ export default class IgcTreeItemComponent extends LitElement {
             ? html`
                 <div part="select" aria-hidden="true">
                   <igc-checkbox
-                    @click=${this.selectorClick}
+                    @click=${this._selectorClick}
                     .checked=${this.selected}
                     .indeterminate=${this.indeterminate}
                     .disabled=${this.disabled}
-                    tabindex="-1"
                   >
                   </igc-checkbox>
                 </div>
@@ -580,16 +605,16 @@ export default class IgcTreeItemComponent extends LitElement {
         <div part="label">
           <slot
             name="label"
-            @slotchange=${this.labelChange}
-            @focusin=${this.onFocusIn}
-            @focusout=${this.onFocusOut}
+            @slotchange=${this._labelChange}
+            @focusin=${this._onFocusIn}
+            @focusout=${this._onFocusOut}
           >
             <span part="text">${this.label}</span>
           </slot>
         </div>
       </div>
-      <div ${ref(this.groupRef)} role="group" aria-hidden=${!this.expanded}>
-        <slot @slotchange=${this.handleChange}></slot>
+      <div ${ref(this._groupRef)} role="group" .inert=${!this.expanded}>
+        <slot @slotchange=${this._handleChange}></slot>
       </div>
     `;
   }

--- a/src/components/tree/tree-utils.spec.ts
+++ b/src/components/tree/tree-utils.spec.ts
@@ -43,7 +43,7 @@ export class TreeTestFunctions {
     item: IgcTreeItemComponent,
     selector: string
   ): HTMLSlotElement => {
-    return item.shadowRoot!.querySelector(selector) as HTMLSlotElement;
+    return item.renderRoot.querySelector(selector) as HTMLSlotElement;
   };
 
   public static verifyExpansionState = (
@@ -297,12 +297,13 @@ export const navigationTree = `<igc-tree selection='none' style="height: 400px; 
                                        <igc-tree-item label="Tree Item 4"></igc-tree-item>
                                      </igc-tree>`;
 
-export const wrappedItemsTree = `<igc-tree selection='none' style="height: 400px;">
+export const itemWrappedInDivTree = `<igc-tree selection='none' style="height: 400px;">
                                     <igc-tree-item label="Tree Item 1" expanded>
                                       <div>
                                         <igc-tree-item label="Tree Item 1.1" expanded>
                                           <igc-tree-item label="Tree Item 1.1.1"></igc-tree-item>
                                         </igc-tree-item>
                                       </div>
+                                    </igc-tree-item>
                                     <igc-tree-item label="Tree Item 2"></igc-tree-item>
                                   </igc-tree>`;

--- a/src/components/tree/tree.context.ts
+++ b/src/components/tree/tree.context.ts
@@ -1,0 +1,9 @@
+import { createContext } from '@lit/context';
+import type IgcTreeComponent from './tree.js';
+
+/**
+ * Provides the owning `igc-tree` instance to descendant `igc-tree-item`s.
+ */
+export const treeContext = createContext<IgcTreeComponent | undefined>(
+  Symbol('igc-tree-context')
+);

--- a/src/components/tree/tree.context.ts
+++ b/src/components/tree/tree.context.ts
@@ -1,9 +1,0 @@
-import { createContext } from '@lit/context';
-import type IgcTreeComponent from './tree.js';
-
-/**
- * Provides the owning `igc-tree` instance to descendant `igc-tree-item`s.
- */
-export const treeContext = createContext<IgcTreeComponent | undefined>(
-  Symbol('igc-tree-context')
-);

--- a/src/components/tree/tree.navigation.ts
+++ b/src/components/tree/tree.navigation.ts
@@ -1,313 +1,275 @@
-import { isLTR } from '../common/util.js';
+import {
+  addKeybindings,
+  arrowDown,
+  arrowLeft,
+  arrowRight,
+  arrowUp,
+  ctrlKey,
+  endKey,
+  enterKey,
+  homeKey,
+  shiftKey,
+  spaceBar,
+} from '../common/controllers/key-bindings.js';
+import { isLTR, scrollIntoView } from '../common/util.js';
 import type IgcTreeComponent from './tree.js';
 import type { IgcTreeSelectionService } from './tree.selection.js';
 import type IgcTreeItemComponent from './tree-item.js';
 
-export const NAVIGATION_KEYS = new Set([
-  'down',
-  'up',
-  'left',
-  'right',
-  'arrowdown',
-  'arrowup',
-  'arrowleft',
-  'arrowright',
-  'home',
-  'end',
-  'space',
-  'spacebar',
-  ' ',
-]);
-
-/* blazorSuppress */
+/**
+ * Handles roving-tabindex keyboard navigation and active/focused item tracking for the tree.
+ *
+ * Unlike the previous implementation, "visible" (keyboard-navigable) items are **not** cached.
+ * They are derived on demand, only when a navigation key is actually pressed, directly from each
+ * item's live `expanded`/`disabled`/`parent` state. This avoids doing any work on every single
+ * item mount/expand/disable — the dominant cost in trees with many items — since navigation only
+ * needs to know the visible set at the moment of a keypress, not continuously.
+ *
+ * @hidden @internal
+ */
 export class IgcTreeNavigationService {
-  private tree!: IgcTreeComponent;
-  private selectionService!: IgcTreeSelectionService;
-
   private _focusedItem: IgcTreeItemComponent | null = null;
-
-  private _lastFocusedItem: IgcTreeItemComponent | null = null;
   private _activeItem: IgcTreeItemComponent | null = null;
 
-  private _visibleChildren: IgcTreeItemComponent[] = [];
-  private _invisibleChildren: Set<IgcTreeItemComponent> = new Set();
-  private _disabledChildren: Set<IgcTreeItemComponent> = new Set();
-
   constructor(
-    tree: IgcTreeComponent,
-    selectionService: IgcTreeSelectionService
+    private readonly tree: IgcTreeComponent,
+    private readonly selection: IgcTreeSelectionService
   ) {
-    this.tree = tree;
-    this.selectionService = selectionService;
-  }
-
-  public updateVisChild(): void {
-    this._visibleChildren = this.tree?.items
-      ? this.tree.items.filter(
-          (i: IgcTreeItemComponent) =>
-            !(this._invisibleChildren.has(i) || this._disabledChildren.has(i))
-        )
-      : [];
+    addKeybindings(tree, {
+      bindingDefaults: { preventDefault: true, repeat: true },
+    })
+      .set(homeKey, () => this.setFocusedAndActiveItem(this._navigable[0]))
+      .set(endKey, () => this.setFocusedAndActiveItem(this._lastVisible()))
+      .set(arrowLeft, this._arrowLeft)
+      .set(arrowRight, this._arrowRight)
+      .set(arrowUp, () => this._arrowVertical(-1, true))
+      .set(arrowDown, () => this._arrowVertical(1, true))
+      .set([ctrlKey, arrowUp], () => this._arrowVertical(-1, false))
+      .set([ctrlKey, arrowDown], () => this._arrowVertical(1, false))
+      .set('*', this._asterisk)
+      .set(spaceBar, () => this._space(false))
+      .set([shiftKey, spaceBar], () => this._space(true))
+      .set(enterKey, this._enter, { preventDefault: false });
   }
 
   public get focusedItem(): IgcTreeItemComponent | null {
     return this._focusedItem;
   }
 
-  public focusItem(value: IgcTreeItemComponent | null, shouldFocus = true) {
-    if (this._focusedItem === value) {
-      return;
-    }
-    this._lastFocusedItem = this._focusedItem;
-    if (this._lastFocusedItem) {
-      this._lastFocusedItem.removeAttribute('tabindex');
-    }
-    this._focusedItem = value;
-    if (this._focusedItem !== null && shouldFocus) {
-      this._focusedItem.tabIndex = 0;
-      this._focusedItem.focus({
-        preventScroll: true,
-      });
-      this._focusedItem.wrapper?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
-      });
-    }
-  }
-
   public get activeItem(): IgcTreeItemComponent | null {
     return this._activeItem;
   }
 
-  public setActiveItem(value: IgcTreeItemComponent | null, shouldEmit = true) {
+  public focusItem(
+    value: IgcTreeItemComponent | null,
+    shouldFocus = true
+  ): void {
+    if (this._focusedItem === value) {
+      return;
+    }
+
+    this._focusedItem?.removeAttribute('tabindex');
+    this._focusedItem = value;
+
+    if (this._focusedItem && shouldFocus) {
+      this._focusedItem.tabIndex = 0;
+      this._focusedItem.focus({ preventScroll: true });
+      this._scrollIntoView(this._focusedItem);
+    }
+  }
+
+  public setActiveItem(
+    value: IgcTreeItemComponent | null,
+    shouldEmit = true
+  ): void {
     if (this._activeItem === value) {
       return;
     }
+
     if (this._activeItem && value) {
       this._activeItem.active = false;
     }
+
     this._activeItem = value;
+
     if (this._activeItem) {
       this._activeItem.active = true;
-    }
-    if (shouldEmit && this._activeItem) {
-      this.tree.emitEvent('igcActiveItem', { detail: this._activeItem });
-    }
-  }
-
-  public get visibleChildren(): IgcTreeItemComponent[] {
-    return this._visibleChildren;
-  }
-
-  public update_disabled_cache(item: IgcTreeItemComponent): void {
-    if (item.disabled) {
-      this._disabledChildren.add(item);
-    } else {
-      this._disabledChildren.delete(item);
-    }
-    this.updateVisChild();
-  }
-
-  public delete_item(item: IgcTreeItemComponent) {
-    if (this.activeItem === item) {
-      this.setActiveItem(null);
-    }
-    if (this.focusedItem === item) {
-      this.focusItem(null, false);
-      const firstNotDisableItem = this.tree.items.find(
-        (i: IgcTreeItemComponent) => !i.disabled
-      );
-      if (firstNotDisableItem) {
-        firstNotDisableItem.tabIndex = 0;
-        this.focusItem(firstNotDisableItem, false);
+      if (shouldEmit) {
+        this.tree.emitEvent('igcActiveItem', { detail: this._activeItem });
       }
     }
   }
 
-  public update_visible_cache(
-    item: IgcTreeItemComponent,
-    expanded: boolean,
-    shouldUpdateNestedChildren = true,
-    shouldUpdate = true
-  ): void {
-    if (expanded && !this._invisibleChildren.has(item)) {
-      item.getChildren()?.forEach((child: IgcTreeItemComponent) => {
-        this._invisibleChildren.delete(child);
-        if (shouldUpdateNestedChildren) {
-          this.update_visible_cache(child, child.expanded, true, false);
-        }
-      });
-    } else {
-      for (const child of item.getChildren({ flatten: true })) {
-        this._invisibleChildren.add(child);
-      }
-    }
-
-    if (shouldUpdate) {
-      this.updateVisChild();
-    }
-  }
-
-  /**
-   * Sets the item as focused (and active)
-   *
-   * @param item target item
-   * @param isActive if true, sets the item as active
-   */
+  /** Sets the item as focused (and optionally active). */
   public setFocusedAndActiveItem(
-    item: IgcTreeItemComponent,
+    item: IgcTreeItemComponent | undefined,
     isActive = true,
     shouldFocus = true
   ): void {
+    if (!item) {
+      return;
+    }
     if (isActive) {
       this.setActiveItem(item);
     }
     this.focusItem(item, shouldFocus);
   }
 
-  /** Handler for keydown events. Used in tree.component.ts */
-  public handleKeydown(event: KeyboardEvent) {
-    const key = event.key.toLowerCase();
-    if (!this.focusedItem) {
-      return;
+  /** Called by a tree item on `disconnectedCallback`. */
+  public handleItemDisconnect(item: IgcTreeItemComponent): void {
+    if (this._activeItem === item) {
+      this.setActiveItem(null);
     }
-    if (!(NAVIGATION_KEYS.has(key) || key === '*')) {
-      if (key === 'enter') {
-        this.setActiveItem(this.focusedItem);
-      }
-      return;
-    }
-    event.preventDefault();
-    this.handleNavigation(event);
-  }
-
-  private handleNavigation(event: KeyboardEvent) {
-    switch (event.key.toLowerCase()) {
-      case 'home':
-        this.setFocusedAndActiveItem(this.visibleChildren[0]);
-        break;
-      case 'end':
-        this.setFocusedAndActiveItem(
-          this.visibleChildren[this.visibleChildren.length - 1]
-        );
-        break;
-      case 'arrowleft':
-      case 'left':
-        if (!isLTR(this.tree)) {
-          this.handleArrowRight();
-        } else {
-          this.handleArrowLeft();
-        }
-        break;
-      case 'arrowright':
-      case 'right':
-        if (!isLTR(this.tree)) {
-          this.handleArrowLeft();
-        } else {
-          this.handleArrowRight();
-        }
-        break;
-      case 'arrowup':
-      case 'up':
-        this.handleUpDownArrow(true, event);
-        break;
-      case 'arrowdown':
-      case 'down':
-        this.handleUpDownArrow(false, event);
-        break;
-      case '*':
-        this.handleAsterisk();
-        break;
-      case ' ':
-      case 'spacebar':
-      case 'space':
-        this.handleSpace(event.shiftKey);
-        break;
-      default:
-        return;
-    }
-  }
-
-  private handleArrowLeft(): void {
-    if (this.focusedItem?.expanded && this.focusedItem.getChildren()?.length) {
-      this.setActiveItem(this.focusedItem);
-      this.focusedItem.collapseWithEvent();
-    } else {
-      const parentItem = this.focusedItem?.parent;
-      if (parentItem && !parentItem.disabled) {
-        this.setFocusedAndActiveItem(parentItem);
+    if (this._focusedItem === item) {
+      this.focusItem(null, false);
+      const next = this.tree.items.find((i) => !i.disabled);
+      if (next) {
+        next.tabIndex = 0;
+        this.focusItem(next, false);
       }
     }
   }
 
-  private handleArrowRight(): void {
-    if (this.focusedItem!.getChildren()?.length > 0) {
-      if (!this.focusedItem?.expanded) {
-        this.setActiveItem(this.focusedItem);
-        this.focusedItem!.expandWithEvent();
-      } else {
-        const firstChild = this.focusedItem
-          .getChildren()
-          .find((item: IgcTreeItemComponent) => !item.disabled);
-        if (firstChild) {
-          this.setFocusedAndActiveItem(firstChild);
-        }
+  //#region Visible/navigable item resolution (computed on demand, not cached)
+
+  private _isNavigable(item: IgcTreeItemComponent): boolean {
+    if (item.disabled) {
+      return false;
+    }
+    for (let ancestor = item.parent; ancestor; ancestor = ancestor.parent) {
+      if (!ancestor.expanded) {
+        return false;
       }
     }
+    return true;
   }
 
-  private handleUpDownArrow(isUp: boolean, event: KeyboardEvent): void {
-    const next = this.getVisibleItem(this.focusedItem!, isUp ? -1 : 1);
-    if (next === this.focusedItem) {
-      return;
-    }
-
-    if (event.ctrlKey) {
-      this.setFocusedAndActiveItem(next, false);
-    } else {
-      this.setFocusedAndActiveItem(next);
-    }
+  private get _navigable(): IgcTreeItemComponent[] {
+    return this.tree.items.filter((item) => this._isNavigable(item));
   }
 
-  private handleAsterisk(): void {
-    const items = this.focusedItem?.parent
-      ? this.focusedItem!.parent?.getChildren()
-      : this.tree.items?.filter(
-          (item: IgcTreeItemComponent) => item.level === 0
-        );
-    items?.forEach((item: IgcTreeItemComponent) => {
-      if (!item.disabled && !item.expanded && item.hasChildren) {
-        item.expandWithEvent();
-      }
-    });
+  private _lastVisible(): IgcTreeItemComponent {
+    const items = this._navigable;
+    return items[items.length - 1];
   }
 
-  private handleSpace(shiftKey = false): void {
-    if (this.tree.selection === 'none') {
-      this.setActiveItem(this.focusedItem);
-      return;
-    }
-
-    this.setActiveItem(this.focusedItem);
-    if (shiftKey) {
-      this.selectionService.selectMultipleItems(this.focusedItem!);
-      return;
-    }
-
-    if (this.focusedItem!.selected) {
-      this.selectionService.deselectItem(this.focusedItem!);
-    } else {
-      this.selectionService.selectItem(this.focusedItem!);
-    }
-  }
-
-  /** Gets the next visible item in the given direction - 1 -> next, -1 -> previous */
-  private getVisibleItem(
+  /** Next/previous navigable item relative to `item`, or `item` itself if there isn't one. */
+  private _adjacent(
     item: IgcTreeItemComponent,
-    dir: 1 | -1 = 1
+    dir: 1 | -1
   ): IgcTreeItemComponent {
-    const itemIndex = this.visibleChildren.indexOf(item);
-    return this.visibleChildren[itemIndex + dir] || item;
+    const items = this._navigable;
+    const index = items.indexOf(item);
+    return items[index + dir] ?? item;
   }
+
+  private _scrollIntoView(item: IgcTreeItemComponent): void {
+    scrollIntoView(item.wrapper);
+  }
+
+  //#endregion
+
+  //#region Keyboard handlers
+
+  private readonly _arrowLeft = (): void => {
+    isLTR(this.tree)
+      ? this._collapseOrGoToParent()
+      : this._expandOrGoToFirstChild();
+  };
+
+  private readonly _arrowRight = (): void => {
+    isLTR(this.tree)
+      ? this._expandOrGoToFirstChild()
+      : this._collapseOrGoToParent();
+  };
+
+  private _collapseOrGoToParent(): void {
+    const item = this._focusedItem;
+    if (!item) {
+      return;
+    }
+    if (item.expanded && item.getChildren().length) {
+      this.setActiveItem(item);
+      item.collapseWithEvent();
+      return;
+    }
+    if (item.parent && !item.parent.disabled) {
+      this.setFocusedAndActiveItem(item.parent);
+    }
+  }
+
+  private _expandOrGoToFirstChild(): void {
+    const item = this._focusedItem;
+    if (!item || item.getChildren().length === 0) {
+      return;
+    }
+    if (!item.expanded) {
+      this.setActiveItem(item);
+      item.expandWithEvent();
+      return;
+    }
+    const firstChild = item.getChildren().find((child) => !child.disabled);
+    if (firstChild) {
+      this.setFocusedAndActiveItem(firstChild);
+    }
+  }
+
+  private _arrowVertical(dir: 1 | -1, shouldActivate: boolean): void {
+    const item = this._focusedItem;
+    if (!item) {
+      return;
+    }
+    const next = this._adjacent(item, dir);
+    if (next === item) {
+      return;
+    }
+    this.setFocusedAndActiveItem(next, shouldActivate);
+  }
+
+  private readonly _asterisk = (): void => {
+    const item = this._focusedItem;
+    if (!item) {
+      return;
+    }
+    const siblings = item.parent
+      ? item.parent.getChildren()
+      : this.tree.items.filter((i) => i.level === 0);
+
+    for (const sibling of siblings) {
+      if (!sibling.disabled && !sibling.expanded && sibling.hasChildren) {
+        sibling.expandWithEvent();
+      }
+    }
+  };
+
+  private _space(shiftKey: boolean): void {
+    const item = this._focusedItem;
+    if (!item) {
+      return;
+    }
+
+    if (this.tree.selection === 'none') {
+      this.setActiveItem(item);
+      return;
+    }
+
+    this.setActiveItem(item);
+
+    if (shiftKey) {
+      this.selection.selectMultipleItems(item);
+      return;
+    }
+
+    item.selected
+      ? this.selection.deselectItem(item)
+      : this.selection.selectItem(item);
+  }
+
+  private readonly _enter = (): void => {
+    if (this._focusedItem) {
+      this.setActiveItem(this._focusedItem);
+    }
+  };
+
+  //#endregion
 }

--- a/src/components/tree/tree.navigation.ts
+++ b/src/components/tree/tree.navigation.ts
@@ -86,7 +86,7 @@ export class IgcTreeNavigationService {
       return;
     }
 
-    if (this._activeItem && value) {
+    if (this._activeItem) {
       this._activeItem.active = false;
     }
 

--- a/src/components/tree/tree.spec.ts
+++ b/src/components/tree/tree.spec.ts
@@ -11,6 +11,7 @@ import {
   DIFF_OPTIONS,
   disabledItemsTree,
   expandCollapseTree,
+  itemWrappedInDivTree,
   navigationTree,
   PARTS,
   SLOTS,
@@ -18,7 +19,6 @@ import {
   simpleHierarchyTree,
   simpleTree,
   TreeTestFunctions,
-  wrappedItemsTree,
 } from './tree-utils.spec.js';
 
 describe('Tree', () => {
@@ -58,7 +58,7 @@ describe('Tree', () => {
         expect(label?.textContent).to.equal(item.label);
 
         // the last slot is unnamed and is where child tree items are rendered
-        const slots = item.shadowRoot!.querySelectorAll('slot');
+        const slots = item.renderRoot.querySelectorAll('slot');
         const childrenSlot = Array.from(slots).filter(
           (s) => s.name === ''
         )[0] as HTMLSlotElement;
@@ -154,13 +154,15 @@ describe('Tree', () => {
       expect(topLevelItems[0].expanded).to.be.false; // collapsed by default
       expect(topLevelItems[1].expanded).to.be.true;
 
-      const content1 =
-        topLevelItems[0].shadowRoot!.querySelector('div[role="group"]');
-      expect(content1?.ariaHidden).to.equal('true');
+      const content1 = topLevelItems[0].renderRoot.querySelector(
+        'div[role="group"]'
+      ) as HTMLElement;
+      expect(content1.inert).to.be.true;
 
-      const content2 =
-        topLevelItems[1].shadowRoot!.querySelector('div[role="group"]');
-      expect(content2?.ariaHidden).to.equal('false');
+      const content2 = topLevelItems[1].renderRoot.querySelector(
+        'div[role="group"]'
+      ) as HTMLElement;
+      expect(content2.inert).to.be.false;
     });
 
     it('Should not render expand indicator if an item has no children', async () => {
@@ -178,7 +180,7 @@ describe('Tree', () => {
       expect(tree.selection).to.equal('none'); // by default
 
       tree.items.forEach((item) => {
-        const selectionPart = item.shadowRoot!.querySelector(PARTS.select);
+        const selectionPart = item.renderRoot.querySelector(PARTS.select);
         expect(selectionPart).to.be.null;
       });
 
@@ -186,7 +188,7 @@ describe('Tree', () => {
       await elementUpdated(tree);
 
       tree.items.forEach((item) => {
-        const selectionPart = item.shadowRoot!.querySelector(PARTS.select);
+        const selectionPart = item.renderRoot.querySelector(PARTS.select);
         expect(selectionPart).dom.to.equal(
           `<div part="select" aria-hidden="true">
               <igc-checkbox label-position="after"></igc-checkbox>
@@ -230,7 +232,7 @@ describe('Tree', () => {
       await elementUpdated(tree);
 
       expect(tree.items[0].selected).to.be.false;
-      let selectionPart = tree.items[0].shadowRoot!.querySelector(PARTS.select);
+      let selectionPart = tree.items[0].renderRoot.querySelector(PARTS.select);
       expect(selectionPart).lightDom.to.equal(
         `<igc-checkbox label-position="after"></igc-checkbox>`,
         DIFF_OPTIONS
@@ -243,7 +245,7 @@ describe('Tree', () => {
       tree.items[0].selected = true;
       await elementUpdated(tree);
 
-      selectionPart = tree.items[0].shadowRoot!.querySelector(PARTS.select);
+      selectionPart = tree.items[0].renderRoot.querySelector(PARTS.select);
       cb = selectionPart?.children[0] as IgcCheckboxComponent;
       expect(cb.checked).to.be.true;
       expect(cb.indeterminate).to.be.false;
@@ -314,7 +316,7 @@ describe('Tree', () => {
       // verify the default indentation div is displayed for other child item
       const indentationPart12 = topLevelItems[0]
         .getChildren()[1]
-        .shadowRoot!.querySelector(PARTS.indentation);
+        .renderRoot.querySelector(PARTS.indentation);
       expect(indentationPart12).dom.to.equal(
         `<div part="indentation" aria-hidden="true">
           <slot name="indentation"></slot>
@@ -374,7 +376,7 @@ describe('Tree', () => {
       await elementUpdated(tree);
 
       tree.items.forEach((item) => {
-        const selectionPart = item.shadowRoot!.querySelector(PARTS.select);
+        const selectionPart = item.renderRoot.querySelector(PARTS.select);
         expect(selectionPart).to.be.null;
       });
 
@@ -492,14 +494,22 @@ describe('Tree', () => {
       expect(tree.items.length).to.equal(1);
     });
 
-    it('Should correctly assign the parent item when child items are wrapped within other elements', async () => {
-      tree = await TreeTestFunctions.createTreeElement(wrappedItemsTree);
-      expect(tree.items[0].parent).to.be.null;
-      expect(tree.items[0].children[0].tagName.toLocaleLowerCase() === 'div');
-      // Should also correctly retrieve the direct children in this case
-      const child1 = tree.items[0].getChildren()[0];
-      expect(child1.label).to.equal('Tree Item 1.1');
-      expect(child1.parent).to.equal(tree.items[0]);
+    it('Should not recognize a tree item as a child if it is wrapped within another element (e.g. a `<div>`)', async () => {
+      tree = await TreeTestFunctions.createTreeElement(itemWrappedInDivTree);
+
+      // "Tree Item 1.1" (and its own child) are nested inside a <div> inside "Tree Item 1" -
+      // they are not direct light-DOM children of it, so they are not picked up as its items.
+      const item1 = tree.items[0];
+      expect(item1.label).to.equal('Tree Item 1');
+      expect(item1.getChildren()).to.have.lengthOf(0);
+
+      // The tree's own flattened `items` collection only walks direct `igc-tree-item`
+      // children, so the wrapped items are excluded entirely from the whole tree too.
+      expect(tree.items).to.have.lengthOf(2);
+      expect(tree.items.map((i) => i.label)).to.eql([
+        'Tree Item 1',
+        'Tree Item 2',
+      ]);
     });
   });
 
@@ -771,7 +781,7 @@ describe('Tree', () => {
 
       TreeTestFunctions.verifyItemSelection(topLevelItems[0], false);
 
-      const selectionPart = topLevelItems[0].shadowRoot!.querySelector(
+      const selectionPart = topLevelItems[0].renderRoot.querySelector(
         PARTS.select
       );
       const cb = selectionPart?.children[0] as IgcCheckboxComponent;
@@ -1014,7 +1024,7 @@ describe('Tree', () => {
       disabledItems[0].selected = true;
       await elementUpdated(tree);
 
-      const selectionPart = disabledItems[0].shadowRoot!.querySelector(
+      const selectionPart = disabledItems[0].renderRoot.querySelector(
         PARTS.select
       );
       const cb = selectionPart?.children[0] as IgcCheckboxComponent;

--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -1,4 +1,3 @@
-import { ContextProvider } from '@lit/context';
 import {
   type ITreeResourceStrings,
   TreeResourceStringsEN,
@@ -15,7 +14,6 @@ import type { TreeSelection } from '../types.js';
 import { styles } from './themes/container.base.css.js';
 import { all } from './themes/container.js';
 import type { IgcTreeComponentEventMap } from './tree.common.js';
-import { treeContext } from './tree.context.js';
 import { IgcTreeNavigationService } from './tree.navigation.js';
 import { IgcTreeSelectionService } from './tree.selection.js';
 import IgcTreeItemComponent from './tree-item.js';
@@ -54,11 +52,6 @@ export default class IgcTreeComponent extends EventEmitterMixin<
       defaultEN: TreeResourceStringsEN,
     }
   );
-
-  private readonly _contextProvider = new ContextProvider(this, {
-    context: treeContext,
-    initialValue: this,
-  });
 
   /** @hidden @internal */
   public selectionService!: IgcTreeSelectionService;
@@ -164,7 +157,9 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     }
 
     if (changed.has('selection') || changed.has('resourceStrings')) {
-      this._contextProvider.updateObservers();
+      for (const item of this.items) {
+        item.requestUpdate();
+      }
     }
   }
 

--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -1,21 +1,21 @@
+import { ContextProvider } from '@lit/context';
 import {
   type ITreeResourceStrings,
   TreeResourceStringsEN,
 } from 'igniteui-i18n-core';
-import { html, LitElement } from 'lit';
+import { html, LitElement, type PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 import { addThemingController } from '../../theming/theming-controller.js';
 import { blazorAdditionalDependencies } from '../common/decorators/blazorAdditionalDependencies.js';
-import { watch } from '../common/decorators/watch.js';
 import { registerComponent } from '../common/definitions/register.js';
 import { addI18nController } from '../common/i18n/i18n-controller.js';
 import type { Constructor } from '../common/mixins/constructor.js';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
-import { addSafeEventListener } from '../common/util.js';
 import type { TreeSelection } from '../types.js';
 import { styles } from './themes/container.base.css.js';
 import { all } from './themes/container.js';
 import type { IgcTreeComponentEventMap } from './tree.common.js';
+import { treeContext } from './tree.context.js';
 import { IgcTreeNavigationService } from './tree.navigation.js';
 import { IgcTreeSelectionService } from './tree.selection.js';
 import IgcTreeItemComponent from './tree-item.js';
@@ -54,6 +54,11 @@ export default class IgcTreeComponent extends EventEmitterMixin<
       defaultEN: TreeResourceStringsEN,
     }
   );
+
+  private readonly _contextProvider = new ContextProvider(this, {
+    context: treeContext,
+    initialValue: this,
+  });
 
   /** @hidden @internal */
   public selectionService!: IgcTreeSelectionService;
@@ -108,23 +113,66 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     return this._i18nController.resourceStrings;
   }
 
-  @watch('dir')
-  protected onDirChange(): void {
-    this.items?.forEach((item: IgcTreeItemComponent) => {
-      item.requestUpdate();
-    });
+  /* blazorSuppress */
+  /**
+   * Returns all of the tree's items.
+   */
+  public get items(): IgcTreeItemComponent[] {
+    const result: IgcTreeItemComponent[] = [];
+    for (const el of this.children) {
+      if (el.tagName.toLowerCase() === IgcTreeItemComponent.tagName) {
+        const item = el as IgcTreeItemComponent;
+        result.push(item, ...item.getChildren({ flatten: true }));
+      }
+    }
+    return result;
   }
 
-  @watch('selection', { waitUntilFirstUpdate: true })
-  protected selectionModeChange(): void {
+  constructor() {
+    super();
+
+    addThemingController(this, all);
+
+    this.selectionService = new IgcTreeSelectionService(this);
+    this.navService = new IgcTreeNavigationService(this, this.selectionService);
+  }
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this.setAttribute('role', 'tree');
+    const items = this.items;
+    // set init to true for all items which are rendered along with the tree
+    for (const item of items) {
+      item.init = true;
+    }
+    const firstNotDisabledItem = items.find((i) => !i.disabled);
+    if (firstNotDisabledItem) {
+      firstNotDisabledItem.tabIndex = 0;
+      this.navService.focusItem(firstNotDisabledItem);
+    }
+  }
+
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+
+    if (this.hasUpdated && changed.has('selection')) {
+      this._selectionModeChange();
+    }
+
+    if (changed.has('singleBranchExpand')) {
+      this._singleBranchExpandChange();
+    }
+
+    if (changed.has('selection') || changed.has('resourceStrings')) {
+      this._contextProvider.updateObservers();
+    }
+  }
+
+  private _selectionModeChange(): void {
     this.selectionService.clearItemsSelection();
-    this.items?.forEach((item: IgcTreeItemComponent) => {
-      item.requestUpdate();
-    });
   }
 
-  @watch('singleBranchExpand')
-  protected singleBranchExpandChange(): void {
+  private _singleBranchExpandChange(): void {
     if (this.singleBranchExpand) {
       // if activeItem -> do not collapse its branch
       if (this.navService.activeItem) {
@@ -141,43 +189,6 @@ export default class IgcTreeComponent extends EventEmitterMixin<
         }
       }
     }
-  }
-
-  constructor() {
-    super();
-
-    addThemingController(this, all);
-
-    this.selectionService = new IgcTreeSelectionService(this);
-    this.navService = new IgcTreeNavigationService(this, this.selectionService);
-
-    addSafeEventListener(this, 'keydown', this.handleKeydown);
-  }
-
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    this.setAttribute('role', 'tree');
-    // set init to true for all items which are rendered along with the tree
-    this.items.forEach((i: IgcTreeItemComponent) => {
-      i.init = true;
-    });
-    const firstNotDisabledItem = this.items.find(
-      (i: IgcTreeItemComponent) => !i.disabled
-    );
-    if (firstNotDisabledItem) {
-      firstNotDisabledItem.tabIndex = 0;
-      this.navService.focusItem(firstNotDisabledItem);
-    }
-  }
-
-  /* blazorSuppress */
-  /** Returns all of the tree's items. */
-  public get items(): Array<IgcTreeItemComponent> {
-    return Array.from(this.querySelectorAll('igc-tree-item'));
-  }
-
-  private handleKeydown(event: KeyboardEvent) {
-    this.navService.handleKeydown(event);
   }
 
   /* blazorSuppress */


### PR DESCRIPTION
## Description

Rearchitect igc-tree/igc-tree-item's internal wiring while preserving the public API (properties, attributes, events, methods, CSS parts/custom properties) and existing behaviors.

- Replace `closest('igc-tree')` DOM-traversal wiring with a `@lit/context` provider/consumer (new tree.context.ts) so items resolve their owning tree synchronously without querying the DOM.
- Replace `querySelectorAll`-based child/descendant resolution with native light-DOM `.children` traversal; drop support for tree items wrapped in intermediate elements (e.g. `<div>`) in favor of direct nesting.
- Rewrite keyboard navigation on top of the shared `key-bindings` controller instead of a manual keydown switch statement; compute the navigable/visible item set on demand instead of eagerly caching it, removing the O(n²) recompute-on-every-mount root cause of prior sluggishness.
- Fix a real algorithmic issue in child/descendant collection: replace recursive `flatMap` + spread concatenation (quadratic for deeply nested trees) with a single-pass accumulator.
- Add `contain: layout` to the tree container and each tree-item host to scope reflow cost, smoothing out the expand/collapse height animation without reintroducing the compositing/scroll-jank risk that ruled out `content-visibility` for this component.
- Fix keyboard-navigation scroll lag: focus-driven scrollIntoView now scrolls instantly instead of `smooth`, so holding an arrow key no longer causes the visible scroll position to fall behind the actual focused/active item.
- Normalize all private members in tree-item.ts to the project's `_`-prefix convention.

## Type of Change
- [x] Refactoring (code improvements without functional changes)


## Testing

Test suite: adapted tree-utils.spec.ts/tree.spec.ts fixtures for the dropped wrapper-element support; all other specs unchanged and passing against the new implementation (88/88).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally