### PR TITLE
fix(tabs): opaque scroll buttons in the Indigo theme (#1955)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - #### Form associated components
   - Validation messages no longer disappear right after the first failed form submission. The submit-driven invalid state used to hold only for the update the submission itself scheduled, so any re-render that followed - a `slotchange` from the validation slots the submission had just projected, for instance - silently dropped the projected messages while the invalid styling stayed on.
   - Invalid styling now follows the validity state, so a control that turns valid again (a cleared `required`, a widened `min`/`max`, a disabled control) drops the styles it picked up from an earlier interaction or submission.
+- #### Tabs
+  - See-through scroll buttons in the Indigo theme. The buttons are sticky and the tab headers scroll underneath them, but the theme leaves both the buttons and the tabs strip transparent, so the scrolled headers showed through. The buttons now paint an opaque surface backdrop below their themed background. [#1955](https://github.com/IgniteUI/igniteui-webcomponents/issues/1955)
 
 ## [7.2.4] - 2026-06-29
 ### Added

--- a/src/components/tabs/themes/shared/tabs/tabs.indigo.scss
+++ b/src/components/tabs/themes/shared/tabs/tabs.indigo.scss
@@ -44,8 +44,24 @@ $theme: $indigo;
     }
 }
 
+// The scroll buttons are sticky and the tab items scroll underneath them.
+// Both the button and the tabs strip are transparent in Indigo, so an opaque
+// surface backdrop is painted below the themed background, otherwise the tabs
+// show through the buttons.
+igc-icon-button::part(base) {
+    overflow: hidden;
+    background-color: color($color: 'surface');
+    background-image: linear-gradient(
+        var-get($theme, 'button-background'),
+        var-get($theme, 'button-background')
+    );
+}
+
 igc-icon-button:hover::part(base) {
-    background-color: var-get($theme, 'button-hover-background');
+    background-image: linear-gradient(
+        var-get($theme, 'button-hover-background'),
+        var-get($theme, 'button-hover-background')
+    );
 
     &::after {
         content: '';
@@ -53,10 +69,6 @@ igc-icon-button:hover::part(base) {
         inset: 0;
         z-index: 1;
     }
-}
-
-igc-icon-button::part(base) {
-    overflow: hidden;
 }
 
 igc-icon-button[disabled]::part(base), 


### PR DESCRIPTION
## Description

The tab headers no longer show through the scroll buttons. The buttons now paint an opaque surface backdrop underneath their themed background, so the content scrolling beneath them stays hidden.

The 6.0.0 refactor moved the scroll buttons inside the scrolling container - they are sticky grid cells that the headers scroll under, where before they were flex siblings sitting outside the scroller and nothing could pass behind them. Material, Fluent and Bootstrap resolve button-background to surface and were unaffected; Indigo leaves both button-background and item-background transparent, so from 6.0.0 on its buttons were see-through.

The backdrop is layered rather than substituted: background-color carries the surface color and the themed background goes on top as a gradient, so a button-background set through the Sass theme - or auto-derived from a custom item-background - still covers it, and the parameters fixed in #1929 keep working. Hover moves to the same layer, so Indigo's translucent button-hover-background tint now composites over the surface instead of over nothing. The disabled and focused states inherit the backdrop from the base rule.

Default Indigo will show a faint surface patch where the buttons sit if the surrounding background is not surface, which is inherent to overlaying a transparent strip and matches what the other three themes already do.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related Issues

Closes #1955

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
