### PR TITLE
refactor(nav-drawer): use shared theming size tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "husky": "^9.1.7",
         "ig-typedoc-theme": "^7.0.1",
         "igniteui-i18n-resources": "^1.0.5",
-        "igniteui-theming": "^27.3.0",
+        "igniteui-theming": "^27.4.0",
         "keep-a-changelog": "^3.0.5",
         "lint-staged": "^17.0.8",
         "lit-analyzer": "^2.0.3",
@@ -7960,9 +7960,9 @@
       }
     },
     "node_modules/igniteui-theming": {
-      "version": "27.3.0",
-      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-27.3.0.tgz",
-      "integrity": "sha512-9xpPZkMUBSBzA1KzBoXurx61RoaUKW7p/H6CWks+Nh8SehsvAj2j4DSQlT0IR6bb41kRICYVNuyTqMicqLmaLA==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-27.4.0.tgz",
+      "integrity": "sha512-0lxn6jDcPKdEtewxx/q+F0MBGhlfXCx1nzfFRS55GmfcYAexNwAjfjS2MlE+Tc/aN33spDA9GkP6cQNI2s+BdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "husky": "^9.1.7",
     "ig-typedoc-theme": "^7.0.1",
     "igniteui-i18n-resources": "^1.0.5",
-    "igniteui-theming": "^27.3.0",
+    "igniteui-theming": "^27.4.0",
     "keep-a-changelog": "^3.0.5",
     "lint-staged": "^17.0.8",
     "lit-analyzer": "^2.0.3",

--- a/src/components/nav-drawer/themes/container.base.scss
+++ b/src/components/nav-drawer/themes/container.base.scss
@@ -1,8 +1,10 @@
 @use 'styles/common/component';
 @use 'styles/utilities' as *;
+@use './light/themes' as *;
+
+$theme: $base;
 
 :host {
-    --menu-full-width: #{rem(240px)};
     --menu-height: 50vh;
     --transition-function: cubic-bezier(0.445, 0.05, 0.55, 0.95);
     --transition-duration: 0.35s;
@@ -24,7 +26,7 @@
     }
 
     [part='mini'] {
-        width: var(--menu-mini-width);
+        width: var-get($theme, 'size--mini');
         transition-behavior: allow-discrete;
         transition-duration: var(--transition-duration);
         transition-timing-function: var(--transition-function);
@@ -37,7 +39,7 @@
 
     [part='base'] {
         box-sizing: border-box;
-        width: var(--menu-full-width);
+        width: var-get($theme, 'size');
         padding: unset;
         transition-behavior: allow-discrete;
         transition-duration: var(--transition-duration);
@@ -279,7 +281,7 @@
 
 :host(:not([open])[position='relative']) {
     [part='base'] {
-        margin-inline-start: calc(var(--menu-full-width) * -1);
+        margin-inline-start: calc(#{var-get($theme, 'size')} * -1);
         border-color: transparent;
         overflow: hidden;
     }

--- a/src/components/nav-drawer/themes/container.ts
+++ b/src/components/nav-drawer/themes/container.ts
@@ -15,7 +15,6 @@ import { styles as materialLight } from './light/container/nav-drawer.material.c
 import { styles as sharedLight } from './light/container/nav-drawer.shared.css.js';
 // Shared Styles
 import { styles as bootstrap } from './shared/container/nav-drawer.bootstrap.css.js';
-import { styles as fluent } from './shared/container/nav-drawer.fluent.css.js';
 import { styles as indigo } from './shared/container/nav-drawer.indigo.css.js';
 import { styles as material } from './shared/container/nav-drawer.material.css.js';
 
@@ -30,7 +29,7 @@ const light = {
     ${material} ${materialLight}
   `,
   fluent: css`
-    ${fluent} ${fluentLight}
+    ${fluentLight}
   `,
   indigo: css`
     ${indigo} ${indigoLight}
@@ -48,7 +47,7 @@ const dark = {
     ${material} ${materialDark}
   `,
   fluent: css`
-    ${fluent} ${fluentDark}
+    ${fluentDark}
   `,
   indigo: css`
     ${indigo} ${indigoDark}

--- a/src/components/nav-drawer/themes/shared/container/nav-drawer.bootstrap.scss
+++ b/src/components/nav-drawer/themes/shared/container/nav-drawer.bootstrap.scss
@@ -1,9 +1,5 @@
 @use 'styles/utilities' as *;
 
-:host {
-    --menu-mini-width: #{rem(88px)};
-}
-
 [part='mini'],
 [part='main'] {
     padding: pad(rem(16px));

--- a/src/components/nav-drawer/themes/shared/container/nav-drawer.fluent.scss
+++ b/src/components/nav-drawer/themes/shared/container/nav-drawer.fluent.scss
@@ -1,8 +1,0 @@
-@use 'styles/utilities' as *;
-@use '../../light/themes' as *;
-
-$theme: $fluent;
-
-:host {
-    --menu-mini-width: #{rem(40px)};
-}

--- a/src/components/nav-drawer/themes/shared/container/nav-drawer.indigo.scss
+++ b/src/components/nav-drawer/themes/shared/container/nav-drawer.indigo.scss
@@ -4,13 +4,12 @@
 $theme: $indigo;
 
 :host {
-    --menu-mini-width: #{rem(48px)};
-
     [part='base']::backdrop {
         background: var-get($overlay-indigo, 'background-color');
     }
 
-    [part='mini'], [part="main"] {
+    [part='mini'],
+    [part='main'] {
         padding: pad(rem(8px));
     }
 }

--- a/src/components/nav-drawer/themes/shared/container/nav-drawer.material.scss
+++ b/src/components/nav-drawer/themes/shared/container/nav-drawer.material.scss
@@ -1,9 +1,5 @@
 @use 'styles/utilities' as *;
 
-:host {
-    --menu-mini-width: #{rem(56px)};
-}
-
 [part='mini'],
 [part='main'] {
     padding: pad(rem(8px));


### PR DESCRIPTION
Replace the `--menu-full-width` / `--menu-mini-width` custom properties with the `--ig-nav-drawer-size` / `--ig-nav-drawer-size--mini` tokens emitted from the theming schema, aligning nav drawer sizing across platforms. The empty fluent shared style is removed along with its import.

Closes #2240
Depends on https://github.com/IgniteUI/igniteui-theming/pull/590

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (code improvements without functional changes)

## Checklist

- [ ] My code follows the project's coding standards
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [ ] Breaking changes are documented in the description
