### PR TITLE
fix(date-time-input): only commit value on blur (#1346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Spinning a date part while the editor is focused now also defers to the commit on blur. A programmatic `stepUp()` / `stepDown()` on an unfocused component still updates `value` immediately, as do `clear()`, `setRangeText()`, and direct assignments.
     - For `igc-date-picker` and `igc-date-range-picker` the calendar keeps following the typed date while editing, as before.
 
+### Fixed
+- #### Form associated components
+  - Validation messages no longer disappear right after the first failed form submission. The submit-driven invalid state used to hold only for the update the submission itself scheduled, so any re-render that followed - a `slotchange` from the validation slots the submission had just projected, for instance - silently dropped the projected messages while the invalid styling stayed on.
+  - Invalid styling now follows the validity state, so a control that turns valid again (a cleared `required`, a widened `min`/`max`, a disabled control) drops the styles it picked up from an earlier interaction or submission.
+
 ## [7.2.4] - 2026-06-29
 ### Added
 - #### Form associated custom elements with external labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Removed the `@lit-labs/virtualizer` dependency. Virtualization is now implemented internally by the new `igc-virtual-scroll` component. [#2222](https://github.com/IgniteUI/igniteui-webcomponents/pull/2222)
 - #### Carousel
   - The component now delegates focus, starting with its indicator container, navigation buttons, or the first focusable element in the active slide, whichever is available. Related to [#2291](https://github.com/IgniteUI/igniteui-webcomponents/issues/2291).
+- #### Date time input, Date picker, Date range picker
+  - **Behavioral change:** the `value` property of these components is no longer mutated while the user is typing. It now only ever holds a committed value and changes in lockstep with the `igcChange` event, which is still emitted when the editor loses focus. Previously `value` was updated on every keystroke - becoming `null` for an incomplete mask and the parsed date once the mask filled - without any event announcing it. [#1346](https://github.com/IgniteUI/igniteui-webcomponents/issues/1346)
+    - This makes the components usable in templates where `value` is externally bound, such as an edit template in `igc-grid`. Previously any re-render during typing re-applied the stale bound value and reset the editor, making it impossible to enter a new date.
+    - The value as it is being typed - including the result of spinning a date part or of `Ctrl + ;` - is available on the `detail` of the `igcInput` event, whose payload is unchanged.
+    - Spinning a date part while the editor is focused now also defers to the commit on blur. A programmatic `stepUp()` / `stepDown()` on an unfocused component still updates `value` immediately, as do `clear()`, `setRangeText()`, and direct assignments.
+    - For `igc-date-picker` and `igc-date-range-picker` the calendar keeps following the typed date while editing, as before.
 
 ## [7.2.4] - 2026-06-29
 ### Added

--- a/src/components/common/mixins/forms/associated.ts
+++ b/src/components/common/mixins/forms/associated.ts
@@ -40,14 +40,6 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     protected readonly _formValue!: FormValue<unknown>;
 
     /**
-     * Marks that validation is running as part of a form submission. Counts as
-     * user interaction (so invalid styles apply) and is cleared once the
-     * submit-driven update settles. Orthogonal to `_isInternalValidation`: a
-     * programmatic re-check can run while a submission is still in flight.
-     */
-    private _isFormSubmit = false;
-
-    /**
      * Suppresses invalid styling for a programmatic validation cycle
      * (`checkValidity`/`_validate`). Scoped to the synchronous validity check:
      * set immediately before it and cleared immediately after, so it never
@@ -57,17 +49,18 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     private _touched = false;
     private _isExternalInvalid = false;
 
-    private get _hasUserInteraction(): boolean {
-      return this._touched || this._isFormSubmit;
-    }
-
     private get _shouldApplyStyles(): boolean {
       if (this._isExternalInvalid) {
         return true;
       }
 
+      // A disabled control is barred from constraint validation, so it never
+      // carries invalid styling regardless of what its validators say.
       return (
-        this._invalid && this._hasUserInteraction && !this._isInternalValidation
+        !this._disabled &&
+        this._invalid &&
+        this._touched &&
+        !this._isInternalValidation
       );
     }
 
@@ -99,6 +92,9 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     public set disabled(value: boolean) {
       this._disabled = value;
       this.toggleAttribute('disabled', Boolean(this._disabled));
+      if (this.hasUpdated) {
+        this._setInvalidStyles();
+      }
     }
 
     public get disabled(): boolean {
@@ -182,24 +178,24 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
 
     //#region Form value and validation states
 
-    private async _handleInvalid(event: Event): Promise<void> {
+    private _handleInvalid(event: Event): void {
       event.preventDefault();
       this._invalid = true;
 
       if (this._isInternalValidation) {
         this._isInternalValidation = false;
       } else {
-        this._isFormSubmit = true;
+        // A failed submission counts as user interaction, and a lasting one: the
+        // control was asked for a value it could not provide. Keeping it touched
+        // is what makes `invalid` - and with it the validation messages the host
+        // projects - survive any later re-render, rather than holding only for
+        // the update the submission itself scheduled.
+        this._setTouchedState();
         emitFormInvalidEvent(this);
       }
 
       this._setInvalidStyles();
       this.requestUpdate();
-
-      if (this._isFormSubmit) {
-        await this.updateComplete;
-        this._isFormSubmit = false;
-      }
     }
 
     private _setInvalidStyles(): void {
@@ -276,6 +272,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
       this._isInternalValidation = true;
       this._invalid = !this._internals.checkValidity();
       this._resolveInternalValidation();
+      this._setInvalidStyles();
     }
 
     protected _handleBlur(): void {
@@ -312,6 +309,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
 
     protected formDisabledCallback(state: boolean): void {
       this._disabled = state;
+      this._setInvalidStyles();
       this.requestUpdate();
     }
 

--- a/src/components/date-picker/date-picker-form.spec.ts
+++ b/src/components/date-picker/date-picker-form.spec.ts
@@ -1,4 +1,10 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import {
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+  nextFrame,
+} from '@open-wc/testing';
 import { CalendarDay, toCalendarDay } from '../calendar/model.js';
 import { type DateRangeDescriptor, DateRangeType } from '../calendar/types.js';
 import { defineComponents } from '../common/definitions/defineComponents.js';
@@ -384,6 +390,28 @@ describe('igc-datepicker form integration', () => {
         ];
 
       runValidationContainerTests(IgcDatePickerComponent, testParameters);
+    });
+
+    it('renders the projected messages on the first failed submission', async () => {
+      const form = await fixture<HTMLFormElement>(html`
+        <form>
+          <igc-date-picker name="datePicker" required>
+            <p slot="value-missing">This field is required!</p>
+          </igc-date-picker>
+        </form>
+      `);
+      const picker = form.querySelector(IgcDatePickerComponent.tagName)!;
+
+      form.requestSubmit();
+      await elementUpdated(picker);
+
+      // Projecting the validation slots makes the picker's own slots pick up
+      // content, and the resulting slotchange schedules another update. The
+      // messages have to survive it.
+      await nextFrame();
+
+      ValidityHelpers.hasInvalidStyles(picker).to.be.true;
+      ValidityHelpers.hasSlottedContent(picker, 'value-missing').to.be.true;
     });
   });
 });

--- a/src/components/date-picker/date-picker.spec.ts
+++ b/src/components/date-picker/date-picker.spec.ts
@@ -20,6 +20,7 @@ import {
   isFocused,
   runExternalLabelAssociationTests,
   simulateClick,
+  simulateInput,
   simulateKeyboard,
 } from '../common/utils.spec.js';
 import IgcDateTimeInputComponent from '../date-time-input/date-time-input.js';
@@ -734,6 +735,57 @@ describe('Date picker', () => {
     });
   });
 
+  describe('Uncommitted edits - issue #1346', () => {
+    let input: HTMLInputElement;
+
+    beforeEach(async () => {
+      input = dateTimeInput.renderRoot.querySelector('input')!;
+      picker.inputFormat = 'MM/dd/yyyy';
+      picker.displayFormat = 'MM/dd/yyyy';
+      await elementUpdated(picker);
+    });
+
+    it('does not mutate value while typing in the input', async () => {
+      const initial = new Date(2020, 2, 3);
+      picker.value = initial;
+      dateTimeInput.focus();
+      await elementUpdated(picker);
+
+      dateTimeInput.setSelectionRange(0, input.value.length);
+      simulateInput(input, { value: '10102020', inputType: 'insertText' });
+      await elementUpdated(picker);
+
+      expect(input.value).to.equal('10/10/2020');
+      checkDatesEqual(picker.value!, initial);
+
+      dateTimeInput.blur();
+      await elementUpdated(picker);
+
+      checkDatesEqual(picker.value!, new Date(2020, 9, 10));
+    });
+
+    it('survives a host re-applying the bound value mid-edit', async () => {
+      // The grid edit-template scenario from the issue: change detection re-commits
+      // the bound value on every keystroke. It is equal to the committed one, so the
+      // in-progress edit must survive it.
+      const initial = new Date(2020, 2, 3);
+      picker.value = initial;
+      dateTimeInput.focus();
+      await elementUpdated(picker);
+
+      dateTimeInput.setSelectionRange(0, input.value.length);
+      simulateInput(input, { value: '1010', inputType: 'insertText' });
+      await elementUpdated(picker);
+
+      expect(input.value).to.equal('10/10/____');
+
+      picker.value = new Date(initial.getTime());
+      await elementUpdated(picker);
+
+      expect(input.value).to.equal('10/10/____');
+    });
+  });
+
   describe('Interactions', () => {
     it('should close the picker when in open state on pressing Escape', async () => {
       const eventSpy = spy(picker, 'emitEvent');
@@ -823,8 +875,19 @@ describe('Date picker', () => {
       await elementUpdated(picker);
 
       expect(eventSpy).calledOnceWith('igcInput');
+      // Spinning is an uncommitted edit - `value` follows on blur - so the typed
+      // date is only carried by the event detail. See issue #1346.
+      checkDatesEqual(
+        (eventSpy.firstCall.args[1] as CustomEventInit).detail as Date,
+        expectedValue
+      );
+      expect(picker.value).to.be.null;
       eventSpy.resetHistory();
+
+      dateTimeInput.blur();
+      await elementUpdated(picker);
       checkDatesEqual(picker.value as Date, expectedValue);
+      eventSpy.resetHistory();
 
       picker.value = null;
       picker.nonEditable = true;

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -299,7 +299,13 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
 
   /* @tsTwoWayProperty(true, "igcChange", "detail", false) */
   /**
-   * The value of the picker
+   * The value of the picker.
+   *
+   * Only ever holds a committed value. While the user is typing in the input, the
+   * intermediate state stays in the editor and is committed - together with an
+   * `igcChange` event - when the edit is committed on blur. Use the `igcInput` event
+   * to observe the value as it is being typed.
+   *
    * @attr
    */
   @property({ converter: convertToDate })
@@ -630,9 +636,10 @@ export default class IgcDatePickerComponent extends FormAssociatedRequiredMixin(
       return;
     }
 
-    this.value = (event.target as IgcDateTimeInputComponent).value!;
-    this._calendar.activeDate = this.value ?? this._calendar.activeDate;
-    this.emitEvent('igcInput', { detail: this.value });
+    const draft = (event.target as IgcDateTimeInputComponent)._uncommittedValue;
+
+    this._calendar.activeDate = draft ?? this._calendar.activeDate;
+    this.emitEvent('igcInput', { detail: draft });
   }
 
   protected _handleClosing(): void {

--- a/src/components/date-range-picker/date-range-input.ts
+++ b/src/components/date-range-picker/date-range-input.ts
@@ -40,7 +40,7 @@ export interface IgcDateRangeInputComponentEventMap {
 /* blazorSuppress */
 export default class IgcDateRangeInputComponent extends EventEmitterMixin<
   IgcDateRangeInputComponentEventMap,
-  AbstractConstructor<IgcDateTimeInputBaseComponent>
+  AbstractConstructor<IgcDateTimeInputBaseComponent<DateRangeValue>>
 >(IgcDateTimeInputBaseComponent) {
   public static readonly tagName = 'igc-date-range-input';
   public static styles = [styles, shared];
@@ -64,8 +64,6 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
     return { date: 1, month: 1, year: 1 };
   }
 
-  protected _oldValue: DateRangeValue | null = null;
-
   // #endregion
 
   // #region Public attributes and properties
@@ -73,15 +71,25 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
   /* @tsTwoWayProperty(true, "igcChange", "detail", false, true) */
   /**
    * The value of the date range input.
+   *
+   * Only ever holds a committed value. While the user is typing, the intermediate
+   * state lives in the masked text and is committed - together with an `igcChange`
+   * event - when the edit is committed on blur.
+   *
    * @attr
    */
   @property({ attribute: false })
-  public set value(value: DateRangeValue | null) {
+  public override set value(value: DateRangeValue | null) {
+    if (equal(this._formValue.value, value)) {
+      return;
+    }
+
+    this._isEditing = false;
     this._formValue.setValueAndFormState(value);
     this._updateMaskDisplay();
   }
 
-  public get value(): DateRangeValue | null {
+  public override get value(): DateRangeValue | null {
     return this._formValue.value;
   }
 
@@ -117,38 +125,13 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
     }
   }
 
-  protected override _handleBlur(): void {
-    const isSameValue = equal(this._oldValue, this.value);
-
-    this._focused = false;
-
-    if (!(this._isMaskComplete() || this._isEmptyMask)) {
-      const parsed = this._parser.parseDateRange(this._maskedValue);
-
-      if (parsed && (parsed.start || parsed.end)) {
-        this.value = parsed;
-      } else {
-        this.value = null;
-        this._maskedValue = '';
-      }
-    } else {
-      this._updateMaskDisplay();
-    }
-
-    if (!(this.readOnly || isSameValue)) {
-      this.emitEvent('igcChange', { detail: this.value });
-    }
-
-    super._handleBlur();
-  }
-
   // #endregion
 
   // #region Keybindings overrides
 
   protected override _setCurrentDateTime(): void {
     const today = CalendarDay.today.native;
-    this.value = { start: today, end: today };
+    this._setDraftValue({ start: today, end: today });
     this._emitInputEvent();
   }
 
@@ -196,30 +179,17 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
 
   // #region Internal API Overrides
 
-  protected override _updateMaskDisplay(): void {
-    if (this._focused) {
-      // Only reset mask from value when value is non-null (i.e. after spinning or programmatic set).
-      // When value is null the user is mid-typing — leave _maskedValue unchanged.
-      if (this.value?.start || this.value?.end) {
-        this._maskedValue = this._buildMaskedValue();
-      } else if (!this._maskedValue) {
-        this._maskedValue = this._parser.emptyMask;
-      }
-      return;
-    }
-
-    this._maskedValue = this._buildDisplayValue();
-  }
-
   protected override _performStep(
     datePart: unknown,
     delta: number | undefined,
     isDecrement: boolean
   ): void {
     // If no value exists, set to today's date first
-    if (!this.value?.start && !this.value?.end) {
+    const current = this._uncommittedValue;
+
+    if (!current?.start && !current?.end) {
       const today = CalendarDay.today.native;
-      this.value = { start: today, end: today };
+      this._setDraftValue({ start: today, end: today });
       const { start, end } = this._inputSelection;
       this.updateComplete.then(() =>
         this._input?.setSelectionRange(start, end)
@@ -228,10 +198,6 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
     }
 
     super._performStep(datePart, delta, isDecrement);
-  }
-
-  protected override _commitSpunValue(value: unknown): void {
-    this.value = value as DateRangeValue;
   }
 
   protected override _buildDisplayValue(): string {
@@ -264,9 +230,10 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
 
     const today = CalendarDay.today.native;
     const defaultValue = { start: today, end: today };
+    const current = this._uncommittedValue;
 
     if (!part) {
-      return this.value || defaultValue;
+      return current || defaultValue;
     }
 
     const effectiveDelta =
@@ -282,7 +249,7 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
     return this._parser.spinDateRangePart(
       part,
       spinAmount,
-      this.value,
+      current,
       this.spinLoop,
       amPmValue
     );
@@ -339,8 +306,17 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
     return undefined;
   }
 
-  protected override _buildMaskedValue(): string {
-    return this._parser.formatDateRange(this.value);
+  protected override _parseMask(strict: boolean): DateRangeValue | null {
+    if (strict && !this._isMaskComplete()) {
+      return null;
+    }
+
+    const parsed = this._parser.parseDateRange(this._maskedValue);
+    return parsed?.start || parsed?.end ? parsed : null;
+  }
+
+  protected override _formatValue(value: DateRangeValue | null): string {
+    return this._parser.formatDateRange(value);
   }
 
   protected override _applyMask(string: string): void {
@@ -356,16 +332,6 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
     }
   }
 
-  protected override _syncValueFromMask(): void {
-    if (!this._isMaskComplete()) {
-      this.value = null;
-      return;
-    }
-
-    const parsed = this._parser.parseDateRange(this._maskedValue);
-    this.value = parsed?.start || parsed?.end ? parsed : null;
-  }
-
   // #region Public API Overrides
 
   /** Increments a date/time portion. */
@@ -376,12 +342,6 @@ export default class IgcDateRangeInputComponent extends EventEmitterMixin<
   /** Decrements a date/time portion. */
   public override stepDown(datePart?: DateRangePart, delta?: number): void {
     super.stepDown(datePart, delta);
-  }
-
-  /** Clears the input element of user input. */
-  public override clear(): void {
-    this._maskedValue = '';
-    this.value = null;
   }
 
   public override hasDateParts(): boolean {

--- a/src/components/date-range-picker/date-range-picker-two-inputs.spec.ts
+++ b/src/components/date-range-picker/date-range-picker-two-inputs.spec.ts
@@ -553,8 +553,17 @@ describe('Date range picker - two inputs', () => {
 
         expect(eventSpy).calledOnceWith('igcInput');
         eventSpy.resetHistory();
-        expect(dateTimeInputs[0].value).to.not.be.null;
+
+        // Spinning is an uncommitted edit - `value` follows on blur - so the spun
+        // date is only visible on the draft. See issue #1346.
+        expect(dateTimeInputs[0].value).to.be.null;
+        expect(dateTimeInputs[0]._uncommittedValue).to.not.be.null;
+        checkDatesEqual(dateTimeInputs[0]._uncommittedValue!, expectedValue);
+
+        dateTimeInputs[0].blur();
+        await elementUpdated(picker);
         checkDatesEqual(dateTimeInputs[0].value!, expectedValue);
+        eventSpy.resetHistory();
 
         picker.value = null;
         picker.nonEditable = true;
@@ -674,9 +683,14 @@ describe('Date range picker - two inputs', () => {
         expect(eventSpy).calledWith('igcInput');
         expect(eventSpy).not.calledWith('igcChange');
         eventSpy.resetHistory();
-        checkDatesEqual(dateTimeInputs[0].value!, now.native);
+        checkDatesEqual(dateTimeInputs[0]._uncommittedValue!, now.native);
         // typing a single date does not select a range in the calendar
-        checkSelectedRange(picker, { start: now.native, end: null });
+        checkSelectedRange(
+          picker,
+          { start: now.native, end: null },
+          true,
+          true
+        );
         checkDatesEqual(calendar.activeDate, now.native);
 
         dateTimeInputs[1].focus();
@@ -698,9 +712,14 @@ describe('Date range picker - two inputs', () => {
 
         expect(eventSpy).calledWith('igcInput');
         eventSpy.resetHistory();
-        checkDatesEqual(dateTimeInputs[1].value!, now.native);
+        checkDatesEqual(dateTimeInputs[1]._uncommittedValue!, now.native);
         // typing the end date as well results in a selected range of a single date
-        checkSelectedRange(picker, { start: now.native, end: now.native });
+        checkSelectedRange(
+          picker,
+          { start: now.native, end: now.native },
+          true,
+          true
+        );
         checkDatesEqual(calendar.activeDate, now.native);
 
         simulateKeyboard(dateTimeInputs[1], arrowDown);
@@ -708,13 +727,15 @@ describe('Date range picker - two inputs', () => {
 
         expect(eventSpy).calledWith('igcInput');
         eventSpy.resetHistory();
-        checkDatesEqual(dateTimeInputs[1].value!, aMonthAgo.native);
+        checkDatesEqual(dateTimeInputs[1]._uncommittedValue!, aMonthAgo.native);
         // changing the end date while typing alters the selected range
         // the active date is set to the typed date, in this case the end one
-        checkSelectedRange(picker, {
-          start: now.native,
-          end: aMonthAgo.native,
-        });
+        checkSelectedRange(
+          picker,
+          { start: now.native, end: aMonthAgo.native },
+          true,
+          true
+        );
         checkDatesEqual(calendar.activeDate, aMonthAgo.native);
 
         // on losing focus of the end input, the dates are swapped since end is earlier than start
@@ -746,7 +767,12 @@ describe('Date range picker - two inputs', () => {
           date: 24,
           year: 2025,
         }).native;
-        checkSelectedRange(picker, { start: expectedDate, end: null });
+        checkSelectedRange(
+          picker,
+          { start: expectedDate, end: null },
+          true,
+          true
+        );
         checkDatesEqual(calendar.activeDate, expectedDate);
 
         expect(eventSpy).calledWith('igcInput', {
@@ -766,7 +792,12 @@ describe('Date range picker - two inputs', () => {
           date: 25,
           year: 2025,
         }).native;
-        checkSelectedRange(picker, { start: expectedDate, end: expectedDate2 });
+        checkSelectedRange(
+          picker,
+          { start: expectedDate, end: expectedDate2 },
+          true,
+          true
+        );
         checkDatesEqual(calendar.activeDate, expectedDate2);
 
         expect(eventSpy).calledWith('igcInput', {

--- a/src/components/date-range-picker/date-range-picker.ts
+++ b/src/components/date-range-picker/date-range-picker.ts
@@ -775,14 +775,17 @@ export default class IgcDateRangePickerComponent extends FormAssociatedRequiredM
       event.preventDefault();
       return;
     }
+
     const input = event.target as IgcDateTimeInputComponent;
-    const newValue = input.value ? CalendarDay.from(input.value).native : null;
+    const draft = input._uncommittedValue;
+    const newValue = draft ? CalendarDay.from(draft).native : null;
+    const range = this._getUpdatedDateRange(input, newValue);
 
-    this.value = this._getUpdatedDateRange(input, newValue);
+    this._setCalendarRangeValues(range);
     this._calendar.activeDate =
-      newValue ?? this._firstDefinedInRange ?? this._calendar.activeDate;
+      newValue ?? range.start ?? range.end ?? this._calendar.activeDate;
 
-    this.emitEvent('igcInput', { detail: this.value });
+    this.emitEvent('igcInput', { detail: range });
   }
 
   protected _handleInputChange(event: CustomEvent<Date | null>) {
@@ -790,7 +793,6 @@ export default class IgcDateRangePickerComponent extends FormAssociatedRequiredM
 
     const input = event.target as IgcDateTimeInputComponent;
     const newValue = input.value ? CalendarDay.from(input.value).native : null;
-
     const updatedRange = this._getUpdatedDateRange(input, newValue);
     const { start, end } = this._swapDates(updatedRange) ?? {
       start: null,
@@ -808,13 +810,14 @@ export default class IgcDateRangePickerComponent extends FormAssociatedRequiredM
       event.preventDefault();
       return;
     }
+
     const input = event.target as IgcDateRangeInputComponent;
-    const newValue = input.value;
+    const draft = input._uncommittedValue;
 
-    this.value = newValue;
-    this._calendar.activeDate = newValue?.start;
+    this._setCalendarRangeValues(draft);
+    this._calendar.activeDate = draft?.start;
 
-    this.emitEvent('igcInput', { detail: this.value });
+    this.emitEvent('igcInput', { detail: draft });
   }
 
   protected _handleDateRangeInputChange(
@@ -913,15 +916,21 @@ export default class IgcDateRangePickerComponent extends FormAssociatedRequiredM
     this._calendar[activeDaysViewIndex] = 0;
   }
 
+  /**
+   * Composes the range from what the two editors currently hold.
+   *
+   * The sibling input is read through its draft rather than through the committed
+   * `value`, since an edit in progress there has not reached the picker yet.
+   */
   private _getUpdatedDateRange(
     input: IgcDateTimeInputComponent,
     newValue: Date | null
   ): DateRangeValue {
-    const { start = null, end = null } = this.value ?? {};
+    const [startInput, endInput] = this._inputs;
 
-    return input === this._inputs[0]
-      ? { start: newValue, end }
-      : { start, end: newValue };
+    return input === startInput
+      ? { start: newValue, end: endInput?._uncommittedValue ?? null }
+      : { start: startInput?._uncommittedValue ?? null, end: newValue };
   }
 
   // Delegates the validity methods of internal input elements
@@ -944,23 +953,27 @@ export default class IgcDateRangePickerComponent extends FormAssociatedRequiredM
       createDateConstraints(this.min, this.max, this.disabledDates) ?? [];
   }
 
-  private _setCalendarRangeValues() {
+  /**
+   * Reflects a range in the calendar. Defaults to the committed value, but the input
+   * handlers pass the uncommitted draft so that the calendar keeps following along
+   * while the user types.
+   */
+  private _setCalendarRangeValues(range: DateRangeValue | null = this.value) {
     if (!this._calendar) {
       return;
     }
 
-    if (isCompleteDateRange(this.value)) {
+    if (isCompleteDateRange(range)) {
       this._calendar.values =
-        CalendarDay.compare(this.value.start, this.value.end) === 0
-          ? [this.value.start]
-          : [this.value.start, this.value.end];
-      this._calendar.activeDate = this._firstDefinedInRange;
+        CalendarDay.compare(range.start, range.end) === 0
+          ? [range.start]
+          : [range.start, range.end];
+      this._calendar.activeDate = range.start;
       return;
     }
 
-    this._calendar.values = this._firstDefinedInRange
-      ? [this._firstDefinedInRange]
-      : null;
+    const first = range?.start ?? range?.end ?? null;
+    this._calendar.values = first ? [first] : null;
   }
 
   private _swapDates(range: DateRangeValue): DateRangeValue {

--- a/src/components/date-range-picker/date-range-picker.utils.spec.ts
+++ b/src/components/date-range-picker/date-range-picker.utils.spec.ts
@@ -32,7 +32,12 @@ export const selectDates = async (
 export const checkSelectedRange = (
   picker: IgcDateRangePickerComponent,
   expectedValue: DateRangeValue | null,
-  useTwoInputs = true
+  useTwoInputs = true,
+  /**
+   * Set while an edit is still in progress. The inputs only commit their `value` on
+   * blur (see issue #1346), so mid-typing the draft has to be read instead.
+   */
+  uncommitted = false
 ) => {
   const calendar = picker.renderRoot.querySelector(
     IgcCalendarComponent.tagName
@@ -44,11 +49,14 @@ export const checkSelectedRange = (
     const inputs = picker.renderRoot.querySelectorAll(
       IgcDateTimeInputComponent.tagName
     );
+    const readValue = (input: IgcDateTimeInputComponent) =>
+      uncommitted ? input._uncommittedValue : input.value;
+
     if (expectedValue?.start) {
-      checkDatesEqual(inputs[0].value!, expectedValue.start);
+      checkDatesEqual(readValue(inputs[0])!, expectedValue.start);
     }
     if (expectedValue?.end) {
-      checkDatesEqual(inputs[1].value!, expectedValue.end);
+      checkDatesEqual(readValue(inputs[1])!, expectedValue.end);
     }
   } else {
     const input = getInput(picker);

--- a/src/components/date-time-input/date-time-input.base.ts
+++ b/src/components/date-time-input/date-time-input.base.ts
@@ -29,6 +29,8 @@ import {
   renderInputShell,
 } from '../common/templates/input-shell.js';
 import { renderMaskedNativeInput } from '../common/templates/masked-input.js';
+import { equal } from '../common/util.js';
+import type { RangeTextSelectMode } from '../types.js';
 import type { DatePartDeltas } from './date-part.js';
 import { dateTimeInputValidators } from './validators.js';
 
@@ -50,9 +52,9 @@ const Slots = setSlots(
 /* omitModule */
 @blazorDeepImport
 @shadowOptions({ delegatesFocus: true })
-export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
-  FormAssociatedRequiredMixin(LitElement)
-) {
+export abstract class IgcDateTimeInputBaseComponent<
+  T,
+> extends MaskBehaviorMixin(FormAssociatedRequiredMixin(LitElement)) {
   // #region Internal state and properties
 
   protected abstract readonly _themes: ThemingController;
@@ -101,6 +103,30 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
   protected _defaultDisplayFormat = '';
   protected _displayFormat?: string;
   protected _inputFormat?: string;
+
+  /**
+   * Whether the user has an uncommitted edit in progress.
+   *
+   * While set, the masked text - not the public `value` - is the source of truth:
+   * typing updates the mask only, and the parsed result reaches `value` (together
+   * with `igcChange`) when the edit is committed on blur. Keeping `value` in sync
+   * with the last emitted `igcChange` is what stops a host that two-way binds the
+   * property from clobbering a half-typed mask on an unrelated re-render.
+   */
+  protected _isEditing = false;
+
+  /** The value the input was focused with, used to detect a committed change. */
+  protected _oldValue: T | null = null;
+
+  /**
+   * The value currently in the editor - the parsed draft while an edit is in
+   * progress, otherwise the committed public value.
+   *
+   * @hidden @internal
+   */
+  public get _uncommittedValue(): T | null {
+    return this._isEditing ? this._parseMask(true) : this.value;
+  }
 
   protected get _targetDatePart(): unknown {
     return this._focused
@@ -278,6 +304,12 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
     }
   }
 
+  protected override _handleBlur(): void {
+    this._focused = false;
+    this._commitEdit();
+    super._handleBlur();
+  }
+
   /**
    * Handles wheel events for spinning date parts.
    */
@@ -338,8 +370,7 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
     if (!part) return;
 
     const { start, end } = this._inputSelection;
-    const newValue = this._calculateSpunValue(part, delta, isDecrement);
-    this._commitSpunValue(newValue);
+    this._setDraftValue(this._calculateSpunValue(part, delta, isDecrement));
     this.updateComplete.then(() => this._input?.setSelectionRange(start, end));
   }
 
@@ -348,9 +379,103 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
    * When focused, shows the editable mask. When unfocused, defers to the leaf's display formatter.
    */
   protected _updateMaskDisplay(): void {
-    this._maskedValue = this._focused
-      ? this._buildMaskedValue()
-      : this._buildDisplayValue();
+    if (!this._focused) {
+      this._maskedValue = this._buildDisplayValue();
+    } else if (!this._isEditing) {
+      // An edit in progress owns the masked text. Rebuilding it from `value` here
+      // would discard whatever the user has typed so far.
+      this._maskedValue = this._buildMaskedValue();
+    }
+  }
+
+  /** Builds the editable mask shown while the input is focused. */
+  protected _buildMaskedValue(): string {
+    const masked = this._formatValue(this.value);
+
+    // A value-less mask formats to the empty mask; prefer whatever is already in
+    // the editor so that a partially typed mask survives a re-render.
+    return masked === this._parser.emptyMask
+      ? this._maskedValue || masked
+      : masked;
+  }
+
+  /**
+   * Applies a value produced by an interactive edit (spinning, `Ctrl + ;`).
+   * While focused this only moves the draft; outside of an editing session - e.g. a
+   * programmatic `stepUp()` - there is no blur coming to commit it.
+   */
+  protected _setDraftValue(value: T): void {
+    if (!this._focused) {
+      this.value = value;
+      return;
+    }
+
+    this._isEditing = true;
+    this._maskedValue = this._formatValue(value);
+    this.requestUpdate();
+  }
+
+  /** Applies the masked text to the public value without emitting anything. */
+  protected _applyDraft(): void {
+    this._isEditing = false;
+    this.value = this._parseMask(true);
+    this._updateMaskDisplay();
+  }
+
+  /**
+   * Commits the current draft to the public value, emitting `igcChange` when the
+   * committed value differs from the one the input was focused with.
+   */
+  protected _commitEdit(): void {
+    // Only an actual edit is re-parsed. Without this guard a mask holding a
+    // display-formatted value - a read-only or untouched input - would be read back
+    // under the input format and mangled.
+    if (this._isEditing) {
+      this._isEditing = false;
+
+      // A partially filled mask is parsed leniently, missing parts falling back to
+      // their defaults; only a mask that resolves to nothing clears the value.
+      const parsed = this._parseMask(false);
+
+      if (parsed === null) {
+        this.clear();
+      } else {
+        this.value = parsed;
+      }
+    }
+
+    // The assignments above are no-ops when the value did not change, so the mask
+    // still has to be flipped back to the display format explicitly.
+    this._updateMaskDisplay();
+
+    // The value can also have moved without an edit - `clear()` or a programmatic
+    // assignment while focused - and that is a committed change just the same.
+    if (!this.readOnly && !equal(this._oldValue, this.value)) {
+      this._oldValue = this.value;
+      this.emitEvent('igcChange', { detail: this.value });
+    }
+  }
+
+  /**
+   * Marks the masked text as an uncommitted edit. The parsed result deliberately
+   * does not reach the public `value` here - that happens on commit - so that the
+   * property stays in sync with the last emitted `igcChange`. See {@link _isEditing}.
+   */
+  protected override _syncValueFromMask(): void {
+    if (this._focused) {
+      this._isEditing = true;
+      return;
+    }
+
+    // A mask mutation outside of an editing session - e.g. text dropped onto an
+    // unfocused input - has no blur coming to commit it.
+    this._applyDraft();
+  }
+
+  protected override _restoreDefaultValue(): void {
+    this._isEditing = false;
+    super._restoreDefaultValue();
+    this._updateMaskDisplay();
   }
 
   /**
@@ -439,8 +564,25 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
     this._performStep(datePart, delta, true);
   }
 
+  /* blazorSuppress */
+  /** Replaces the selected text in the control and re-applies the mask. */
+  public override setRangeText(
+    replacement: string,
+    start?: number,
+    end?: number,
+    selectMode?: RangeTextSelectMode
+  ): void {
+    super.setRangeText(replacement, start, end, selectMode);
+    this._applyDraft();
+  }
+
   /** Clears the input element of user input. */
-  public abstract clear(): void;
+  public clear(): void {
+    this._isEditing = false;
+    this._maskedValue = '';
+    this.value = null;
+    this._updateMaskDisplay();
+  }
 
   //#endregion
 
@@ -492,9 +634,25 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
 
   protected abstract get _datePartDeltas(): DatePartDeltas;
 
-  protected abstract _buildMaskedValue(): string;
+  /** Provided by `EventEmitterMixin` in the concrete components. */
+  public abstract emitEvent(name: string, init?: CustomEventInit): boolean;
+
+  /** The committed value of the input. */
+  public abstract get value(): T | null;
+  public abstract set value(value: T | null);
+
+  /**
+   * Parses the current masked text into the leaf's value type.
+   *
+   * A `strict` parse mirrors the committed value semantics - an incomplete mask has
+   * no value yet and resolves to `null` rather than to a defaults-filled one.
+   */
+  protected abstract _parseMask(strict: boolean): T | null;
+
+  /** Formats a value into the editable mask. */
+  protected abstract _formatValue(value: T | null): string;
+
   protected abstract _buildDisplayValue(): string;
-  protected abstract override _syncValueFromMask(): void;
   protected abstract _calculatePartNavigationPosition(
     value: string,
     direction: number
@@ -503,8 +661,7 @@ export abstract class IgcDateTimeInputBaseComponent extends MaskBehaviorMixin(
     part: unknown,
     delta: number | undefined,
     isDecrement: boolean
-  ): unknown;
-  protected abstract _commitSpunValue(value: unknown): void;
+  ): T;
   protected abstract _setCurrentDateTime(): void;
   protected abstract _handleFocus(): Promise<void>;
   protected abstract _getDatePartAtCursor(): unknown;

--- a/src/components/date-time-input/date-time-input.spec.ts
+++ b/src/components/date-time-input/date-time-input.spec.ts
@@ -234,6 +234,116 @@ describe('Date Time Input component', () => {
       expect(input.value).to.deep.equal('1/1/2000');
     });
 
+    describe('Uncommitted edits - issue #1346', () => {
+      beforeEach(async () => {
+        element.inputFormat = 'MM/dd/yyyy';
+        element.displayFormat = 'MM/dd/yyyy';
+        await elementUpdated(element);
+      });
+
+      it('does not mutate value while typing, neither partially nor fully', async () => {
+        const initial = new Date(2020, 2, 3);
+        element.value = initial;
+        element.focus();
+        await elementUpdated(element);
+
+        element.setSelectionRange(0, input.value.length);
+        simulateInput(input, { value: '10', inputType: 'insertText' });
+        await elementUpdated(element);
+
+        // Partial mask
+        expect(input.value).to.equal('10/__/____');
+        expect(element.value?.getTime()).to.equal(initial.getTime());
+
+        element.setSelectionRange(0, input.value.length);
+        simulateInput(input, { value: '10102020', inputType: 'insertText' });
+        await elementUpdated(element);
+
+        // Complete mask - still uncommitted
+        expect(input.value).to.equal('10/10/2020');
+        expect(element.value?.getTime()).to.equal(initial.getTime());
+
+        element.blur();
+        await elementUpdated(element);
+
+        expect(element.value?.getTime()).to.equal(
+          new Date(2020, 9, 10).getTime()
+        );
+      });
+
+      it('exposes the typed date through igcInput while value stays put', async () => {
+        const eventSpy = spy(element, 'emitEvent');
+        element.focus();
+        await elementUpdated(element);
+
+        simulateInput(input, { value: '10102020', inputType: 'insertText' });
+        await elementUpdated(element);
+
+        expect(element.value).to.be.null;
+        expect(eventSpy).calledWith('igcInput', {
+          detail: new Date(2020, 9, 10).toISOString(),
+        });
+      });
+
+      it('re-applying an equal value while typing does not reset the mask', async () => {
+        const initial = new Date(2020, 2, 3);
+        element.value = initial;
+        element.focus();
+        await elementUpdated(element);
+
+        element.setSelectionRange(0, input.value.length);
+        simulateInput(input, { value: '1010', inputType: 'insertText' });
+        await elementUpdated(element);
+
+        expect(input.value).to.equal('10/10/____');
+
+        // What a framework re-render does: re-commit the bound value. It is equal to
+        // the committed one, so the in-progress edit must survive it.
+        element.value = new Date(initial.getTime());
+        await elementUpdated(element);
+
+        expect(input.value).to.equal('10/10/____');
+      });
+
+      it('emits a single igcChange on blur carrying the committed value', async () => {
+        const eventSpy = spy(element, 'emitEvent');
+        element.focus();
+        await elementUpdated(element);
+
+        simulateInput(input, { value: '10102020', inputType: 'insertText' });
+        await elementUpdated(element);
+
+        expect(eventSpy).not.calledWith('igcChange');
+
+        element.blur();
+        await elementUpdated(element);
+
+        const changes = eventSpy
+          .getCalls()
+          .filter((call) => call.args[0] === 'igcChange');
+
+        expect(changes).lengthOf(1);
+        expect(
+          (changes[0].args[1] as CustomEventInit).detail.getTime()
+        ).to.equal(new Date(2020, 9, 10).getTime());
+      });
+
+      it('a genuinely different value assigned while typing still wins', async () => {
+        element.focus();
+        await elementUpdated(element);
+
+        simulateInput(input, { value: '1010', inputType: 'insertText' });
+        await elementUpdated(element);
+
+        expect(input.value).to.equal('10/10/____');
+
+        element.value = new Date(1999, 0, 2);
+        await elementUpdated(element);
+
+        expect(input.value).to.equal('01/02/1999');
+      });
+    });
+
     it('should correctly switch between different pre-defined date formats', async () => {
       const targetDate = new Date(2020, 2, 3, 0, 0, 0, 0);
 
@@ -523,13 +633,21 @@ describe('Date Time Input component', () => {
       simulateWheel(input, { deltaY: -125 });
       await elementUpdated(element);
 
-      expect(element.value.getFullYear()).to.equal(value.getFullYear() + 1);
+      // Spinning is an uncommitted edit while the input is focused.
+      expect(element.value?.getTime()).to.equal(value.getTime());
+      expect(parser.parseDate(input.value)?.getFullYear()).to.equal(
+        value.getFullYear() + 1
+      );
 
       element.setSelectionRange(0, 0);
 
       simulateWheel(input, { deltaY: 125 });
       await elementUpdated(element);
 
+      element.blur();
+      await elementUpdated(element);
+
+      expect(element.value.getFullYear()).to.equal(value.getFullYear() + 1);
       expect(element.value.getMonth()).to.equal(value.getMonth() - 1);
     });
 
@@ -569,6 +687,15 @@ describe('Date Time Input component', () => {
       simulateKeyboard(input, arrowUp);
       await elementUpdated(element);
 
+      // Spinning is an uncommitted edit while the input is focused.
+      expect(element.value?.getTime()).to.equal(value.getTime());
+      expect(parser.parseDate(input.value)?.getFullYear()).to.equal(
+        value.getFullYear() + 1
+      );
+
+      element.blur();
+      await elementUpdated(element);
+
       expect(element.value.getFullYear()).to.equal(value.getFullYear() + 1);
     });
 
@@ -580,6 +707,15 @@ describe('Date Time Input component', () => {
       await elementUpdated(element);
 
       simulateKeyboard(input, arrowDown);
+      await elementUpdated(element);
+
+      // Spinning is an uncommitted edit while the input is focused.
+      expect(element.value?.getTime()).to.equal(value.getTime());
+      expect(parser.parseDate(input.value)?.getFullYear()).to.equal(
+        value.getFullYear() - 1
+      );
+
+      element.blur();
       await elementUpdated(element);
 
       expect(element.value.getFullYear()).to.equal(value.getFullYear() - 1);
@@ -653,7 +789,9 @@ describe('Date Time Input component', () => {
       element.stepDown();
       await elementUpdated(element);
 
-      expect(element.value.getFullYear()).to.eq(2022);
+      // Spinning is an uncommitted edit while the input is focused, so the draft
+      // in the mask - not the public value - is what moves.
+      expect(input.value).to.equal('2022/06/01');
       expect(input.selectionStart).to.eq(start);
       expect(input.selectionEnd).to.eq(end);
 
@@ -663,9 +801,17 @@ describe('Date Time Input component', () => {
       end = input.selectionEnd;
 
       element.stepUp();
-      expect(element.value.getMonth()).to.eq(6);
+      await elementUpdated(element);
+
+      expect(input.value).to.equal('2022/07/01');
       expect(input.selectionStart).to.eq(start);
       expect(input.selectionEnd).to.eq(end);
+
+      element.blur();
+      await elementUpdated(element);
+
+      expect(element.value.getFullYear()).to.eq(2022);
+      expect(element.value.getMonth()).to.eq(6);
     });
 
     it('ArrowLeft/Right should navigate to the beginning/end of date section', async () => {
@@ -736,7 +882,7 @@ describe('Date Time Input component', () => {
       expect(input.value).to.be.empty;
     });
 
-    it('set value when input is complete', async () => {
+    it('commits the value on blur when input is complete', async () => {
       element.inputFormat = 'dd.MM.yyyy';
       parser.mask = 'dd.MM.yyyy';
 
@@ -755,7 +901,13 @@ describe('Date Time Input component', () => {
 
       expect(isValidDate(parse2)).to.be.true;
 
-      //10.10.2000
+      // A complete mask is still an uncommitted edit - issue #1346
+      expect(element.value).to.be.null;
+
+      element.blur();
+      await elementUpdated(element);
+
+      //10.10.2020
       expect(element.value?.setHours(0, 0, 0, 0)).to.equal(
         parse2?.setHours(0, 0, 0, 0)
       );
@@ -793,7 +945,16 @@ describe('Date Time Input component', () => {
       simulateKeyboard(input, [ctrlKey, ';']);
       await elementUpdated(element);
 
-      expect(element.value).to.not.be.undefined;
+      // Uncommitted while the input is focused - issue #1346
+      expect(element.value).to.be.null;
+      expect(parser.parseDate(input.value)?.setHours(0, 0, 0, 0)).to.equal(
+        today
+      );
+
+      element.blur();
+      await elementUpdated(element);
+
+      expect(element.value).to.not.be.null;
       expect(element.value!.setHours(0, 0, 0, 0)).to.equal(today);
     });
 

--- a/src/components/date-time-input/date-time-input.ts
+++ b/src/components/date-time-input/date-time-input.ts
@@ -65,7 +65,7 @@ export interface IgcDateTimeInputComponentEventMap {
  */
 export default class IgcDateTimeInputComponent extends EventEmitterMixin<
   IgcDateTimeInputComponentEventMap,
-  AbstractConstructor<IgcDateTimeInputBaseComponent>
+  AbstractConstructor<IgcDateTimeInputBaseComponent<Date>>
 >(IgcDateTimeInputBaseComponent) {
   public static readonly tagName = 'igc-date-time-input';
   public static styles = [styles, shared];
@@ -95,8 +95,6 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
     return { ...DEFAULT_DATE_PARTS_SPIN_DELTAS, ...this.spinDelta };
   }
 
-  protected _oldValue: Date | null = null;
-
   //#endregion
 
   //#region Public attributes and properties
@@ -104,15 +102,28 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
   /* @tsTwoWayProperty(true, "igcChange", "detail", false) */
   /**
    * The value of the input.
+   *
+   * Only ever holds a committed value. While the user is typing, the intermediate
+   * state lives in the masked text and is committed - together with an `igcChange`
+   * event - when the edit is committed on blur. Use the `igcInput` event to observe
+   * the value as it is being typed.
+   *
    * @attr
    */
   @property({ converter: convertToDate })
-  public set value(value: Date | string | null | undefined) {
-    this._formValue.setValueAndFormState(value as Date | null);
+  public override set value(value: Date | string | null | undefined) {
+    const next = convertToDate(value);
+
+    if (equal(this._formValue.value, next)) {
+      return;
+    }
+
+    this._isEditing = false;
+    this._formValue.setValueAndFormState(next);
     this._updateMaskDisplay();
   }
 
-  public get value(): Date | null {
+  public override get value(): Date | null {
     return this._formValue.value;
   }
 
@@ -136,30 +147,6 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
     } else if (this.displayFormat !== this.inputFormat) {
       this._updateMaskDisplay();
     }
-  }
-
-  protected override _handleBlur(): void {
-    this._focused = false;
-
-    // Handle incomplete mask input
-    if (!(this._isMaskComplete() || this._isEmptyMask)) {
-      const parsedDate = this._parser.parseDate(this._maskedValue);
-
-      if (parsedDate) {
-        this.value = parsedDate;
-      } else {
-        this.clear();
-      }
-    } else {
-      this._updateMaskDisplay();
-    }
-
-    // Emit change event if value changed
-    if (!this.readOnly && !equal(this._oldValue, this.value)) {
-      this.emitEvent('igcChange', { detail: this.value });
-    }
-
-    super._handleBlur();
   }
 
   //#endregion
@@ -217,14 +204,17 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
       this._parser.getFirstDatePart()?.type) as DatePart | undefined;
   }
 
-  /**
-   * Builds the masked value string from the current date value.
-   * Returns empty mask if no value, or existing masked value if incomplete.
-   */
-  protected override _buildMaskedValue(): string {
-    return isValidDate(this.value)
-      ? this._parser.formatDate(this.value)
-      : this._maskedValue || this._parser.emptyMask;
+  protected override _parseMask(strict: boolean): Date | null {
+    if (strict && !this._isMaskComplete()) {
+      return null;
+    }
+
+    const parsed = this._parser.parseDate(this._maskedValue);
+    return isValidDate(parsed) ? parsed : null;
+  }
+
+  protected override _formatValue(value: Date | null): string {
+    return this._parser.formatDate(value);
   }
 
   /**
@@ -237,17 +227,10 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
   }
 
   /**
-   * Commits a value produced by spinning a date part.
-   */
-  protected override _commitSpunValue(value: unknown): void {
-    this.value = value as Date;
-  }
-
-  /**
    * Sets the value to the current date/time.
    */
   protected override _setCurrentDateTime(): void {
-    this.value = new Date();
+    this._setDraftValue(new Date());
     this._emitInputEvent();
   }
 
@@ -257,7 +240,9 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
    */
   protected override _emitInputEvent(): void {
     this._setTouchedState();
-    this.emitEvent('igcInput', { detail: this.value?.toISOString() });
+    this.emitEvent('igcInput', {
+      detail: this._uncommittedValue?.toISOString(),
+    });
   }
 
   /**
@@ -283,11 +268,13 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
    * Spins a specific date part by the given delta.
    */
   protected _spinDatePart(datePart: DatePart, delta: number): Date {
-    if (!isValidDate(this.value)) {
+    const current = this._uncommittedValue;
+
+    if (!isValidDate(current)) {
       return new Date();
     }
 
-    const newDate = new Date(this.value.getTime());
+    const newDate = new Date(current.getTime());
     const partType = datePart as unknown as DateParts;
 
     // Get the part instance from the parser, or create one for explicit spin operations
@@ -314,24 +301,10 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
       date: newDate,
       spinLoop: this.spinLoop,
       amPmValue,
-      originalDate: this.value,
+      originalDate: current,
     });
 
     return newDate;
-  }
-
-  /**
-   * Updates the internal value based on the current masked input.
-   * Only sets a value if the mask is complete and parses to a valid date.
-   */
-  protected override _syncValueFromMask(): void {
-    if (!this._isMaskComplete()) {
-      this.value = null;
-      return;
-    }
-
-    const parsedDate = this._parser.parseDate(this._maskedValue);
-    this.value = isValidDate(parsedDate) ? parsedDate : null;
   }
 
   //#endregion
@@ -346,12 +319,6 @@ export default class IgcDateTimeInputComponent extends EventEmitterMixin<
   /** Decrements a date/time portion. */
   public override stepDown(datePart?: DatePart, delta?: number): void {
     super.stepDown(datePart, delta);
-  }
-
-  /** Clears the input element of user input. */
-  public override clear(): void {
-    this._maskedValue = '';
-    this.value = null;
   }
 
   /* blazorSuppress */

--- a/src/components/validation-container/validation-container.spec.ts
+++ b/src/components/validation-container/validation-container.spec.ts
@@ -76,4 +76,31 @@ describe('Validation container', () => {
 
     await ValidityHelpers.checkValidationSlots(input, 'valueMissing');
   });
+
+  it('validation messages survive a re-render after a failed form submission', async () => {
+    const form = await fixture<HTMLFormElement>(html`
+      <form>
+        <igc-input name="input" required>
+          <div slot=${valueMissingSlot}>Value missing</div>
+        </igc-input>
+      </form>
+    `);
+
+    input = form.querySelector(IgcInputComponent.tagName)!;
+
+    form.requestSubmit();
+    await elementUpdated(input);
+
+    ValidityHelpers.hasInvalidStyles(input).to.be.true;
+    ValidityHelpers.hasSlottedContent(input, valueMissingSlot).to.be.true;
+
+    // Any subsequent host update - a slotchange, an unrelated property - used to
+    // drop the messages, since the submission only kept the control invalid for
+    // the update it scheduled itself.
+    input.requestUpdate();
+    await elementUpdated(input);
+
+    ValidityHelpers.hasInvalidStyles(input).to.be.true;
+    ValidityHelpers.hasSlottedContent(input, valueMissingSlot).to.be.true;
+  });
 });

--- a/stories/date-picker.stories.ts
+++ b/stories/date-picker.stories.ts
@@ -72,7 +72,8 @@ const metadata: Meta<IgcDatePickerComponent> = {
     },
     value: {
       type: 'Date',
-      description: 'The value of the picker',
+      description:
+        'The value of the picker.\n\nOnly ever holds a committed value. While the user is typing in the input, the\nintermediate state stays in the editor and is committed - together with an\n`igcChange` event - when the edit is committed on blur. Use the `igcInput` event\nto observe the value as it is being typed.',
       control: 'date',
     },
     activeDate: {
@@ -257,7 +258,14 @@ interface IgcDatePickerArgs {
   nonEditable: boolean;
   /** Makes the control a readonly field. */
   readOnly: boolean;
-  /** The value of the picker */
+  /**
+   * The value of the picker.
+   *
+   * Only ever holds a committed value. While the user is typing in the input, the
+   * intermediate state stays in the editor and is committed - together with an
+   * `igcChange` event - when the edit is committed on blur. Use the `igcInput` event
+   * to observe the value as it is being typed.
+   */
   value: Date;
   /**
    * Gets/Sets the date which is shown in the calendar picker and is highlighted.

--- a/stories/date-time-input.stories.ts
+++ b/stories/date-time-input.stories.ts
@@ -27,9 +27,10 @@ const metadata: Meta<IgcDateTimeInputComponent> = {
   },
   argTypes: {
     value: {
-      type: 'Date',
-      description: 'The value of the input.',
-      control: 'date',
+      type: 'T',
+      description:
+        'The value of the input.\n\nOnly ever holds a committed value. While the user is typing, the intermediate\nstate lives in the masked text and is committed - together with an `igcChange`\nevent - when the edit is committed on blur. Use the `igcInput` event to observe\nthe value as it is being typed.',
+      control: 'T',
     },
     readOnly: {
       type: 'boolean',
@@ -137,8 +138,15 @@ const metadata: Meta<IgcDateTimeInputComponent> = {
 export default metadata;
 
 interface IgcDateTimeInputArgs {
-  /** The value of the input. */
-  value: Date;
+  /**
+   * The value of the input.
+   *
+   * Only ever holds a committed value. While the user is typing, the intermediate
+   * state lives in the masked text and is committed - together with an `igcChange`
+   * event - when the edit is committed on blur. Use the `igcInput` event to observe
+   * the value as it is being typed.
+   */
+  value: T;
   /** Makes the control a readonly field. */
   readOnly: boolean;
   /** The mask pattern of the component. */


### PR DESCRIPTION
## Description

`value` no longer moves on every keystroke. While the input is focused the masked text is the source of truth, and the parsed result reaches `value` together with `igcChange` when the edit is committed on blur. Use `igcInput` to observe the value as it is typed - its ISO-string detail is unchanged.

This is what the annotated two-way binding always claimed: framework wrappers treat `igcChange` as the only signal that `value` moved, so a host that binds the property held a stale value for the whole editing session. On every keystroke it re-committed that stale value, and the setter rebuilt the mask from it, wiping the half-typed input - reported against an igx-grid cell editor, where an unrelated re-render was enough to trigger it.

The draft alone does not fix that, since the re-applied value is an equal but not identical Date and passes Lit's dirty check. So the setter is now idempotent: an assignment that deep-equals the current value is a no-op and cannot disturb an edit in progress.

Spinning and Ctrl+; while focused move the draft; unfocused stepUp/stepDown, clear(), setRangeText() and drops still commit immediately, as they have no blur coming to commit them. The pickers stop assigning their own value on igcInput and read the draft instead, so the calendar keeps following along while the user types.

Same treatment for igc-date-range-input, and the shared logic - commit, draft, mask display, clear and setRangeText - now lives once in IgcDateTimeInputBaseComponent, which became generic over its value type. Both concrete inputs come out smaller than before the fix.

**Behavioral change**: reading `.value` mid-typing now returns the last committed value.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Behavioral change (fix or feature that causes existing functionality to change)

## Related Issues

Closes #1346


## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] Breaking changes are documented in the description
