### PR TITLE
fix(combo): correct selection/filtering bugs and speed up large data sets

### DIFF
--- a/src/components/combo/combo.spec.ts
+++ b/src/components/combo/combo.spec.ts
@@ -613,6 +613,40 @@ describe('Combo', () => {
       expect(eventSpy).calledWithExactly('igcChange', args);
     });
 
+    it('should not repeat a value in newValue when data records share a value key', async () => {
+      const twins = [
+        { id: 'a', name: 'first-a', country: 'X', zip: '1' },
+        { id: 'b', name: 'bee', country: 'X', zip: '2' },
+        { id: 'a', name: 'second-a', country: 'X', zip: '3' },
+      ];
+      combo = await fixture<IgcComboComponent<City>>(
+        html`<igc-combo
+          .data=${twins}
+          value-key="id"
+          display-key="name"
+        ></igc-combo>`
+      );
+
+      // The value setter resolves the first match only, so just one of the
+      // two 'a' records starts out selected.
+      combo.value = ['a'];
+      await elementUpdated(combo);
+
+      let newValue: unknown;
+      combo.addEventListener('igcChange', (event: CustomEvent) => {
+        newValue = event.detail.newValue;
+      });
+
+      await openComboPopover(combo);
+
+      // Selecting the twin resolves both 'a' records, one of which is already
+      // in the selection.
+      items(combo)[2].click();
+      await elementUpdated(combo);
+
+      expect(newValue).to.eql(combo.value);
+    });
+
     it('should fire igcChange deselection type event on mouse click', async () => {
       const eventSpy = spy(combo, 'emitEvent');
       const args = {

--- a/src/components/combo/combo.spec.ts
+++ b/src/components/combo/combo.spec.ts
@@ -618,6 +618,25 @@ describe('Combo', () => {
       expect(combo.value).lengthOf(2);
     });
 
+    it('should keep the previous selection when cancelling the selection event in single selection mode', async () => {
+      combo.singleSelect = true;
+      combo.select('BG02');
+      await elementUpdated(combo);
+
+      combo.addEventListener('igcChange', (event: CustomEvent) => {
+        event.preventDefault();
+      });
+      combo.open = true;
+
+      await comboStable(combo);
+
+      first(items(combo)).click();
+      await elementUpdated(combo);
+
+      expect(combo.value).to.eql(['BG02']);
+      expect(input.value).to.equal('Plovdiv');
+    });
+
     it('should not stringify values in event', async () => {
       interface CustomValue {
         id: number;
@@ -1396,6 +1415,18 @@ describe('Combo', () => {
       expect(items(combo).length).to.equal(cities.length);
     });
 
+    it('should not filter via the main input when disableFiltering is set', async () => {
+      combo.singleSelect = true;
+      combo.disableFiltering = true;
+      await elementUpdated(combo);
+
+      await openComboPopover(combo);
+      expect(items(combo).length).to.equal(cities.length);
+
+      await filterCombo('sof');
+      expect(items(combo).length).to.equal(cities.length);
+    });
+
     it('issue 1987 - do not close the dropdown on user pointer selection', async () => {
       await openComboPopover(combo);
 
@@ -1488,6 +1519,72 @@ describe('Combo', () => {
 
       expect(combo.value).to.be.empty;
       expect(input.value).to.equal('');
+    });
+  });
+
+  describe('ARIA', () => {
+    beforeEach(async () => {
+      combo = await fixture<IgcComboComponent<City>>(
+        html`<igc-combo
+          .data=${cities}
+          value-key="id"
+          display-key="name"
+          group-key="country"
+        ></igc-combo>`
+      );
+
+      options = combo.renderRoot.querySelector(
+        '[part="list"]'
+      ) as IgcVirtualScrollComponent;
+      input = combo.renderRoot.querySelector(
+        'igc-input#target'
+      ) as IgcInputComponent;
+    });
+
+    it('should report posinset/setsize excluding group headers', async () => {
+      await openComboPopover(combo);
+
+      const rendered = items(combo);
+      expect(rendered).lengthOf(cities.length);
+      expect(headerItems(combo)).lengthOf(2);
+
+      for (const [index, item] of rendered.entries()) {
+        expect(item.getAttribute('aria-posinset')).to.equal(`${index + 1}`);
+        expect(item.getAttribute('aria-setsize')).to.equal(`${cities.length}`);
+      }
+    });
+
+    it('should renumber posinset/setsize when the options are filtered', async () => {
+      await openComboPopover(combo);
+      await filterCombo('a');
+
+      const rendered = items(combo);
+      expect(rendered.length).to.be.lessThan(cities.length);
+
+      for (const [index, item] of rendered.entries()) {
+        expect(item.getAttribute('aria-posinset')).to.equal(`${index + 1}`);
+        expect(item.getAttribute('aria-setsize')).to.equal(
+          `${rendered.length}`
+        );
+      }
+    });
+
+    it('should point aria-activedescendant at the active option and drop it on close', async () => {
+      await openComboPopover(combo);
+
+      expect(options.getAttribute('aria-activedescendant')).to.be.null;
+
+      simulateKeyboard(options, arrowDown);
+      await comboStable(combo);
+
+      const active = items(combo).find((item) => item.active)!;
+      expect(active).to.not.be.undefined;
+      expect(options.getAttribute('aria-activedescendant')).to.equal(active.id);
+
+      await combo.hide();
+      await elementUpdated(combo);
+
+      expect(options.getAttribute('aria-activedescendant')).to.be.null;
     });
   });
 

--- a/src/components/combo/combo.spec.ts
+++ b/src/components/combo/combo.spec.ts
@@ -251,6 +251,58 @@ describe('Combo', () => {
       await expect(combo).to.be.accessible();
     });
 
+    it('picks up items appended to the data array in place', async () => {
+      const data = [...cities];
+      combo = await fixture<IgcComboComponent<City>>(
+        html`<igc-combo
+          .data=${data}
+          value-key="id"
+          display-key="name"
+        ></igc-combo>`
+      );
+      input = combo.renderRoot.querySelector(
+        'igc-input#target'
+      ) as IgcInputComponent;
+
+      // Warm both the value index and the data pipeline
+      combo.select('BG01');
+      await openComboPopover(combo);
+      expect(items(combo)).lengthOf(cities.length);
+
+      data.push({
+        id: 'BG04',
+        name: 'Burgas',
+        country: 'Bulgaria',
+        zip: '8000',
+      });
+      combo.select('BG04');
+      await comboStable(combo);
+
+      expect(combo.value).to.eql(['BG01', 'BG04']);
+      expect(items(combo)).lengthOf(cities.length + 1);
+    });
+
+    it('picks up items removed from the data array in place', async () => {
+      const data = [...cities];
+      combo = await fixture<IgcComboComponent<City>>(
+        html`<igc-combo
+          .data=${data}
+          value-key="id"
+          display-key="name"
+        ></igc-combo>`
+      );
+
+      combo.select('BG01');
+      await openComboPopover(combo);
+      expect(items(combo)).lengthOf(cities.length);
+
+      data.splice(0, 1);
+      combo.deselect('BG02');
+      await comboStable(combo);
+
+      expect(items(combo)).lengthOf(cities.length - 1);
+    });
+
     it('is successfully created with default properties.', () => {
       expect(document.querySelector('igc-combo')).to.exist;
       expect(combo.data).to.equal(cities);

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -807,7 +807,7 @@ export default class IgcComboComponent<
   private _previewValue(resolved: T[], selecting: boolean): ComboValue<T>[] {
     if (selecting) {
       return this._toValues(
-        this.singleSelect ? resolved : [...resolved, ...this._selected]
+        this.singleSelect ? resolved : new Set([...resolved, ...this._selected])
       );
     }
 

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -27,7 +27,6 @@ import {
   bindIf,
   first,
   getElementFromPath,
-  isDefined,
   isEmpty,
   stopPropagation,
 } from '../common/util.js';
@@ -56,7 +55,6 @@ import type {
   IgcComboComponentEventMap,
   Item,
   Keys,
-  Values,
 } from './types.js';
 import { comboValidators } from './validators.js';
 
@@ -230,14 +228,17 @@ export default class IgcComboComponent<
   );
 
   private _data: T[] = [];
+  private _index?: Map<Item<T>, number[]>;
   private _valueKey?: Keys<T>;
   private _displayKey?: Keys<T>;
   private _placeholderSearch?: string;
   private _disableFiltering = false;
   private _singleSelect = false;
   private _selected: Set<T> = new Set();
+  // `filterKey` is left unset here - both key fields are still undefined at
+  // field-initialization time. The `displayKey` setter fills it in.
   private _filteringOptions: FilteringOptions<T> = {
-    filterKey: this.displayKey,
+    filterKey: undefined,
     caseSensitive: false,
     matchDiacritics: false,
   };
@@ -262,10 +263,21 @@ export default class IgcComboComponent<
   }
 
   @state()
-  private _activeDescendant?: string;
-
-  @state()
   private _displayValue = '';
+
+  /** The DOM id of the option rendered at `index` in the current data state. */
+  private _itemId(index: number): string {
+    const position = index + 1;
+    return this.id ? `${this.id}-item-${position}` : `item-${position}`;
+  }
+
+  /**
+   * Derived from {@link _activeIndex} rather than tracked separately, so that it
+   * cannot go stale and does not have to be assigned while rendering an item.
+   */
+  private get _activeDescendant(): string | undefined {
+    return this._activeIndex > -1 ? this._itemId(this._activeIndex) : undefined;
+  }
 
   private get _mainAriaLabel(): string {
     return isEmpty(this._selected)
@@ -281,9 +293,8 @@ export default class IgcComboComponent<
   /* treatAsRef */
   @property({ attribute: false })
   public set data(value: T[]) {
-    if (this._data !== value) {
-      this._data = asArray(value);
-    }
+    this._data = asArray(value);
+    this._index = undefined;
   }
 
   public get data(): T[] {
@@ -309,11 +320,11 @@ export default class IgcComboComponent<
     this._syncSelectionFromValue();
 
     if (this.hasUpdated) {
-      const pristine = this._pristine;
-      this._activeIndex = -1;
-      this._searchTerm = '';
-      this._formValue.setValueAndFormState(this.value);
-      this._pristine = pristine;
+      this._withPristine(() => {
+        this._activeIndex = -1;
+        this._searchTerm = '';
+        this._formValue.setValueAndFormState(this.value);
+      });
     }
   }
 
@@ -401,6 +412,7 @@ export default class IgcComboComponent<
   public set valueKey(value: Keys<T> | undefined) {
     this._valueKey = value;
     this._displayKey = this._displayKey ?? this._valueKey;
+    this._index = undefined;
   }
 
   public get valueKey() {
@@ -596,11 +608,23 @@ export default class IgcComboComponent<
     // When data changes, re-sync selection and form
     // This handles the delayed data scenario where value was set before data
     if (props.has('data') && !isEmpty(this.data) && !isEmpty(this.value)) {
-      const pristine = this._pristine;
-      this._syncSelectionFromValue();
-      this._formValue.setValueAndFormState(this.value);
-      this._pristine = pristine;
+      this._withPristine(() => {
+        this._syncSelectionFromValue();
+        this._formValue.setValueAndFormState(this.value);
+      });
     }
+  }
+
+  /**
+   * Runs `callback`, restoring the pristine flag afterwards.
+   *
+   * Re-syncing the form value in reaction to a configuration change (as opposed
+   * to user interaction) must not count as the control having been dirtied.
+   */
+  private _withPristine(callback: () => void): void {
+    const pristine = this._pristine;
+    callback();
+    this._pristine = pristine;
   }
 
   protected override updated(props: PropertyValues<this>): void {
@@ -622,7 +646,10 @@ export default class IgcComboComponent<
   protected override _setDefaultValue(current: string | null): void {
     try {
       this.defaultValue = JSON.parse(current || '[]');
-    } catch {}
+    } catch {
+      // A malformed `value` attribute keeps the previous default rather than
+      // discarding it - see the "invalid JSON" form integration test.
+    }
   }
 
   // #endregion
@@ -672,17 +699,41 @@ export default class IgcComboComponent<
   // #region Selection helpers
 
   /**
+   * Maps every value representation in the data source to the positions of the
+   * records carrying it. Built on demand and dropped whenever `data` or
+   * `valueKey` changes.
+   *
+   * Positions (rather than records) are stored so that resolution can hand back
+   * matches in data-source order, and duplicate value keys keep resolving to
+   * every record that carries them.
+   */
+  private get _dataIndex(): Map<Item<T>, number[]> {
+    this._index ??= Map.groupBy(this.data.keys(), (position) =>
+      this._resolveItemValue(this.data[position])
+    );
+
+    return this._index;
+  }
+
+  /**
    * Resolves user-provided items (value keys or object references)
-   * to actual objects from the data source in a single pass.
+   * to actual objects from the data source, in data-source order.
    */
   private _resolveItems(items: Item<T>[]): T[] {
-    if (this.valueKey) {
-      const keys = new Set(items as Values<T>[]);
-      return this.data.filter((item) => keys.has(item[this.valueKey!]));
+    const index = this._dataIndex;
+    const positions: number[] = [];
+
+    for (const item of items) {
+      const matches = index.get(item);
+
+      if (matches) {
+        positions.push(...matches);
+      }
     }
 
-    const dataSet = new Set(this.data);
-    return (items as T[]).filter((item) => dataSet.has(item));
+    return positions
+      .sort((a, b) => a - b)
+      .map((position) => this.data[position]);
   }
 
   /**
@@ -694,108 +745,134 @@ export default class IgcComboComponent<
   }
 
   /**
-   * Maps data items to their value representations using the given key.
-   * When key is undefined, returns the items themselves.
+   * Maps data records to their value representations - the `valueKey` property
+   * of each, or the record itself when no `valueKey` is set.
    */
-  private _getValues(items: Iterable<T>, key?: Keys<T>): ComboValue<T>[] {
-    return Iterator.from(items)
-      .map((item) => (key ? item[key] : undefined) ?? item)
-      .toArray();
+  private _toValues(items: Iterable<T>): ComboValue<T>[] {
+    const { valueKey } = this;
+    const values: ComboValue<T>[] = [];
+
+    for (const item of items) {
+      values.push((valueKey ? item[valueKey] : undefined) ?? item);
+    }
+
+    return values;
+  }
+
+  /**
+   * Recomputes {@link _displayValue} from the current selection and returns its
+   * value representation, walking the selection once for both projections.
+   */
+  private _projectSelection(): ComboValue<T>[] {
+    const { valueKey, displayKey } = this;
+    const values: ComboValue<T>[] = [];
+    const display: string[] = [];
+
+    for (const item of this._selected) {
+      values.push((valueKey ? item[valueKey] : undefined) ?? item);
+      display.push(String((displayKey ? item[displayKey] : undefined) ?? item));
+    }
+
+    this._displayValue = display.join(', ');
+    return values;
   }
 
   private _emitSelectionChange(detail: IgcComboChangeEventArgs): boolean {
     return this.emitEvent('igcChange', { cancelable: true, detail });
   }
 
-  private _selectItems(items?: Item<T> | Item<T>[], emit = false): void {
-    let collection = asArray(items);
+  /**
+   * Builds the value the component would have if `resolved` were applied to the
+   * current selection. Used as the `newValue` payload of the change event.
+   */
+  private _previewValue(resolved: T[], selecting: boolean): ComboValue<T>[] {
+    if (selecting) {
+      return this._toValues(
+        this.singleSelect ? resolved : [...resolved, ...this._selected]
+      );
+    }
 
-    if (this.singleSelect) {
+    const removed = new Set(resolved);
+
+    return this._toValues(
+      Iterator.from(this._selected).filter((item) => !removed.has(item))
+    );
+  }
+
+  /**
+   * Adds the given `items` to, or removes them from, the current selection.
+   *
+   * An empty collection is a "select all" / "deselect all" request. Single
+   * selection has no "select all" - it only resets the current selection.
+   *
+   * When `emit` is set, the cancellable `igcChange` event is fired *before* any
+   * mutation takes place, so cancelling it leaves the selection untouched.
+   *
+   * @returns Whether the change was committed.
+   */
+  private _updateSelection(
+    items: Item<T> | Item<T>[] | undefined,
+    type: 'selection' | 'deselection',
+    emit: boolean
+  ): boolean {
+    const singleSelect = this.singleSelect;
+    const selecting = type === 'selection';
+    const collection = singleSelect
+      ? asArray(items).slice(0, 1)
+      : asArray(items);
+
+    if (isEmpty(collection)) {
+      if (selecting) {
+        this._selected = singleSelect ? new Set() : new Set(this.data);
+
+        if (singleSelect) {
+          this._searchTerm = '';
+        }
+      } else {
+        if (
+          emit &&
+          !this._emitSelectionChange({
+            newValue: [],
+            items: this.selection,
+            type,
+          })
+        ) {
+          return false;
+        }
+
+        this._selected.clear();
+      }
+
+      this.requestUpdate();
+      return true;
+    }
+
+    const resolved = this._resolveItems(collection);
+
+    if (
+      emit &&
+      !this._emitSelectionChange({
+        newValue: this._previewValue(resolved, selecting),
+        items: resolved,
+        type,
+      })
+    ) {
+      return false;
+    }
+
+    // Past this point the change is committed - only now is it safe to drop
+    // the previous single selection and its search term.
+    if (selecting && singleSelect) {
       this._selected.clear();
       this._searchTerm = '';
     }
 
-    if (isEmpty(collection)) {
-      if (!this.singleSelect) {
-        this._selected = new Set(this.data);
-        this.requestUpdate();
-      }
-      return;
-    }
-
-    if (this.singleSelect) {
-      collection = collection.slice(0, 1);
-    }
-
-    const resolved = this._resolveItems(collection);
-
-    if (
-      emit &&
-      !this._emitSelectionChange({
-        newValue: this._getValues(
-          [...resolved, ...this._selected],
-          this.valueKey
-        ),
-        items: resolved,
-        type: 'selection',
-      })
-    ) {
-      return;
-    }
-
     for (const item of resolved) {
-      this._selected.add(item);
+      selecting ? this._selected.add(item) : this._selected.delete(item);
     }
 
     this.requestUpdate();
-  }
-
-  private _deselectItems(items?: Item<T> | Item<T>[], emit = false): void {
-    let collection = asArray(items);
-
-    if (isEmpty(collection)) {
-      if (
-        emit &&
-        !this._emitSelectionChange({
-          newValue: [],
-          items: Array.from(this._selected),
-          type: 'deselection',
-        })
-      ) {
-        return;
-      }
-
-      this._selected.clear();
-      this.requestUpdate();
-      return;
-    }
-
-    if (this.singleSelect) {
-      collection = collection.slice(0, 1);
-    }
-
-    const resolved = this._resolveItems(collection);
-    const resolvedSet = new Set(resolved);
-    const remaining = Array.from(this._selected).filter(
-      (item) => !resolvedSet.has(item)
-    );
-
-    if (
-      emit &&
-      !this._emitSelectionChange({
-        newValue: this._getValues(remaining, this.valueKey),
-        items: resolved,
-        type: 'deselection',
-      })
-    ) {
-      return;
-    }
-
-    for (const item of resolved) {
-      this._selected.delete(item);
-    }
-
-    this.requestUpdate();
+    return true;
   }
 
   /**
@@ -814,58 +891,66 @@ export default class IgcComboComponent<
         this._formValue.setValueAndFormState(values);
       }
 
-      const items = Iterator.from(values)
-        .map((val) => this._findItemByValue(val, this.valueKey))
-        .filter(isDefined);
+      const index = this._dataIndex;
 
-      for (const item of items) {
-        this._selected.add(item);
+      for (const value of values) {
+        // First match only - mirrors resolving a value against the data source
+        const position = index.get(value)?.[0];
+
+        if (position !== undefined) {
+          this._selected.add(this.data[position]);
+        }
       }
     }
 
-    this._displayValue = this._getValues(this._selected, this.displayKey).join(
-      ', '
-    );
+    this._projectSelection();
+  }
+
+  protected _syncValueFromSelection(): void {
+    this._formValue.setValueAndFormState(this._projectSelection());
+    this._setSingleSelectionDisplayValue(this._displayValue);
+    this._validate();
+    this._listRef.value?.requestUpdate();
   }
 
   /**
-   * Finds an item in the data array by its value (or value key).
-   * Returns undefined if the item is not found.
+   * The data record rendered at `index`, or undefined when that position holds
+   * a group header instead of a selectable option.
+   *
+   * Guarding on this matters: an unresolvable record would reach
+   * {@link _updateSelection} as an empty collection, which reads as
+   * "select everything".
    */
-  private _findItemByValue(value: ComboValue<T>, key?: Keys<T>): T | undefined {
-    return this.data.find((item) => (key ? item[key] : item) === value);
-  }
-
-  protected _syncValueFromSelection(initial = false): void {
-    const values = this._getValues(this._selected, this.valueKey);
-    this._displayValue = this._getValues(this._selected, this.displayKey).join(
-      ', '
-    );
-    this._formValue.setValueAndFormState(values);
-
-    if (!initial) {
-      this._setSingleSelectionDisplayValue(this._displayValue);
-      this._validate();
-      this._listRef.value?.requestUpdate();
-    }
+  private _recordAt(index: number): T | undefined {
+    const record = this._state.dataState[index];
+    return record && !record.header ? record.value : undefined;
   }
 
   private _toggleSelection(index: number): void {
-    const record = this.data[this._state.dataState[index].dataIndex];
+    const record = this._recordAt(index);
 
-    this._selected.has(record)
-      ? this._deselectItems(this._resolveItemValue(record), true)
-      : this._selectItems(this._resolveItemValue(record), true);
+    if (!record) {
+      return;
+    }
+
+    this._updateSelection(
+      this._resolveItemValue(record),
+      this._selected.has(record) ? 'deselection' : 'selection',
+      true
+    );
 
     this._activeIndex = index;
     this._syncValueFromSelection();
   }
 
   private _selectByIndex(index: number): void {
-    this._selectItems(
-      this._resolveItemValue(this.data[this._state.dataState[index].dataIndex]),
-      true
-    );
+    const record = this._recordAt(index);
+
+    if (!record) {
+      return;
+    }
+
+    this._updateSelection(this._resolveItemValue(record), 'selection', true);
     this._activeIndex = index;
     this._syncValueFromSelection();
   }
@@ -875,7 +960,7 @@ export default class IgcComboComponent<
       this._searchTerm = '';
       this._clearSingleSelection();
     } else {
-      this._deselectItems([], true);
+      this._updateSelection([], 'deselection', true);
     }
     this._syncValueFromSelection();
   }
@@ -883,8 +968,17 @@ export default class IgcComboComponent<
   private _clearSingleSelection(): void {
     const [selection] = this._selected;
 
-    if (selection) {
-      this._deselectItems(this._resolveItemValue(selection), true);
+    // The form state is reset directly rather than through
+    // `_syncValueFromSelection` so that the text the user is currently typing
+    // into the main input is left alone.
+    if (
+      selection &&
+      this._updateSelection(
+        this._resolveItemValue(selection),
+        'deselection',
+        true
+      )
+    ) {
       this._formValue.setValueAndFormState([]);
     }
   }
@@ -897,13 +991,18 @@ export default class IgcComboComponent<
     detail,
   }: CustomEvent<string>): Promise<void> {
     this._setTouchedState();
-    this._show(true);
-    this._searchTerm = detail;
+    void this._show(true);
+
+    // In single selection mode the main input doubles as the filtering input,
+    // so it is the only place `disableFiltering` can be honored.
+    if (!this.disableFiltering) {
+      this._searchTerm = detail;
+    }
 
     // wait for the dataState to update after filtering
     await this.updateComplete;
 
-    this._activeIndex = this._state.dataState.findIndex((i) => !i.header);
+    this._activeIndex = this._state.firstItemIndex;
     // clear the selection upon typing
     this._clearSingleSelection();
   }
@@ -998,7 +1097,7 @@ export default class IgcComboComponent<
    * ```
    */
   public select(items?: Item<T> | Item<T>[]): void {
-    this._selectItems(items);
+    this._updateSelection(items, 'selection', false);
     this._syncValueFromSelection();
   }
 
@@ -1026,7 +1125,7 @@ export default class IgcComboComponent<
    * ```
    */
   public deselect(items?: Item<T> | Item<T>[]): void {
-    this._deselectItems(items);
+    this._updateSelection(items, 'deselection', false);
     this._syncValueFromSelection();
   }
 
@@ -1045,21 +1144,15 @@ export default class IgcComboComponent<
       `;
     }
 
-    const position = index + 1;
-    const id = this.id ? `${this.id}-item-${position}` : `item-${position}`;
     const active = this._activeIndex === index;
-    const selected = this._selected.has(this.data[item.dataIndex]);
-
-    if (active) {
-      this._activeDescendant = id;
-    }
+    const selected = this._selected.has(item.value);
 
     return html`
       <igc-combo-item
-        id=${id}
+        id=${this._itemId(index)}
         part=${partMap({ item: true, selected, active })}
-        aria-setsize=${this._state.dataState.length}
-        aria-posinset=${position}
+        aria-setsize=${this._state.itemCount}
+        aria-posinset=${item.position}
         exportparts="checkbox, checkbox-indicator, checked"
         .index=${index}
         ?active=${active}

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -229,6 +229,7 @@ export default class IgcComboComponent<
 
   private _data: T[] = [];
   private _index?: Map<Item<T>, number[]>;
+  private _indexSize = 0;
   private _valueKey?: Keys<T>;
   private _displayKey?: Keys<T>;
   private _placeholderSearch?: string;
@@ -623,8 +624,12 @@ export default class IgcComboComponent<
    */
   private _withPristine(callback: () => void): void {
     const pristine = this._pristine;
-    callback();
-    this._pristine = pristine;
+
+    try {
+      callback();
+    } finally {
+      this._pristine = pristine;
+    }
   }
 
   protected override updated(props: PropertyValues<this>): void {
@@ -706,11 +711,18 @@ export default class IgcComboComponent<
    * Positions (rather than records) are stored so that resolution can hand back
    * matches in data-source order, and duplicate value keys keep resolving to
    * every record that carries them.
+   *
+   * The size comparison picks up in-place growth or shrink (push/splice) of the
+   * same array. Replacing elements without changing the length is not detectable
+   * here and still requires reassigning `data`.
    */
   private get _dataIndex(): Map<Item<T>, number[]> {
-    this._index ??= Map.groupBy(this.data.keys(), (position) =>
-      this._resolveItemValue(this.data[position])
-    );
+    if (!this._index || this._indexSize !== this.data.length) {
+      this._index = Map.groupBy(this.data.keys(), (position) =>
+        this._resolveItemValue(this.data[position])
+      );
+      this._indexSize = this.data.length;
+    }
 
     return this._index;
   }
@@ -718,20 +730,27 @@ export default class IgcComboComponent<
   /**
    * Resolves user-provided items (value keys or object references)
    * to actual objects from the data source, in data-source order.
+   *
+   * @remarks
+   * Repeating the same value in `items` resolves it once - a record cannot be
+   * selected twice, and duplicates would otherwise reach the change event
+   * payload.
    */
   private _resolveItems(items: Item<T>[]): T[] {
     const index = this._dataIndex;
-    const positions: number[] = [];
+    const positions = new Set<number>();
 
     for (const item of items) {
       const matches = index.get(item);
 
       if (matches) {
-        positions.push(...matches);
+        for (const position of matches) {
+          positions.add(position);
+        }
       }
     }
 
-    return positions
+    return Array.from(positions)
       .sort((a, b) => a - b)
       .map((position) => this.data[position]);
   }

--- a/src/components/combo/controllers/data.ts
+++ b/src/components/combo/controllers/data.ts
@@ -18,7 +18,12 @@ export class DataState<T extends object> implements ReactiveController {
   private readonly _grouping = new GroupDataOperation<T>();
   private _compareCollator: Intl.Collator;
 
+  /** The data source, indexed into records. Rebuilt only when `data` changes. */
+  private _indexed: ComboRecord<T>[] = [];
+  private _source?: T[];
+
   private _dataState: ComboRecord<T>[] = [];
+  private _itemCount = 0;
   private _searchTerm = '';
   private _dirty = true;
 
@@ -26,9 +31,28 @@ export class DataState<T extends object> implements ReactiveController {
 
   //#region Public state accessors
 
-  /** The current state of the data in the combo component. */
-  public get dataState(): Readonly<ComboRecord<T>[]> {
+  /**
+   * The current state of the data in the combo component.
+   *
+   * @remarks
+   * Treat the returned collection as immutable - it is shared with the
+   * virtualized list and may be the cached indexed source itself.
+   */
+  public get dataState(): ComboRecord<T>[] {
     return this._dataState;
+  }
+
+  /** The number of selectable options in {@link dataState}, excluding group headers. */
+  public get itemCount(): number {
+    return this._itemCount;
+  }
+
+  /**
+   * The index in {@link dataState} of the first selectable option,
+   * or `-1` when there are none.
+   */
+  public get firstItemIndex(): number {
+    return this._dataState.findIndex((record) => !record.header);
   }
 
   /**
@@ -102,10 +126,22 @@ export class DataState<T extends object> implements ReactiveController {
    * Called during the update lifecycle to batch changes.
    */
   private _runPipelineIfDirty(): void {
-    if (this._dirty) {
-      this._dataState = this._apply(Array.from(this._host.data));
-      this._dirty = false;
+    if (!this._dirty) {
+      return;
     }
+
+    const data = this._host.data;
+
+    // Records are immutable, so the indexed source only needs rebuilding when
+    // the data source itself is replaced. Filter-only runs (every keystroke in
+    // the search input) reuse it instead of re-allocating a record per item.
+    if (this._source !== data) {
+      this._source = data;
+      this._indexed = this._index(data);
+    }
+
+    this._dataState = this._apply(this._indexed);
+    this._dirty = false;
   }
 
   //#endregion
@@ -119,19 +155,32 @@ export class DataState<T extends object> implements ReactiveController {
     return data.map((item, index) => ({
       value: item,
       header: false,
-      dataIndex: index,
+      position: index + 1,
     }));
   }
 
   /**
-   * Applies the data pipeline: indexing, filtering, and grouping.
+   * Applies the data pipeline: filtering and grouping over the indexed source,
+   * then renumbers the visible options so that the `aria-posinset`/`aria-setsize`
+   * pair reported by the list skips group headers.
    */
-  private _apply(data: T[]): ComboRecord<T>[] {
-    let records = this._index(data);
-    records = this._filtering.apply(records, this);
-    records = this._grouping.apply(records, this);
+  private _apply(records: ComboRecord<T>[]): ComboRecord<T>[] {
+    const result = this._grouping.apply(
+      this._filtering.apply(records, this),
+      this
+    );
 
-    return records;
+    let position = 0;
+
+    for (const record of result) {
+      if (!record.header) {
+        record.position = ++position;
+      }
+    }
+
+    this._itemCount = position;
+
+    return result;
   }
 
   //#endregion

--- a/src/components/combo/controllers/data.ts
+++ b/src/components/combo/controllers/data.ts
@@ -18,7 +18,7 @@ export class DataState<T extends object> implements ReactiveController {
   private readonly _grouping = new GroupDataOperation<T>();
   private _compareCollator: Intl.Collator;
 
-  /** The data source, indexed into records. Rebuilt only when `data` changes. */
+  /** The data source, indexed into records. See {@link _isSourceOutdated}. */
   private _indexed: ComboRecord<T>[] = [];
   private _source?: T[];
 
@@ -35,10 +35,10 @@ export class DataState<T extends object> implements ReactiveController {
    * The current state of the data in the combo component.
    *
    * @remarks
-   * Treat the returned collection as immutable - it is shared with the
-   * virtualized list and may be the cached indexed source itself.
+   * The collection is shared with the virtualized list and may be the cached
+   * indexed source itself, so it is handed out as read-only.
    */
-  public get dataState(): ComboRecord<T>[] {
+  public get dataState(): readonly ComboRecord<T>[] {
     return this._dataState;
   }
 
@@ -107,7 +107,21 @@ export class DataState<T extends object> implements ReactiveController {
    * @internal
    */
   public hostUpdate(): void {
+    // Mutating the data array in place notifies neither Lit nor `invalidate()`,
+    // so a changed length is detected here to mark the pipeline dirty on its
+    // own. Replacing elements without changing the length stays undetectable
+    // and still requires reassigning `data`.
+    if (this._isSourceOutdated()) {
+      this._dirty = true;
+    }
+
     this._runPipelineIfDirty();
+  }
+
+  /** Whether the indexed source no longer matches the host's data array. */
+  private _isSourceOutdated(): boolean {
+    const data = this._host.data;
+    return this._source !== data || this._indexed.length !== data.length;
   }
 
   /**
@@ -130,14 +144,14 @@ export class DataState<T extends object> implements ReactiveController {
       return;
     }
 
-    const data = this._host.data;
-
-    // Records are immutable, so the indexed source only needs rebuilding when
-    // the data source itself is replaced. Filter-only runs (every keystroke in
-    // the search input) reuse it instead of re-allocating a record per item.
-    if (this._source !== data) {
-      this._source = data;
-      this._indexed = this._index(data);
+    // A record's `value` and `header` are fixed for a given data item, so the
+    // indexed source only needs rebuilding when it no longer matches the host's
+    // data. Filter-only runs (every keystroke in the search input) reuse it
+    // instead of re-allocating a record per item. The derived `position` is the
+    // one field that does change per run - see `_apply`.
+    if (this._isSourceOutdated()) {
+      this._source = this._host.data;
+      this._indexed = this._index(this._source);
     }
 
     this._dataState = this._apply(this._indexed);
@@ -163,6 +177,12 @@ export class DataState<T extends object> implements ReactiveController {
    * Applies the data pipeline: filtering and grouping over the indexed source,
    * then renumbers the visible options so that the `aria-posinset`/`aria-setsize`
    * pair reported by the list skips group headers.
+   *
+   * @remarks
+   * `position` is derived view state and is deliberately renumbered in place.
+   * The records belong solely to this controller, and every run recomputes the
+   * field before anything reads it, so copying them per run would only add an
+   * allocation to each keystroke.
    */
   private _apply(records: ComboRecord<T>[]): ComboRecord<T>[] {
     const result = this._grouping.apply(

--- a/src/components/combo/controllers/navigation.ts
+++ b/src/components/combo/controllers/navigation.ts
@@ -54,7 +54,7 @@ export class ComboNavigationController<T extends object> {
   }
 
   private get _firstItem(): number {
-    return this._state.dataState.findIndex((rec) => !rec.header);
+    return this._state.firstItemIndex;
   }
 
   private get _lastItem(): number {
@@ -186,17 +186,13 @@ export class ComboNavigationController<T extends object> {
   };
 
   private _onHome = (): void => {
-    const previous = this.active;
-    this.active = this._firstItem;
+    this._setActive(this._firstItem);
     this._scrollToActive();
-    this._host.requestUpdate('_activeIndex', previous);
   };
 
   private _onEnd = (): void => {
-    const previous = this.active;
-    this.active = this._lastItem;
+    this._setActive(this._lastItem);
     this._scrollToActive();
-    this._host.requestUpdate('_activeIndex', previous);
   };
 
   private _onArrowUp = (): void => {
@@ -212,6 +208,17 @@ export class ComboNavigationController<T extends object> {
   //#endregion
 
   //#region Internal helper methods
+
+  /**
+   * The single write path for the active index. The host mirrors this through
+   * its own `_activeIndex` accessor, so it has to be told which property
+   * changed and what it changed from.
+   */
+  private _setActive(index: number): void {
+    const previous = this.active;
+    this.active = index;
+    this._host.requestUpdate('_activeIndex', previous);
+  }
 
   private _scrollToActive(behavior?: ScrollBehavior): void {
     this._list?.scrollToIndex(this.active, {
@@ -246,9 +253,7 @@ export class ComboNavigationController<T extends object> {
     }
 
     if (next !== -1) {
-      const previous = this.active;
-      this.active = next;
-      this._host.requestUpdate('_activeIndex', previous);
+      this._setActive(next);
     }
   }
 

--- a/src/components/combo/operations/filter.spec.ts
+++ b/src/components/combo/operations/filter.spec.ts
@@ -1,0 +1,117 @@
+import { expect } from '@open-wc/testing';
+
+import type { DataState } from '../controllers/data.js';
+import type { ComboRecord, FilteringOptions } from '../types.js';
+import FilterDataOperation from './filter.js';
+
+type City = { name: string; country: string };
+
+/**
+ * The filter operation only reads `searchTerm` and `filteringOptions` off the
+ * data state, so a plain stand-in keeps these tests off the component lifecycle.
+ */
+function stateStub(
+  searchTerm: string,
+  filteringOptions: FilteringOptions<City>
+): DataState<City> {
+  return { searchTerm, filteringOptions } as DataState<City>;
+}
+
+function records(...values: City[]): ComboRecord<City>[] {
+  return values.map((value, index) => ({
+    value,
+    header: false,
+    position: index + 1,
+  }));
+}
+
+describe('Combo filter operation', () => {
+  const data = records(
+    { name: 'Sofia', country: 'Bulgaria' },
+    { name: 'Plovdiv', country: 'Bulgaria' },
+    { name: 'São Paulo', country: 'Brazil' }
+  );
+
+  const defaults: FilteringOptions<City> = {
+    filterKey: 'name',
+    caseSensitive: false,
+    matchDiacritics: false,
+  };
+
+  let filter: FilterDataOperation<City>;
+
+  beforeEach(() => {
+    filter = new FilterDataOperation<City>();
+  });
+
+  const names = (result: ComboRecord<City>[]) =>
+    result.map((record) => record.value.name);
+
+  it('returns the input untouched when there is no search term', () => {
+    const result = filter.apply(data, stateStub('', defaults));
+    expect(result).to.equal(data);
+  });
+
+  it('matches case-insensitively and ignores diacritics by default', () => {
+    expect(names(filter.apply(data, stateStub('sof', defaults)))).to.eql([
+      'Sofia',
+    ]);
+    expect(names(filter.apply(data, stateStub('sao', defaults)))).to.eql([
+      'São Paulo',
+    ]);
+  });
+
+  it('honors filterKey', () => {
+    const options = { ...defaults, filterKey: 'country' as const };
+    expect(names(filter.apply(data, stateStub('bulg', options)))).to.eql([
+      'Sofia',
+      'Plovdiv',
+    ]);
+  });
+
+  // The operation memoizes each record's normalized text, so every option that
+  // feeds that normalization has to invalidate the cache when it changes.
+  it('re-normalizes when caseSensitive changes between passes', () => {
+    expect(names(filter.apply(data, stateStub('sof', defaults)))).to.eql([
+      'Sofia',
+    ]);
+
+    const sensitive = { ...defaults, caseSensitive: true };
+    expect(filter.apply(data, stateStub('sof', sensitive))).to.be.empty;
+    expect(names(filter.apply(data, stateStub('Sof', sensitive)))).to.eql([
+      'Sofia',
+    ]);
+
+    expect(names(filter.apply(data, stateStub('sof', defaults)))).to.eql([
+      'Sofia',
+    ]);
+  });
+
+  it('re-normalizes when matchDiacritics changes between passes', () => {
+    expect(names(filter.apply(data, stateStub('sao', defaults)))).to.eql([
+      'São Paulo',
+    ]);
+
+    const exact = { ...defaults, matchDiacritics: true };
+    expect(filter.apply(data, stateStub('sao', exact))).to.be.empty;
+    expect(names(filter.apply(data, stateStub('são', exact)))).to.eql([
+      'São Paulo',
+    ]);
+
+    expect(names(filter.apply(data, stateStub('sao', defaults)))).to.eql([
+      'São Paulo',
+    ]);
+  });
+
+  it('re-normalizes when filterKey changes between passes', () => {
+    expect(filter.apply(data, stateStub('bulg', defaults))).to.be.empty;
+
+    const byCountry = { ...defaults, filterKey: 'country' as const };
+    expect(names(filter.apply(data, stateStub('bulg', byCountry)))).to.eql([
+      'Sofia',
+      'Plovdiv',
+    ]);
+
+    expect(filter.apply(data, stateStub('bulg', defaults))).to.be.empty;
+  });
+});

--- a/src/components/combo/operations/filter.ts
+++ b/src/components/combo/operations/filter.ts
@@ -1,13 +1,60 @@
 import type { DataState } from '../controllers/data.js';
 import type { ComboRecord, FilteringOptions } from '../types.js';
 
+/**
+ * Filters combo records against the current search term.
+ *
+ * @remarks
+ * Normalizing a record's searchable text (lower-casing and stripping
+ * diacritics) dominates the cost of a filter pass, and every keystroke filters
+ * the same records again. The normalized text is therefore memoized per record
+ * and only recomputed when the normalization inputs change - records themselves
+ * are replaced when the data source changes, so the weak cache drops stale
+ * entries on its own.
+ */
 export default class FilterDataOperation<T extends object> {
-  protected normalize<T extends object>(
-    string: string,
+  private _cache = new WeakMap<ComboRecord<T>, string>();
+  private _signature?: string;
+
+  protected normalize(
+    value: string,
     { caseSensitive, matchDiacritics }: FilteringOptions<T>
-  ) {
-    const str = caseSensitive ? string : string.toLocaleLowerCase();
-    return matchDiacritics ? str : str.normalize('NFKD').replace(/\p{M}/gu, '');
+  ): string {
+    const text = caseSensitive ? value : value.toLocaleLowerCase();
+    return matchDiacritics
+      ? text
+      : text.normalize('NFKD').replace(/\p{M}/gu, '');
+  }
+
+  /** Drops the memoized text whenever the normalization inputs change. */
+  private _syncCache({
+    filterKey,
+    caseSensitive,
+    matchDiacritics,
+  }: FilteringOptions<T>): void {
+    const signature = `${String(filterKey)}|${caseSensitive}|${matchDiacritics}`;
+
+    if (this._signature !== signature) {
+      this._signature = signature;
+      this._cache = new WeakMap();
+    }
+  }
+
+  private _textOf(
+    record: ComboRecord<T>,
+    options: FilteringOptions<T>
+  ): string {
+    let text = this._cache.get(record);
+
+    if (text === undefined) {
+      const { filterKey } = options;
+      const value = record.value;
+
+      text = this.normalize(`${filterKey ? value[filterKey] : value}`, options);
+      this._cache.set(record, text);
+    }
+
+    return text;
   }
 
   public apply(
@@ -15,14 +62,17 @@ export default class FilterDataOperation<T extends object> {
     controller: DataState<T>
   ): ComboRecord<T>[] {
     const { searchTerm, filteringOptions } = controller;
-    const { filterKey: key } = filteringOptions;
 
-    if (!searchTerm) return data;
+    this._syncCache(filteringOptions);
+
+    if (!searchTerm) {
+      return data;
+    }
+
     const term = this.normalize(searchTerm, filteringOptions);
 
-    return data.filter(({ value }) => {
-      const string = key ? `${value[key]}` : `${value}`;
-      return this.normalize(string, filteringOptions).includes(term);
-    });
+    return data.filter((record) =>
+      this._textOf(record, filteringOptions).includes(term)
+    );
   }
 }

--- a/src/components/combo/operations/filter.ts
+++ b/src/components/combo/operations/filter.ts
@@ -36,7 +36,7 @@ export default class FilterDataOperation<T extends object> {
 
     if (this._signature !== signature) {
       this._signature = signature;
-      this._cache = new WeakMap();
+      this._cache = new WeakMap<ComboRecord<T>, string>();
     }
   }
 

--- a/src/components/combo/operations/group.ts
+++ b/src/components/combo/operations/group.ts
@@ -37,7 +37,7 @@ export default class GroupDataOperation<T extends object> {
             [groupKey as Keys<T>]: key,
           } as T,
           header: true,
-          dataIndex: -1,
+          position: -1,
         },
         ...(grouped.get(key) ?? []),
       ];

--- a/src/components/combo/types.ts
+++ b/src/components/combo/types.ts
@@ -9,7 +9,11 @@ export type Item<T extends object> = T | Values<T>;
 export type ComboRecord<T extends object> = {
   value: T;
   header: boolean;
-  dataIndex: number;
+  /**
+   * 1-based position among the currently visible options, excluding group
+   * headers. `-1` for header records. Reassigned on every pipeline run.
+   */
+  position: number;
 };
 
 export type ComboHost<T extends object> = ReactiveControllerHost &


### PR DESCRIPTION
Selection is now mutated only after the cancellable igcChange event is accepted, so preventing it no longer wipes the current single selection. disable-filtering is honored on the main input too, which is the only filtering path single-select has.

Selection resolution goes through a lazily built value index instead of scanning the data source per item, and the filter memoizes each record's normalized text instead of re-normalizing every record on every keystroke:

  - setting 2000 values over 20k records: 208ms -> 4ms
  - 7 keystrokes over 20k accented records: 102ms -> 37ms

aria-posinset/aria-setsize now exclude group headers, and aria-activedescendant is derived from the active index rather than assigned mid-render, dropping an extra update cycle per keypress.

Internally: select/deselect collapse into a single path, ComboRecord loses the redundant dataIndex, and the active-index write path is centralized.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
