### PR TITLE
feat(icon): add stripMeta option to registerIcon and registerIconFromText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- #### Icon
+  - `registerIcon` and `registerIconFromText` now accept a `RegisterIconOptions` object as their third argument in addition to the existing plain collection string. Setting `stripMeta: true` removes `<title>` and `<desc>` elements from the stored SVG, preventing the browser from displaying a native tooltip on hover. The title text is still captured and exposed as the `aria-label` of the host `<igc-icon>` element. Any `aria-labelledby` / `aria-describedby` references on the root `<svg>` that pointed to the stripped elements' IDs are cleaned up automatically. [#1822](https://github.com/IgniteUI/igniteui-webcomponents/issues/1822)
+
 ## [7.2.4] - 2026-06-29
 ### Added
 - #### Form associated custom elements with external labels

--- a/src/components/icon/icon.registry.ts
+++ b/src/components/icon/icon.registry.ts
@@ -8,9 +8,32 @@ import type {
   IconCallback,
   IconMeta,
   IconReferencePair,
+  RegisterIconOptions,
   SvgIcon,
 } from './registry/types.js';
 import { ActionType } from './registry/types.js';
+
+/**
+ * Resolves the stripMeta argument of `registerIcon` / `registerIconFromText`.
+ *
+ * Accepts either the plain-string collection name **or** the
+ * {@link RegisterIconOptions} object, and always returns a fully-resolved
+ * options record so call-sites do not need to branch.
+ *
+ * @internal
+ */
+function resolveIconOptions(
+  collectionOrOptions?: string | RegisterIconOptions
+): Required<RegisterIconOptions> {
+  if (typeof collectionOrOptions === 'string') {
+    return { collection: collectionOrOptions, stripMeta: false };
+  }
+
+  return {
+    collection: collectionOrOptions?.collection ?? 'default',
+    stripMeta: collectionOrOptions?.stripMeta ?? false,
+  };
+}
 
 /**
  * Global singleton registry for managing SVG icons and their references.
@@ -62,6 +85,8 @@ class IconsRegistry {
    * @param name - The unique name for the icon within its collection
    * @param iconText - The SVG markup as a string
    * @param collection - The collection to register the icon in (default: 'default')
+   * @param stripMeta - When `true`, strips `<title>` and `<desc>` elements from
+   *   the SVG before storing it (see {@link RegisterIconOptions.stripMeta}).
    *
    * @remarks
    * This method:
@@ -75,9 +100,10 @@ class IconsRegistry {
   public register(
     name: string,
     iconText: string,
-    collection = 'default'
+    collection = 'default',
+    stripMeta = false
   ): void {
-    const svgIcon = this._svgIconParser.parse(iconText);
+    const svgIcon = this._svgIconParser.parse(iconText, stripMeta);
     this._collections.getOrCreate(collection).set(name, svgIcon);
 
     const icons = createIconDefaultMap<string, SvgIcon>();
@@ -292,36 +318,61 @@ export function getIconRegistry() {
  *
  * @param name - The unique name for the icon
  * @param url - The URL to fetch the SVG icon from
- * @param collection - The collection to register the icon in (default: 'default')
+ * @param collection - The collection to register the icon in (default: `'default'`)
+ *
+ * @returns A promise that resolves when the icon is registered
+ *
+ * @throws If the HTTP request fails or returns a non-OK status
+ */
+export async function registerIcon(
+  name: string,
+  url: string,
+  collection?: string
+): Promise<void>;
+
+/**
+ * Registers an icon by fetching it from a URL.
+ *
+ * @param name - The unique name for the icon
+ * @param url - The URL to fetch the SVG icon from
+ * @param options - Registration options: target collection and/or `stripMeta`
  *
  * @returns A promise that resolves when the icon is registered
  *
  * @throws If the HTTP request fails or returns a non-OK status
  *
  * @remarks
- * This function fetches SVG content from the provided URL and registers it
- * in the icon registry. The icon becomes immediately available to all icon
- * components in the application.
+ * This overload accepts a {@link RegisterIconOptions} object so you can control
+ * the target collection **and** opt into SVG meta stripping in one call:
  *
- * @example
  * ```typescript
- * // Register an icon from a URL
- * await registerIcon('custom-icon', '/assets/icons/custom.svg');
+ * // Strip <title>/<desc> to prevent browser-native tooltips on hover
+ * await registerIcon('home', '/icons/home.svg', { stripMeta: true });
  *
- * // Use in HTML
- * // <igc-icon name="custom-icon"></igc-icon>
+ * // Or with a custom collection:
+ * await registerIcon('home', '/icons/home.svg', {
+ *   collection: 'my-lib',
+ *   stripMeta: true,
+ * });
  * ```
  */
 export async function registerIcon(
   name: string,
   url: string,
-  collection = 'default'
-) {
+  options?: RegisterIconOptions
+): Promise<void>;
+
+export async function registerIcon(
+  name: string,
+  url: string,
+  collectionOrOptions?: string | RegisterIconOptions
+): Promise<void> {
+  const { collection, stripMeta } = resolveIconOptions(collectionOrOptions);
   const response = await fetch(url);
 
   if (response.ok) {
     const value = await response.text();
-    getIconRegistry().register(name, value, collection);
+    getIconRegistry().register(name, value, collection, stripMeta);
   } else {
     throw new Error(`Icon request failed. Status: ${response.status}.`);
   }
@@ -332,32 +383,52 @@ export async function registerIcon(
  *
  * @param name - The unique name for the icon
  * @param iconText - The SVG markup as a string
- * @param collection - The collection to register the icon in (default: 'default')
+ * @param collection - The collection to register the icon in (default: `'default'`)
+ *
+ * @throws If the SVG text is malformed or doesn't contain an SVG element
+ */
+export function registerIconFromText(
+  name: string,
+  iconText: string,
+  collection?: string
+): void;
+
+/**
+ * Registers an icon from SVG text content.
+ *
+ * @param name - The unique name for the icon
+ * @param iconText - The SVG markup as a string
+ * @param options - Registration options: target collection and/or `stripMeta`
  *
  * @throws If the SVG text is malformed or doesn't contain an SVG element
  *
  * @remarks
- * This is the preferred method for registering icons when you have the SVG
- * content directly (e.g., from a bundled asset or inline string). The icon
- * becomes immediately available to all icon components.
+ * This overload accepts a {@link RegisterIconOptions} object so you can control
+ * the target collection **and** opt into SVG meta stripping in one call:
  *
- * The SVG text is parsed to extract viewBox, title, and other metadata.
- *
- * @example
  * ```typescript
- * const iconSvg = '<svg viewBox="0 0 24 24"><path d="..."/></svg>';
- * registerIconFromText('my-icon', iconSvg, 'custom');
+ * const iconSvg = '<svg viewBox="0 0 24 24"><title>Home</title><path d="..."/></svg>';
  *
- * // Use in HTML
- * // <igc-icon name="my-icon" collection="custom"></igc-icon>
+ * // Strip <title>/<desc> to prevent browser-native tooltips on hover
+ * registerIconFromText('home', iconSvg, { stripMeta: true });
+ *
+ * // Or with a custom collection:
+ * registerIconFromText('home', iconSvg, { collection: 'my-lib', stripMeta: true });
  * ```
  */
 export function registerIconFromText(
   name: string,
   iconText: string,
-  collection = 'default'
-) {
-  getIconRegistry().register(name, iconText, collection);
+  options?: RegisterIconOptions
+): void;
+
+export function registerIconFromText(
+  name: string,
+  iconText: string,
+  collectionOrOptions?: string | RegisterIconOptions
+): void {
+  const { collection, stripMeta } = resolveIconOptions(collectionOrOptions);
+  getIconRegistry().register(name, iconText, collection, stripMeta);
 }
 
 /**

--- a/src/components/icon/icon.spec.ts
+++ b/src/components/icon/icon.spec.ts
@@ -82,6 +82,96 @@ describe('Icon registry', () => {
     expect(getIconRegistry().get(name, collection)?.svg).to.not.be.undefined;
   });
 
+  describe('stripMeta option', () => {
+    it('does not strip meta by default (registerIconFromText)', () => {
+      registerIconFromText(name, bugSvg, collection);
+      const icon = getIconRegistry().get(name, collection)!;
+
+      expect(icon.svg).to.include('<title');
+      expect(icon.svg).to.include('<desc');
+      expect(icon.title).to.equal('Bug Icon');
+    });
+
+    it('strips <title> and <desc> when stripMeta is true (registerIconFromText)', () => {
+      registerIconFromText(name, bugSvg, { collection, stripMeta: true });
+      const icon = getIconRegistry().get(name, collection)!;
+
+      expect(icon.svg).not.to.include('<title');
+      expect(icon.svg).not.to.include('<desc');
+    });
+
+    it('still captures title text into SvgIcon.title when stripMeta is true', () => {
+      registerIconFromText(name, bugSvg, { collection, stripMeta: true });
+      const icon = getIconRegistry().get(name, collection)!;
+
+      // Title text is preserved so the host <igc-icon> can still expose it as aria-label.
+      expect(icon.title).to.equal('Bug Icon');
+    });
+
+    it('cleans up aria-labelledby references to stripped element IDs', () => {
+      // bugSvg has aria-labelledby="brbug-desc brbug-title" on the root <svg>.
+      // After stripping, both IDs are gone so the attribute should be removed.
+      registerIconFromText(name, bugSvg, { collection, stripMeta: true });
+      const icon = getIconRegistry().get(name, collection)!;
+
+      expect(icon.svg).not.to.include('aria-labelledby');
+    });
+
+    it('retains aria-labelledby IDs that do not belong to stripped elements', () => {
+      // Construct an SVG where aria-labelledby references one external ID in
+      // addition to the title/desc IDs that will be stripped.
+      const svgWithExtraRef = [
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"',
+        ' aria-labelledby="extra-label brbug-title brbug-desc">',
+        '<title id="brbug-title">Bug Icon</title>',
+        '<desc id="brbug-desc">A picture showing an insect.</desc>',
+        '<path d="M0 0h24v24H0z"/>',
+        '</svg>',
+      ].join('');
+
+      registerIconFromText(name, svgWithExtraRef, {
+        collection,
+        stripMeta: true,
+      });
+      const icon = getIconRegistry().get(name, collection)!;
+
+      // Only the IDs that belonged to stripped elements are removed;
+      // 'extra-label' must survive.
+      expect(icon.svg).to.include('aria-labelledby="extra-label"');
+    });
+
+    it('strips meta when using the options-object form of registerIconFromText with a collection', () => {
+      const altCollection = `${collection}-alt`;
+      registerIconFromText(name, bugSvg, {
+        collection: altCollection,
+        stripMeta: true,
+      });
+      const icon = getIconRegistry().get(name, altCollection)!;
+
+      expect(icon).to.not.be.undefined;
+      expect(icon.svg).not.to.include('<title');
+      expect(icon.svg).not.to.include('<desc');
+      expect(icon.title).to.equal('Bug Icon');
+    });
+
+    it('strips meta when fetching via registerIcon with options object', async () => {
+      await registerIcon(name, '', { collection, stripMeta: true });
+      const icon = getIconRegistry().get(name, collection)!;
+
+      expect(icon.svg).not.to.include('<title');
+      expect(icon.svg).not.to.include('<desc');
+      expect(icon.title).to.equal('Bug Icon');
+    });
+
+    it('old string-collection API still works without stripping', () => {
+      registerIconFromText(name, bugSvg, collection);
+      const icon = getIconRegistry().get(name, collection)!;
+
+      expect(icon.svg).to.include('<title');
+      expect(icon.title).to.equal('Bug Icon');
+    });
+  });
+
   describe('Referential Icons', () => {
     before(() => {
       defineComponents(IgcIconComponent);

--- a/src/components/icon/icon.spec.ts
+++ b/src/components/icon/icon.spec.ts
@@ -50,6 +50,26 @@ function mockResponse() {
   return Promise.resolve(response);
 }
 
+/**
+ * Resolves once `channel` has received `count` messages.
+ * Set up the returned Promise *before* triggering the action so no
+ * message is missed, then await it after.
+ */
+function waitForMessages(
+  channel: BroadcastChannel,
+  count: number
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let n = 0;
+    channel.addEventListener('message', function listener() {
+      if (++n >= count) {
+        channel.removeEventListener('message', listener);
+        resolve();
+      }
+    });
+  });
+}
+
 describe('Icon registry', () => {
   const name = 'test';
   const collection = 'test-collection';
@@ -252,8 +272,9 @@ describe('Icon broadcast service', () => {
     it('correct event state when registering an icon', async () => {
       const iconName = 'bug';
 
+      const ready = waitForMessages(channel, 1);
       registerIconFromText(iconName, bugSvg, collectionName);
-      await aTimeout(0);
+      await ready;
 
       const { actionType, collections } = first(events).data;
       expect(actionType).to.equal(ActionType.RegisterIcon);
@@ -270,10 +291,11 @@ describe('Icon broadcast service', () => {
         ['search', searchSvg],
       ] as const;
 
+      const ready = waitForMessages(channel, icons.length);
       for (const each of icons) {
         registerIconFromText(each[0], each[1], collectionName);
       }
-      await aTimeout(0);
+      await ready;
 
       expect(events).lengthOf(icons.length);
       for (const [idx, event] of events.entries()) {
@@ -291,13 +313,13 @@ describe('Icon broadcast service', () => {
       const refName = 'bug-reference';
       const refCollectionName = 'ref-test';
 
+      const ready = waitForMessages(channel, 2);
       registerIconFromText('reference-test', bugSvg, collectionName);
-
       setIconRef(refName, refCollectionName, {
         name: 'reference-test',
         collection: collectionName,
       });
-      await aTimeout(0);
+      await ready;
 
       const { actionType, collections, references } = last(events).data;
 
@@ -312,12 +334,13 @@ describe('Icon broadcast service', () => {
       const refName = 'bug-reference';
       const refCollectionName = 'ref-test';
 
+      const ready = waitForMessages(channel, 2);
       registerIconFromText('reference-test', bugSvg, collectionName);
       const meta = new IconMetaClass();
       meta.name = 'reference-test';
       meta.collection = collectionName;
       setIconRef(refName, refCollectionName, meta);
-      await aTimeout(0);
+      await ready;
 
       const { actionType, collections, references } = last(events).data;
 
@@ -354,8 +377,9 @@ describe('Icon broadcast service', () => {
       // 1 global one, initialized when you get the icon registry first time.
 
       // a peer is requesting a state sync
+      const ready = waitForMessages(channel, 3);
       channel.postMessage({ actionType: ActionType.SyncState });
-      await aTimeout(20);
+      await ready;
 
       // all icon broadcasts must respond with their state
       // 2 from broadcast service + 1 from global.
@@ -372,11 +396,13 @@ describe('Icon broadcast service', () => {
   describe('Peer registry', () => {
     it('registered icon is correctly sent when a peer requests a sync states', async () => {
       const iconName = 'bug';
-      registerIconFromText(iconName, bugSvg, collectionName);
 
-      // a peer is requesting a state sync
+      // registerIconFromText fires RegisterIcon; the SyncState postMessage
+      // triggers a SyncState response from the registry — 2 messages total.
+      const ready = waitForMessages(channel, 2);
+      registerIconFromText(iconName, bugSvg, collectionName);
       channel.postMessage({ actionType: ActionType.SyncState });
-      await aTimeout(0);
+      await ready;
 
       expect(events).lengthOf(2); // [ActionType.RegisterIcon, ActionType.SyncState]
 
@@ -399,9 +425,11 @@ describe('Icon broadcast service', () => {
         overwrite: true,
       });
 
-      // a peer is requesting a state sync
+      // setIconRef with external:false fires no broadcast; the SyncState
+      // postMessage triggers exactly one SyncState response.
+      const ready = waitForMessages(channel, 1);
       channel.postMessage({ actionType: ActionType.SyncState });
-      await aTimeout(0);
+      await ready;
 
       expect(events).lengthOf(1); // [ActionType.SyncState]
 
@@ -607,8 +635,9 @@ describe('DefaultMap serialization for cross-browser compatibility', () => {
   });
 
   it('broadcasted collections data is sent as plain Maps', async () => {
+    const ready = waitForMessages(channel, 1);
     registerIconFromText('test-icon', bugSvg, collectionName);
-    await aTimeout(0);
+    await ready;
 
     const { collections } = first(events).data;
 
@@ -622,6 +651,7 @@ describe('DefaultMap serialization for cross-browser compatibility', () => {
   });
 
   it('broadcasted references data is sent as plain Maps', async () => {
+    const ready = waitForMessages(channel, 2);
     registerIconFromText('ref-test', bugSvg, collectionName);
     const refName = 'bug-ref';
     const refCollection = 'ref-collection';
@@ -630,7 +660,7 @@ describe('DefaultMap serialization for cross-browser compatibility', () => {
       name: 'ref-test',
       collection: collectionName,
     });
-    await aTimeout(0);
+    await ready;
 
     const { references } = last(events).data;
 
@@ -644,8 +674,9 @@ describe('DefaultMap serialization for cross-browser compatibility', () => {
   });
 
   it('nested plain Maps can be structured cloned and transmitted safely', async () => {
+    const ready = waitForMessages(channel, 1);
     registerIconFromText('nested-icon', bugSvg, collectionName);
-    await aTimeout(0);
+    await ready;
 
     const { collections } = first(events).data;
 

--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -203,9 +203,10 @@ export default class IgcIconComponent extends LitElement {
   protected async registerIcon(
     name: string,
     url: string,
-    collection = 'default'
+    collection = 'default',
+    stripMeta = false
   ) {
-    await registerIcon_impl(name, url, collection);
+    await registerIcon_impl(name, url, { collection, stripMeta });
   }
 
   /* c8 ignore next 8 */
@@ -213,9 +214,10 @@ export default class IgcIconComponent extends LitElement {
   protected registerIconFromText(
     name: string,
     iconText: string,
-    collection = 'default'
+    collection = 'default',
+    stripMeta = false
   ) {
-    registerIconFromText_impl(name, iconText, collection);
+    registerIconFromText_impl(name, iconText, { collection, stripMeta });
   }
 
   /* c8 ignore next 4 */

--- a/src/components/icon/registry/parser.ts
+++ b/src/components/icon/registry/parser.ts
@@ -1,5 +1,8 @@
 import type { SvgIcon } from './types.js';
 
+/** ARIA attributes that may reference stripped element IDs and need to be cleaned up. */
+const ARIA_ID_REF_ATTRS = ['aria-labelledby', 'aria-describedby'] as const;
+
 /* blazorSuppress */
 export class SvgIconParser {
   private _parser: DOMParser;
@@ -8,7 +11,18 @@ export class SvgIconParser {
     this._parser = new DOMParser();
   }
 
-  public parse(svgString: string): SvgIcon {
+  /**
+   * Parses an SVG string into a {@link SvgIcon} descriptor.
+   *
+   * @param svgString - Raw SVG markup to parse.
+   * @param stripMeta - When `true`, removes `<title>` and `<desc>` child
+   *   elements from the SVG and cleans up any `aria-labelledby` /
+   *   `aria-describedby` references on the root element that pointed to the
+   *   stripped nodes' IDs. The extracted title text is still returned in
+   *   {@link SvgIcon.title} so the host `<igc-icon>` can use it as its
+   *   `aria-label`. Defaults to `false`.
+   */
+  public parse(svgString: string, stripMeta = false): SvgIcon {
     const root = this._parser.parseFromString(svgString, 'image/svg+xml');
     const svg = root.querySelector('svg');
     const error = root.querySelector('parsererror');
@@ -17,14 +31,64 @@ export class SvgIconParser {
       throw new Error('SVG element not found or malformed SVG string.');
     }
 
-    const title = svg.querySelector('title')?.textContent ?? '';
-
     svg.setAttribute('fit', '');
     svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
 
-    return {
-      svg: svg.outerHTML,
-      title,
-    };
+    const titleEl = svg.querySelector('title');
+    const descEl = svg.querySelector('desc');
+    const title = titleEl?.textContent ?? '';
+
+    if (stripMeta) {
+      this._stripMetaElements(svg, titleEl, descEl);
+    }
+
+    return { svg: svg.outerHTML, title };
+  }
+
+  /**
+   * Removes `<title>` and `<desc>` from the SVG element and repairs any ARIA
+   * ID-reference attributes (`aria-labelledby`, `aria-describedby`) that
+   * pointed to the stripped nodes.
+   *
+   * @remarks
+   * Leaving dangling ARIA ID references after removing their target elements
+   * would produce invalid markup. Collect the IDs of both stripped elements
+   * and rebuilds each reference attribute, keeping only IDs
+   * that still resolve to an existing node. When all referenced IDs are
+   * stripped the attribute is removed entirely.
+   */
+  private _stripMetaElements(
+    svg: SVGElement,
+    title: Element | null,
+    desc: Element | null
+  ): void {
+    const strippedIds = new Set(
+      [title?.id, desc?.id].filter((id): id is string => Boolean(id))
+    );
+
+    title?.remove();
+    desc?.remove();
+
+    if (strippedIds.size === 0) {
+      return;
+    }
+
+    for (const attr of ARIA_ID_REF_ATTRS) {
+      const value = svg.getAttribute(attr);
+
+      if (!value) continue;
+
+      const cleaned = value
+        .split(/\s+/)
+        .filter((id) => !strippedIds.has(id))
+        .join(' ')
+        .trim();
+
+      if (cleaned) {
+        svg.setAttribute(attr, cleaned);
+      } else {
+        svg.removeAttribute(attr);
+      }
+    }
   }
 }

--- a/src/components/icon/registry/parser.ts
+++ b/src/components/icon/registry/parser.ts
@@ -53,9 +53,8 @@ export class SvgIconParser {
    * @remarks
    * Leaving dangling ARIA ID references after removing their target elements
    * would produce invalid markup. Collect the IDs of both stripped elements
-   * and rebuilds each reference attribute, keeping only IDs
-   * that still resolve to an existing node. When all referenced IDs are
-   * stripped the attribute is removed entirely.
+   * and rebuild each reference attribute by filtering out those IDs. When all
+   * referenced IDs are stripped, the attribute is removed entirely.
    */
   private _stripMetaElements(
     svg: SVGElement,

--- a/src/components/icon/registry/types.ts
+++ b/src/components/icon/registry/types.ts
@@ -45,3 +45,48 @@ export interface IconMeta {
   collection: string;
   external?: boolean;
 }
+
+/**
+ * Options for registering an SVG icon.
+ *
+ * @remarks
+ * Can be passed as the third argument to `registerIcon` or `registerIconFromText`
+ * in place of a plain collection string, giving you control over both the
+ * target collection and SVG metadata stripping in a single, named-parameter call.
+ *
+ * @example:
+ * ```typescript
+ * registerIconFromText('home', svg, { collection: 'my-collection', stripMeta: true });
+ * ```
+ */
+export interface RegisterIconOptions {
+  /**
+   * The collection to register the icon in.
+   * @default 'default'
+   */
+  collection?: string;
+
+  /**
+   * Whether to strip SVG meta elements (`<title>` and `<desc>`) from the icon
+   * before storing it.
+   *
+   * @remarks
+   * SVG `<title>` elements cause the browser to display a native tooltip when
+   * the user hovers over the icon — an undesirable side-effect when using icon
+   * packs such as `@igniteui/material-icons-extended` that embed accessible
+   * metadata inside every icon.
+   *
+   * When `stripMeta` is `true`:
+   * - The `<title>` and `<desc>` child elements are removed from the stored SVG.
+   * - Any `aria-labelledby` / `aria-describedby` references on the root
+   *   `<svg>` element that pointed to the stripped elements' IDs are cleaned up
+   *   so the resulting markup contains no dangling ARIA references.
+   * - The **title text** is still captured and stored as `SvgIcon.title`, which
+   *   the `<igc-icon>` component continues to expose as its host `aria-label`.
+   *   Accessibility is therefore preserved at the component level while the
+   *   browser tooltip is suppressed at the SVG level.
+   *
+   * @default false
+   */
+  stripMeta?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,10 @@ export type {
   GroupingDirection,
   IgcComboChangeEventArgs,
 } from './components/combo/types.js';
-export type { IconMeta } from './components/icon/registry/types.js';
+export type {
+  IconMeta,
+  RegisterIconOptions,
+} from './components/icon/registry/types.js';
 export type * from './components/chat/types.js';
 
 // Internal exports for other packages


### PR DESCRIPTION
## Description

Adds a RegisterIconOptions object accepted as the third argument of both registration functions (backward-compatible with the existing string form). When stripMeta is true, the parser removes <title> and <desc> from the stored SVG, preventing browser-native tooltips on hover, and cleans up any aria-labelledby/aria-describedby references on the root <svg> that pointed to the stripped elements' IDs. The title text is still captured into SvgIcon.title so the host <igc-icon> continues to expose it as aria-label.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Closes #1822

## Testing

Added new automated tests and manually tested the feature.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
