### PR TITLE
docs(splitter): Persist pane size in the persisted layout story

### DIFF
--- a/stories/splitter.stories.ts
+++ b/stories/splitter.stories.ts
@@ -368,20 +368,25 @@ export const PersistedLayout: Story = {
     docs: {
       description: {
         story:
-          'Demonstrates reading/writing the `startCollapsed`/`endCollapsed` properties and listening for ' +
-          '`igcExpansionChanged` to persist the collapsed state (e.g. in `localStorage`) and restore it on load.',
+          'Demonstrates reading/writing the `startSize` and `startCollapsed`/`endCollapsed` properties and listening for ' +
+          '`igcResizeEnd`/`igcExpansionChanged` to persist the pane size and collapsed state (e.g. in `localStorage`) ' +
+          'and restore them on load.',
       },
     },
   },
   render: () => {
     const saved = localStorage.getItem(PERSISTED_LAYOUT_KEY);
-    const startCollapsed = saved ? JSON.parse(saved).startCollapsed : false;
-    const endCollapsed = saved ? JSON.parse(saved).endCollapsed : false;
+    const layout = saved ? JSON.parse(saved) : null;
+
+    const startSize = layout?.startSize ?? '50%';
+    const startCollapsed = layout?.startCollapsed ?? false;
+    const endCollapsed = layout?.endCollapsed ?? false;
 
     function persist(splitter: IgcSplitterComponent) {
       localStorage.setItem(
         PERSISTED_LAYOUT_KEY,
         JSON.stringify({
+          startSize: splitter.startSize,
           startCollapsed: splitter.startCollapsed,
           endCollapsed: splitter.endCollapsed,
         })
@@ -398,10 +403,13 @@ export const PersistedLayout: Story = {
 
       <igc-splitter
         style="height: 400px;"
+        .startSize=${startSize}
         .startCollapsed=${startCollapsed}
         .endCollapsed=${endCollapsed}
+        @igcResizeEnd=${(e: CustomEvent) =>
+        persist(e.target as IgcSplitterComponent)}
         @igcExpansionChanged=${(e: CustomEvent) =>
-          persist(e.target as IgcSplitterComponent)}
+        persist(e.target as IgcSplitterComponent)}
       >
         <div slot="start" class="demo-pane">
           <strong>Start panel</strong>

--- a/stories/splitter.stories.ts
+++ b/stories/splitter.stories.ts
@@ -407,9 +407,9 @@ export const PersistedLayout: Story = {
         .startCollapsed=${startCollapsed}
         .endCollapsed=${endCollapsed}
         @igcResizeEnd=${(e: CustomEvent) =>
-        persist(e.target as IgcSplitterComponent)}
+          persist(e.target as IgcSplitterComponent)}
         @igcExpansionChanged=${(e: CustomEvent) =>
-        persist(e.target as IgcSplitterComponent)}
+          persist(e.target as IgcSplitterComponent)}
       >
         <div slot="start" class="demo-pane">
           <strong>Start panel</strong>


### PR DESCRIPTION
## Description

First of all, thank you for working on this feature. I tried the new `PersistedLayout` story, and the collapse/expand events worked very nicely. 

However, I noticed that the story only saves and restores the collapsed state. The pane size is not restored after a reload. Since the story is named "Persisted Layout", I think saving the pane size too would make it a better example of real world usage.

So this PR extends the story to also save and restore `startSize` by listening for the `igcResizeEnd` event. The story description in the docs is updated accordingly. There is no change to the component itself, only to the story.

## Type of Change

- [x] Documentation update

## Related Issues

Related to #2297 and #2299 (this PR targets the `rkaraivanov/splitter-collapsed-panes-state` branch)

## Testing

I ran Storybook locally and checked the `PersistedLayout` story in Chrome:

1. Drag the splitter bar, then reload the page. The pane size is restored.
2. Collapse a pane, then reload the page. The collapsed state is restored, as before.
3. Clear `localStorage` and reload. The story starts from the default 50% layout.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
