### PR TITLE
fix(virtual-scroll): bound waits, gate renders, correct engine edge cases

### DIFF
--- a/src/components/common/controllers/resize-observer.ts
+++ b/src/components/common/controllers/resize-observer.ts
@@ -24,6 +24,13 @@ export interface ResizeObserverControllerConfig {
    * Pass in `null` to skip setting an initial target.
    */
   target?: Element | null;
+  /**
+   * Whether observing a target should request an update on the host.
+   *
+   * Defaults to `true`. Set to `false` when the host already drives its own
+   * update cycle and an extra render per observed element is wasted work.
+   */
+  requestUpdate?: boolean;
 }
 
 class ResizeObserverController implements ReactiveController {
@@ -55,11 +62,19 @@ class ResizeObserverController implements ReactiveController {
     host.addController(this);
   }
 
+  /** The elements currently being observed. */
+  public get targets(): ReadonlySet<Element> {
+    return this._targets;
+  }
+
   /** Starts observing the `targe` element. */
   public observe(target: Element): void {
     this._targets.add(target);
     this._observer.observe(target, this._config.options);
-    this._host.requestUpdate();
+
+    if (this._config.requestUpdate ?? true) {
+      this._host.requestUpdate();
+    }
   }
 
   /** Stops observing the `target` element. */

--- a/src/components/virtualization/engine.spec.ts
+++ b/src/components/virtualization/engine.spec.ts
@@ -1,0 +1,426 @@
+import { expect } from '@open-wc/testing';
+import { VirtualScrollEngine } from './engine.js';
+
+describe('VirtualScrollEngine', () => {
+  const ESTIMATE = 50;
+
+  function createEngine(
+    length = 100,
+    estimate = ESTIMATE
+  ): VirtualScrollEngine {
+    const engine = new VirtualScrollEngine();
+    engine.resize(length, estimate);
+    return engine;
+  }
+
+  /**
+   * A stand-in document whose probe reports `maxSize` as the furthest
+   * reachable coordinate, without touching the real one. `scrollTop` models a
+   * document that is already scrolled when the probe runs - the probe's rect
+   * is viewport-relative, so it comes back short by exactly that much.
+   * `probes` counts how often the probe element was actually created.
+   */
+  function createProbeDocument(maxSize: number, scrollTop = 0) {
+    const probe = {
+      style: {} as CSSStyleDeclaration,
+      getBoundingClientRect: () => ({ top: maxSize - scrollTop }),
+    };
+    const state = { probes: 0 };
+    const doc = {
+      body: { appendChild: () => undefined, removeChild: () => undefined },
+      documentElement: { scrollTop },
+      createElement: () => {
+        state.probes++;
+        return probe;
+      },
+    } as unknown as Document;
+
+    return { doc, state };
+  }
+
+  /**
+   * Builds an engine whose probed maximum browser size is `maxSize`. Anything
+   * past that point makes the engine compress its virtual coordinate space
+   * into the DOM one.
+   */
+  function createEngineWithMaxSize(
+    maxSize: number,
+    length: number,
+    estimate = ESTIMATE
+  ): VirtualScrollEngine {
+    const engine = new VirtualScrollEngine();
+    engine.initMaxBrowserSize(createProbeDocument(maxSize).doc);
+    engine.resize(length, estimate);
+    return engine;
+  }
+
+  describe('Sizing', () => {
+    it('fills new items with the estimated size', () => {
+      const engine = createEngine(10);
+
+      expect(engine.totalSize).to.equal(500);
+      expect(engine.domSize).to.equal(500);
+      expect(engine.getScrollOffsetForIndex(0)).to.equal(0);
+      expect(engine.getScrollOffsetForIndex(3)).to.equal(150);
+    });
+
+    it('reports zero size before it is sized', () => {
+      const engine = new VirtualScrollEngine();
+
+      expect(engine.totalSize).to.equal(0);
+      expect(engine.getScrollOffsetForIndex(5)).to.equal(0);
+      expect(engine.getPhysicalRangeSize(0, 10)).to.equal(0);
+      expect(engine.getVisibleRange(0, 300, 2)).to.eql({
+        startIndex: 0,
+        endIndex: -1,
+      });
+    });
+
+    it('applies a measured size to subsequent offsets', () => {
+      const engine = createEngine(10);
+      engine.measureItem(2, 120);
+
+      expect(engine.totalSize).to.equal(570);
+      expect(engine.getScrollOffsetForIndex(2)).to.equal(100);
+      expect(engine.getScrollOffsetForIndex(3)).to.equal(220);
+      expect(engine.getPhysicalRangeSize(2, 2)).to.equal(120);
+    });
+
+    it('ignores measurements for out of range indices', () => {
+      const engine = createEngine(10);
+      engine.measureItem(10, 120);
+      engine.measureItem(-1, 120);
+
+      expect(engine.totalSize).to.equal(500);
+    });
+
+    it('clamps offsets to the item count', () => {
+      const engine = createEngine(10);
+
+      expect(engine.getScrollOffsetForIndex(10)).to.equal(500);
+      expect(engine.getScrollOffsetForIndex(999)).to.equal(500);
+      expect(engine.getScrollOffsetForIndex(-5)).to.equal(0);
+    });
+
+    it('sums only the requested range, clamped to the item count', () => {
+      const engine = createEngine(10);
+
+      expect(engine.getPhysicalRangeSize(2, 4)).to.equal(150);
+      expect(engine.getPhysicalRangeSize(-5, 1)).to.equal(100);
+      expect(engine.getPhysicalRangeSize(8, 999)).to.equal(100);
+      expect(engine.getPhysicalRangeSize(4, 3)).to.equal(0);
+    });
+  });
+
+  describe('Estimated size', () => {
+    it('applies a new estimate to unmeasured items only', () => {
+      const engine = createEngine(10);
+      engine.measureItem(0, 30);
+      engine.updateEstimatedSize(100);
+
+      expect(engine.totalSize).to.equal(30 + 9 * 100);
+      expect(engine.getScrollOffsetForIndex(1)).to.equal(30);
+    });
+
+    it('treats a measurement equal to the current size as measured', () => {
+      const engine = createEngine(10);
+      // Same value as the estimate - no size change, but the item must still
+      // be flagged as measured so a later estimate cannot overwrite it.
+      engine.measureItem(0, ESTIMATE);
+      engine.updateEstimatedSize(100);
+
+      expect(engine.totalSize).to.equal(ESTIMATE + 9 * 100);
+    });
+  });
+
+  describe('Resizing', () => {
+    it('preserves measured sizes when items are appended', () => {
+      const engine = createEngine(10);
+      engine.measureItem(1, 30);
+      engine.resize(20, ESTIMATE);
+
+      expect(engine.totalSize).to.equal(30 + 19 * ESTIMATE);
+      expect(engine.getScrollOffsetForIndex(2)).to.equal(80);
+    });
+
+    it('preserves measured sizes when items are removed', () => {
+      const engine = createEngine(10);
+      engine.measureItem(1, 30);
+      engine.resize(5, ESTIMATE);
+
+      expect(engine.totalSize).to.equal(30 + 4 * ESTIMATE);
+    });
+
+    it('discards measured sizes at and beyond retainCount', () => {
+      const engine = createEngine(10);
+      engine.measureItem(1, 30);
+      engine.measureItem(6, 30);
+      engine.resize(10, ESTIMATE, 4);
+
+      // Item 1 is retained, item 6 is reset back to the estimate.
+      expect(engine.totalSize).to.equal(30 + 9 * ESTIMATE);
+      expect(engine.getScrollOffsetForIndex(2)).to.equal(80);
+    });
+
+    it('re-marks discarded items as unmeasured', () => {
+      const engine = createEngine(10);
+      engine.measureItem(6, 30);
+      engine.resize(10, ESTIMATE, 4);
+      engine.updateEstimatedSize(100);
+
+      // Nothing is measured any more, so every item follows the new estimate.
+      expect(engine.totalSize).to.equal(10 * 100);
+    });
+
+    it('is a no-op when the length matches and everything is retained', () => {
+      const engine = createEngine(10);
+      engine.measureItem(1, 30);
+
+      let notified = false;
+      engine.onSizeChange = () => {
+        notified = true;
+      };
+      engine.resize(10, ESTIMATE);
+
+      expect(notified).to.be.false;
+      expect(engine.totalSize).to.equal(30 + 9 * ESTIMATE);
+    });
+  });
+
+  describe('Change notifications', () => {
+    it('notifies on resize, measurement and estimate changes', () => {
+      const engine = new VirtualScrollEngine();
+      let count = 0;
+      engine.onSizeChange = () => {
+        count++;
+      };
+
+      engine.resize(10, ESTIMATE);
+      expect(count).to.equal(1);
+
+      engine.measureItem(0, 30);
+      expect(count).to.equal(2);
+
+      engine.updateEstimatedSize(80);
+      expect(count).to.equal(3);
+    });
+
+    it('does not notify when nothing actually changes', () => {
+      const engine = createEngine(10);
+      let count = 0;
+      engine.onSizeChange = () => {
+        count++;
+      };
+
+      engine.measureItem(0, ESTIMATE);
+      engine.updateEstimatedSize(ESTIMATE);
+
+      expect(count).to.equal(0);
+    });
+  });
+
+  describe('Visible range', () => {
+    it('returns an empty range without items or viewport', () => {
+      expect(createEngine(0).getVisibleRange(0, 300, 2)).to.eql({
+        startIndex: 0,
+        endIndex: -1,
+      });
+      expect(createEngine(10).getVisibleRange(0, 0, 2)).to.eql({
+        startIndex: 0,
+        endIndex: -1,
+      });
+    });
+
+    it('covers the viewport from the top', () => {
+      const engine = createEngine(100);
+
+      expect(engine.getVisibleRange(0, 300, 0)).to.eql({
+        startIndex: 0,
+        endIndex: 6,
+      });
+    });
+
+    it('resolves an offset that falls exactly on an item boundary', () => {
+      const engine = createEngine(100);
+
+      expect(engine.getVisibleRange(100, 100, 0)).to.eql({
+        startIndex: 2,
+        endIndex: 4,
+      });
+    });
+
+    it('expands by the over-scan and clamps to the item count', () => {
+      const engine = createEngine(100);
+
+      expect(engine.getVisibleRange(0, 300, 2)).to.eql({
+        startIndex: 0,
+        endIndex: 8,
+      });
+      expect(engine.getVisibleRange(5000, 300, 2)).to.eql({
+        startIndex: 97,
+        endIndex: 99,
+      });
+    });
+
+    it('accounts for measured sizes', () => {
+      const engine = createEngine(100);
+      for (let i = 0; i < 10; i++) {
+        engine.measureItem(i, 100);
+      }
+
+      expect(engine.getVisibleRange(0, 300, 0)).to.eql({
+        startIndex: 0,
+        endIndex: 3,
+      });
+    });
+  });
+
+  describe('Alignment', () => {
+    it('aligns to the leading edge', () => {
+      const engine = createEngine(100);
+
+      expect(engine.getAlignedScrollOffset(10, 300, 'start')).to.equal(500);
+    });
+
+    it('centers the item within the viewport', () => {
+      const engine = createEngine(100);
+
+      // 500 - (300 - 50) / 2
+      expect(engine.getAlignedScrollOffset(10, 300, 'center')).to.equal(375);
+    });
+
+    it('aligns to the trailing edge', () => {
+      const engine = createEngine(100);
+
+      // 500 - (300 - 50)
+      expect(engine.getAlignedScrollOffset(10, 300, 'end')).to.equal(250);
+    });
+
+    it('never returns a negative offset', () => {
+      const engine = createEngine(100);
+
+      expect(engine.getAlignedScrollOffset(0, 300, 'center')).to.equal(0);
+      expect(engine.getAlignedScrollOffset(1, 300, 'end')).to.equal(0);
+    });
+
+    it('clamps to the largest reachable scroll offset', () => {
+      const engine = createEngine(100);
+      const maxOffset = engine.domSize - 300;
+
+      expect(maxOffset).to.equal(5000 - 300);
+      expect(engine.getAlignedScrollOffset(99, 300, 'start')).to.equal(
+        maxOffset
+      );
+    });
+
+    it('reports whether an item is fully in view', () => {
+      const engine = createEngine(100);
+
+      expect(engine.isIndexInView(0, 0, 300)).to.be.true;
+      expect(engine.isIndexInView(5, 0, 300)).to.be.true;
+      // Item 6 spans 300 - 350, so it is only partially visible.
+      expect(engine.isIndexInView(6, 0, 300)).to.be.false;
+      expect(engine.isIndexInView(20, 0, 300)).to.be.false;
+    });
+
+    it('treats an item larger than the viewport as in view once it covers it', () => {
+      const engine = createEngine(10);
+      engine.measureItem(0, 1000);
+
+      // The item can never fit inside the viewport, but while it spans the
+      // whole of it there is nothing to scroll to - as with native
+      // `scrollIntoView({ block: 'nearest' })`.
+      expect(engine.isIndexInView(0, 0, 300)).to.be.true;
+      expect(engine.isIndexInView(0, 350, 300)).to.be.true;
+      // Scrolled past its trailing edge, it no longer covers the viewport.
+      expect(engine.isIndexInView(0, 800, 300)).to.be.false;
+    });
+
+    it('clamps an out of range index the same way as the alignment math', () => {
+      const engine = createEngine(100);
+      const last = engine.getAlignedScrollOffset(99, 300, 'start');
+
+      expect(engine.getAlignedScrollOffset(999, 300, 'start')).to.equal(last);
+      expect(engine.isIndexInView(999, last, 300)).to.equal(
+        engine.isIndexInView(99, last, 300)
+      );
+    });
+
+    it('stays within range on an empty tree', () => {
+      const engine = createEngine(0);
+
+      expect(engine.getAlignedScrollOffset(0, 300, 'center')).to.equal(0);
+      expect(engine.isIndexInView(0, 0, 300)).to.be.false;
+    });
+  });
+
+  describe('Coordinate compression', () => {
+    const MAX_SIZE = 10_000;
+    const ITEMS = 1000; // 50_000px total => ratio of 5
+
+    it('clamps the DOM size to the maximum browser size', () => {
+      const engine = createEngineWithMaxSize(MAX_SIZE, ITEMS);
+
+      expect(engine.totalSize).to.equal(50_000);
+      expect(engine.domSize).to.equal(MAX_SIZE);
+    });
+
+    it('leaves the DOM size untouched below the maximum', () => {
+      const engine = createEngineWithMaxSize(MAX_SIZE, 100);
+
+      expect(engine.totalSize).to.equal(5000);
+      expect(engine.domSize).to.equal(5000);
+    });
+
+    it('maps DOM scroll positions onto the virtual space', () => {
+      const engine = createEngineWithMaxSize(MAX_SIZE, ITEMS);
+
+      // Half way down the DOM range is half way down the virtual range.
+      expect(engine.getVisibleRange(MAX_SIZE / 2, 300, 0).startIndex).to.equal(
+        500
+      );
+      expect(engine.getScrollOffsetForIndex(500)).to.equal(MAX_SIZE / 2);
+    });
+
+    it('sizes the rendered window by the viewport, not by the ratio', () => {
+      const engine = createEngineWithMaxSize(MAX_SIZE, ITEMS);
+      const compressed = engine.getVisibleRange(MAX_SIZE / 2, 300, 0);
+
+      // A 300px viewport of 50px items shows 6 items regardless of how far
+      // the virtual space is compressed - the items themselves still render
+      // at their real size.
+      expect(compressed.endIndex - compressed.startIndex).to.equal(6);
+    });
+
+    it('converts the alignment slack into DOM space', () => {
+      const engine = createEngineWithMaxSize(MAX_SIZE, ITEMS);
+      const start = engine.getAlignedScrollOffset(500, 300, 'start');
+      const centered = engine.getAlignedScrollOffset(500, 300, 'center');
+
+      // The slack is 125 virtual px, which is 25 DOM px at a ratio of 5.
+      expect(start).to.equal(MAX_SIZE / 2);
+      expect(centered).to.equal(MAX_SIZE / 2 - 25);
+    });
+
+    it('probes a given document only once', () => {
+      const { doc, state } = createProbeDocument(MAX_SIZE);
+
+      new VirtualScrollEngine().initMaxBrowserSize(doc);
+      new VirtualScrollEngine().initMaxBrowserSize(doc);
+
+      expect(state.probes).to.equal(1);
+    });
+
+    it('probes the full extent from an already scrolled document', () => {
+      const { doc } = createProbeDocument(MAX_SIZE, 2500);
+      const engine = new VirtualScrollEngine();
+
+      engine.initMaxBrowserSize(doc);
+      engine.resize(ITEMS, ESTIMATE);
+
+      // Without adding the document scroll offset back, the probe would come
+      // back as 7500 and the content would be compressed into it.
+      expect(engine.domSize).to.equal(MAX_SIZE);
+    });
+  });
+});

--- a/src/components/virtualization/engine.ts
+++ b/src/components/virtualization/engine.ts
@@ -1,8 +1,9 @@
+import { clamp } from '../common/util.js';
+import type { ScrollAlignment, VisibleRange } from './types.js';
+
 /**
- * Caches the result of `getMaxBrowserSizeProbePx` per `Document`. The
- * maximum scrollable coordinate a browser supports doesn't change between
- * calls, so repeated probes across multiple virtual-scroll instances in the
- * same document are wasted DOM work.
+ * The maximum scrollable coordinate doesn't change over a document's lifetime,
+ * so instances sharing one document share a single probe.
  */
 const _maxBrowserSizeCache = new WeakMap<Document, number>();
 
@@ -23,8 +24,12 @@ function getMaxBrowserSizeProbePx(doc: Document): number {
   const div = doc.createElement('div');
   div.style.position = 'absolute';
   div.style.top = `${Number.MAX_SAFE_INTEGER}px`;
+  div.style.width = '0';
+  div.style.height = '0';
+  div.style.visibility = 'hidden';
   container.appendChild(div);
-  const size = Math.abs(div.getBoundingClientRect().top);
+  const scrollOffset = doc.documentElement?.scrollTop ?? 0;
+  const size = Math.abs(div.getBoundingClientRect().top) + scrollOffset;
   container.removeChild(div);
 
   _maxBrowserSizeCache.set(doc, size);
@@ -32,27 +37,50 @@ function getMaxBrowserSizeProbePx(doc: Document): number {
 }
 
 /**
- * Binary Indexed Tree (Fenwick tree) over item sizes.
- *
- * Replaces the previous O(N) prefix-sum rebuild that occurred on every
- * `measureItem` call. All hot-path operations are O(log N):
- *   - Point update (item measured)        : O(log N)
- *   - Prefix sum (scroll offset)          : O(log N)
- *   - Index at offset (scroll → item)     : O(log N) via binary lifting
+ * Clamps `index` into `[0, length - 1]`, keeping both `prefixSum(index)` and
+ * `prefixSum(index + 1)` addressable. Callers guard for `length > 0`.
  */
-class BIT {
+function clampIndex(index: number, length: number): number {
+  return clamp(index, 0, length - 1);
+}
+
+/**
+ * Fills `tree` - a 1-indexed Fenwick array of `sizes.length + 1` entries,
+ * expected to be zeroed - with the partial range sums of `sizes` in a single
+ * O(N) pass. Returns the grand total.
+ */
+function buildTree(tree: Float64Array, sizes: Float64Array): number {
+  const length = sizes.length;
+  let total = 0;
+
+  for (let i = 1; i <= length; i++) {
+    tree[i] += sizes[i - 1];
+    total += sizes[i - 1];
+    const j = i + (i & -i);
+    if (j <= length) {
+      tree[j] += tree[i];
+    }
+  }
+  return total;
+}
+
+/**
+ * Binary Indexed Tree (Fenwick tree) over item sizes. Every hot-path
+ * operation is O(log N): point update (item measured), prefix sum (scroll
+ * offset) and index at offset (scroll -> item, via binary lifting).
+ */
+class SizeTree {
   public readonly length: number;
 
   /** 1-indexed BIT; each cell holds a partial range sum. */
   private readonly _tree: Float64Array;
 
-  /** Raw per-item sizes (0-indexed) — kept for O(1) reads and delta calc. */
+  /** Raw per-item sizes (0-indexed), kept for O(1) reads and delta calc. */
   private readonly _sizes: Float64Array;
 
   /**
-   * Tracks which indices hold a real, DOM-measured size (`1`) as opposed to
-   * a placeholder/estimated size that was never actually measured (`0`).
-   * Only unmeasured indices are affected by `applyEstimate()`.
+   * Which indices hold a real, DOM-measured size (`1`) rather than an
+   * estimate (`0`). Only the latter are touched by `applyEstimate`.
    */
   private readonly _measured: Uint8Array;
 
@@ -60,9 +88,8 @@ class BIT {
   private _total: number;
 
   /**
-   * Highest power-of-two ≤ `length`, precomputed once for the binary
-   * lifting in `findIndexAtOffset` instead of recomputing it via
-   * `Math.clz32` on every call (this runs on every scroll event).
+   * Highest power-of-two <= `length`, for the binary lifting in
+   * `findIndexAtOffset`. Precomputed since that runs on every scroll event.
    */
   private readonly _topBit: number;
 
@@ -82,33 +109,23 @@ class BIT {
   }
 
   /**
-   * Creates a BIT of `length` items all initialized to `fillSize`, none of
+   * Creates a tree of `length` items all initialized to `fillSize`, none of
    * which are considered measured yet. O(N).
    */
-  public static filled(length: number, fillSize: number): BIT {
-    return BIT._build(
+  public static filled(length: number, fillSize: number): SizeTree {
+    return SizeTree._build(
       new Float64Array(length).fill(fillSize),
       new Uint8Array(length)
     );
   }
 
   /**
-   * Builds a BIT from a sizes array and its matching measured-flags array. O(N).
+   * Builds a tree from a sizes array and its matching measured-flags array. O(N).
    */
-  private static _build(sizes: Float64Array, measured: Uint8Array): BIT {
-    const length = sizes.length;
-    const tree = new Float64Array(length + 1);
-    let total = 0;
-
-    for (let i = 1; i <= length; i++) {
-      tree[i] += sizes[i - 1];
-      total += sizes[i - 1];
-      const j = i + (i & -i);
-      if (j <= length) {
-        tree[j] += tree[i];
-      }
-    }
-    return new BIT(length, sizes, tree, total, measured);
+  private static _build(sizes: Float64Array, measured: Uint8Array): SizeTree {
+    const tree = new Float64Array(sizes.length + 1);
+    const total = buildTree(tree, sizes);
+    return new SizeTree(sizes.length, sizes, tree, total, measured);
   }
 
   /** Total size of all items. O(1). */
@@ -150,27 +167,31 @@ class BIT {
   }
 
   /**
-   * Returns a new BIT of `newLength` items.
-   * Existing measured sizes (and their measured/estimated status) are
-   * preserved up to `min(this.length, newLength)`; new slots are filled
-   * with `fillSize` and marked unmeasured. Single O(N) build pass.
+   * Returns a new tree of `newLength` items in a single O(N) pass. Sizes and
+   * their measured flags are preserved up to
+   * `min(this.length, newLength, retainCount)`; the rest is filled with
+   * `fillSize` and marked unmeasured. Pass a `retainCount` below the item
+   * count when the data behind those indices changed identity.
    */
-  public cloneResized(newLength: number, fillSize: number): BIT {
+  public cloneResized(
+    newLength: number,
+    fillSize: number,
+    retainCount = newLength
+  ): SizeTree {
     const sizes = new Float64Array(newLength).fill(fillSize);
     const measured = new Uint8Array(newLength);
-    const retained = Math.min(this.length, newLength);
+    const retained = Math.max(0, Math.min(this.length, newLength, retainCount));
     sizes.set(this._sizes.subarray(0, retained));
     measured.set(this._measured.subarray(0, retained));
-    return BIT._build(sizes, measured);
+    return SizeTree._build(sizes, measured);
   }
 
   /**
-   * Applies `estimatedSize` to every item that hasn't been explicitly
-   * measured yet, leaving already-measured items untouched. A single
-   * estimate change can affect most of the items at once (e.g. a whole
-   * never-scrolled-to list), so this rebuilds the tree in one O(N) pass
-   * rather than issuing one O(log N) `update()` per affected item.
-   * Returns true when at least one item's size actually changed.
+   * Applies `estimatedSize` to every unmeasured item, leaving measured ones
+   * untouched. Returns true when at least one size changed.
+   *
+   * One estimate change can affect most of the list at once, so this rebuilds
+   * in a single O(N) pass instead of one O(log N) `update` per item.
    */
   public applyEstimate(estimatedSize: number): boolean {
     let changed = false;
@@ -183,23 +204,13 @@ class BIT {
     if (!changed) return false;
 
     this._tree.fill(0);
-    let total = 0;
-    for (let i = 1; i <= this.length; i++) {
-      this._tree[i] += this._sizes[i - 1];
-      total += this._sizes[i - 1];
-      const j = i + (i & -i);
-      if (j <= this.length) {
-        this._tree[j] += this._tree[i];
-      }
-    }
-    this._total = total;
+    this._total = buildTree(this._tree, this._sizes);
     return true;
   }
 
   /**
-   * Returns the 0-based index of the item that contains the given scroll `offset`,
-   * i.e. the largest i such that `prefixSum(i) <= offset < prefixSum(i + 1)`.
-   * O(log N) via binary lifting on the internal tree.
+   * Returns the 0-based index of the item containing the scroll `offset`, i.e.
+   * the largest i where `prefixSum(i) <= offset < prefixSum(i + 1)`. O(log N).
    */
   public findIndexAtOffset(offset: number): number {
     if (offset <= 0 || this.length === 0) return 0;
@@ -219,21 +230,17 @@ class BIT {
 }
 
 /**
- * Describes the currently visible (and over-scanned) range of items.
- */
-export interface VisibleRange {
-  /** Index of the first rendered item (inclusive) */
-  startIndex: number;
-  /** Index of the last rendered item (inclusive) */
-  endIndex: number;
-}
-
-/**
- * Pure scroll-math engine for a single axis of virtual scrolling.
+ * Pure scroll-math engine for a single axis of virtual scrolling. All size
+ * state is held in a Fenwick tree.
  *
- * All size state is held as plain arrays. Consumers can register an
- * `onSizeChange` callback to react whenever item sizes or the item count
- * changes (e.g. to trigger a Lit `requestUpdate()`).
+ * ### Virtual vs DOM coordinates
+ *
+ * Browsers cap how far an element can be scrolled. When the summed item size
+ * exceeds that cap, the engine compresses the *virtual* space (`0…totalSize`)
+ * into the *DOM* space the browser can represent (`0…domSize`) by the factor
+ * `_virtualRatio`. Every offset crossing that boundary is scaled: incoming
+ * scroll positions are multiplied by the ratio, outgoing offsets divided by
+ * it. Item sizes render at their real px size and so are always virtual.
  */
 export class VirtualScrollEngine {
   private _maxBrowserSize = Number.POSITIVE_INFINITY;
@@ -246,11 +253,11 @@ export class VirtualScrollEngine {
   private _virtualRatio = 1;
 
   /** Binary Indexed Tree for O(log N) size queries and updates. */
-  private _tree: BIT | null = null;
+  private _tree: SizeTree | null = null;
 
   /**
-   * Called whenever item sizes or the item count change.
-   * Assign a callback (e.g. `() => this.requestUpdate()`) to react to size updates.
+   * Called whenever item sizes or the item count change, e.g.
+   * `() => this.requestUpdate()`.
    */
   public onSizeChange: (() => void) | null = null;
 
@@ -259,37 +266,39 @@ export class VirtualScrollEngine {
     return this._tree?.totalSize ?? 0;
   }
 
-  /** Actual DOM space size (clamped to the maximum browser size) */
+  /** Total size in DOM space, clamped to the maximum browser size. */
   public get domSize(): number {
     return this._virtualRatio !== 1 ? this._maxBrowserSize : this.totalSize;
   }
 
-  /**
-   * Initializes the maximum browser size by probing the document, and updates the virtual ratio accordingly.
-   */
+  /** Probes the document for the maximum browser size and rescales. */
   public initMaxBrowserSize(doc: Document): void {
     this._maxBrowserSize = getMaxBrowserSizeProbePx(doc);
     this._updateVirtualRatio();
   }
 
   /**
-   * Grows or shrinks the internal sizes array to `length`.
-   * New entries are filled with `estimatedSize`.
-   * Existing measured sizes are preserved.
+   * Grows or shrinks the internal sizes array to `length`. Measured sizes
+   * below `retainCount` are preserved; the rest is refilled with
+   * `estimatedSize` and marked unmeasured. Callers that only append can leave
+   * `retainCount` at its default; callers whose data changed identity at some
+   * index must pass it, so the stale measurements behind it are discarded.
    */
-  public resize(length: number, estimatedSize: number): void {
-    if (this._tree?.length === length) return;
+  public resize(
+    length: number,
+    estimatedSize: number,
+    retainCount = length
+  ): void {
+    if (this._tree?.length === length && retainCount >= length) return;
 
     this._tree = this._tree
-      ? this._tree.cloneResized(length, estimatedSize)
-      : BIT.filled(length, estimatedSize);
+      ? this._tree.cloneResized(length, estimatedSize, retainCount)
+      : SizeTree.filled(length, estimatedSize);
     this._updateVirtualRatio();
     this.onSizeChange?.();
   }
 
-  /**
-   * Records the measured DOM size for a single item.
-   */
+  /** Records the measured DOM size for a single item. */
   public measureItem(index: number, size: number): void {
     if (!this._tree?.update(index, size)) return;
 
@@ -298,10 +307,9 @@ export class VirtualScrollEngine {
   }
 
   /**
-   * Applies a new estimated size to every item that hasn't been explicitly
-   * measured in the DOM yet. Already-measured items keep their real size.
-   * Use this when `estimatedItemSize` changes but the item count doesn't
-   * (so `resize()` would otherwise be a no-op).
+   * Applies a new estimated size to every item not yet measured in the DOM.
+   * Use this when `estimatedItemSize` changes but the item count doesn't, so
+   * `resize` would be a no-op.
    */
   public updateEstimatedSize(estimatedSize: number): void {
     if (!this._tree?.applyEstimate(estimatedSize)) return;
@@ -311,8 +319,8 @@ export class VirtualScrollEngine {
   }
 
   /**
-   * Returns the DOM scroll offset in pixels that brings item at `index` into view
-   * at the leading edge of the viewport.
+   * Returns the DOM scroll offset in px that puts the item at `index` at the
+   * leading edge of the viewport.
    */
   public getScrollOffsetForIndex(index: number): number {
     if (!this._tree || index <= 0) return 0;
@@ -321,10 +329,72 @@ export class VirtualScrollEngine {
     return this._tree.prefixSum(clamped) / this._virtualRatio;
   }
 
-  /** Returns the item index at the given DOM scroll position. */
-  public getIndexAtScroll(scrollPosition: number): number {
-    if (!this._tree || scrollPosition <= 0) return 0;
-    return this._tree.findIndexAtOffset(scrollPosition * this._virtualRatio);
+  /**
+   * The largest DOM scroll offset the host can reach for the given viewport
+   * size. Requesting anything beyond it silently does nothing, so offsets
+   * handed out to a caller that waits for the scroll to settle are clamped
+   * to it.
+   */
+  private _getMaxScrollOffset(viewportSize: number): number {
+    return Math.max(0, this.domSize - viewportSize);
+  }
+
+  /**
+   * Returns the DOM scroll offset that positions the item at `index`
+   * according to `align` within a `viewportSize` px viewport, clamped to the
+   * reachable scroll range.
+   *
+   * The slack is computed in virtual space against the item's real size and
+   * converted to DOM space once, at the end: a DOM pixel is worth
+   * `_virtualRatio` virtual pixels, so mixing the two would scale the slack.
+   */
+  public getAlignedScrollOffset(
+    index: number,
+    viewportSize: number,
+    align: ScrollAlignment
+  ): number {
+    if (!this._tree || this._tree.length === 0) return 0;
+
+    const clamped = clampIndex(index, this._tree.length);
+    const itemStart = this._tree.prefixSum(clamped);
+    let offset = itemStart;
+
+    if (align !== 'start') {
+      const itemEnd = this._tree.prefixSum(clamped + 1);
+      const slack = viewportSize - Math.max(0, itemEnd - itemStart);
+      offset -= align === 'center' ? slack / 2 : slack;
+    }
+
+    return clamp(
+      offset / this._virtualRatio,
+      0,
+      this._getMaxScrollOffset(viewportSize)
+    );
+  }
+
+  /**
+   * Whether the item at `index` needs no scrolling to be seen at the given DOM
+   * scroll position: either it sits entirely inside the viewport, or it is
+   * larger than the viewport and already covers it end to end. The latter
+   * mirrors native `scrollIntoView({ block: 'nearest' })`.
+   */
+  public isIndexInView(
+    index: number,
+    scrollPosition: number,
+    viewportSize: number
+  ): boolean {
+    if (!this._tree || this._tree.length === 0) return false;
+
+    const clamped = clampIndex(index, this._tree.length);
+    const itemStart = this._tree.prefixSum(clamped);
+    const itemEnd = this._tree.prefixSum(clamped + 1);
+    const viewStart = Math.max(0, scrollPosition) * this._virtualRatio;
+    const viewEnd = viewStart + viewportSize;
+
+    const contained = itemStart >= viewStart && itemEnd <= viewEnd;
+    const spanning = itemStart <= viewStart && itemEnd >= viewEnd;
+
+    return contained || spanning;
   }
 
   /**
@@ -333,38 +403,29 @@ export class VirtualScrollEngine {
   public getVisibleRange(
     scrollPosition: number,
     viewportSize: number,
-    overScan: number,
-    totalItems: number
+    overScan: number
   ): VisibleRange {
-    if (totalItems === 0 || viewportSize <= 0) {
+    if (!this._tree || this._tree.length === 0 || viewportSize <= 0) {
       return { startIndex: 0, endIndex: -1 };
     }
 
-    const start = Math.max(0, this.getIndexAtScroll(scrollPosition) - overScan);
-    const endScrollPosition = scrollPosition + viewportSize;
-    const endRaw = this.getIndexAtScroll(endScrollPosition);
-    const end = Math.min(totalItems - 1, endRaw + overScan);
+    // The viewport is *not* scaled by the virtual ratio: items render at their
+    // real px size, so a `viewportSize` px viewport always shows that many
+    // virtual px worth of items, however compressed the scroll range is.
+    const startOffset = Math.max(0, scrollPosition) * this._virtualRatio;
+    const first = this._tree.findIndexAtOffset(startOffset);
+    const last = this._tree.findIndexAtOffset(startOffset + viewportSize);
 
-    return { startIndex: start, endIndex: end };
+    return {
+      startIndex: Math.max(0, first - overScan),
+      endIndex: Math.min(this._tree.length - 1, last + overScan),
+    };
   }
 
   /**
-   * Returns the CSS `translateY` / `translateX` value (px) to apply to the
-   * absolutely-positioned content wrapper.
-   *
-   * The content wrapper is `position: absolute; top: 0; left: 0` inside a
-   * track element that is `totalSize` px tall/wide. Translating it to
-   * `getContentPosition(startIndex)` places the first rendered item exactly
-   * at its virtual scroll position within the track.
-   */
-  public getContentPosition(index: number): number {
-    return this.getScrollOffsetForIndex(index);
-  }
-
-  /**
-   * Returns the sum of actual sizes for items in [startIndex, endIndex].
-   * Used to clamp the content translate offset under coordinate compression
-   * so rendered items never overflow past `domSize`.
+   * Sum of the actual sizes of the items in [startIndex, endIndex]. Clamps the
+   * content translate offset so rendered items never overflow past `domSize`
+   * under coordinate compression.
    */
   public getPhysicalRangeSize(startIndex: number, endIndex: number): number {
     if (!this._tree) return 0;
@@ -377,9 +438,6 @@ export class VirtualScrollEngine {
   private _updateVirtualRatio(): void {
     const totalSize = this._tree?.totalSize ?? 0;
     this._virtualRatio =
-      this._maxBrowserSize === Number.POSITIVE_INFINITY ||
-      totalSize <= this._maxBrowserSize
-        ? 1
-        : totalSize / this._maxBrowserSize;
+      totalSize <= this._maxBrowserSize ? 1 : totalSize / this._maxBrowserSize;
   }
 }

--- a/src/components/virtualization/types.ts
+++ b/src/components/virtualization/types.ts
@@ -1,6 +1,6 @@
 /**
- * Context for the item template in the virtual scroll component.
- * Provides the item data, its index, and utility properties for template rendering.
+ * Context passed to the item template: the item data, its index and utility
+ * properties for rendering.
  */
 export class VirtualScrollItemContext<T> {
   /** The current item in the virtual scroll */
@@ -27,6 +27,20 @@ export class VirtualScrollItemContext<T> {
   }
 }
 
+/**
+ * How `scrollToIndex` positions the requested item within the viewport.
+ * Mirrors the subset of `ScrollLogicalPosition` the engine can act on.
+ */
+export type ScrollAlignment = 'start' | 'center' | 'end';
+
+/** The currently visible (and over-scanned) range of items. */
+export interface VisibleRange {
+  /** Index of the first rendered item (inclusive) */
+  startIndex: number;
+  /** Index of the last rendered item (inclusive) */
+  endIndex: number;
+}
+
 /** Snapshot of the currently rendered virtual window */
 export interface VirtualScrollState {
   /** The index of the first item currently rendered in the viewport. */
@@ -40,8 +54,8 @@ export interface VirtualScrollState {
 }
 
 /**
- * Request for more data to be loaded in the virtual scroll, typically emitted when the user scrolls near the end of the currently loaded items.
- * The consumer of the virtual scroll component can listen to this event and load more data as needed.
+ * A request for more data, emitted when the rendered window comes near the end
+ * of the loaded items. Consumers listen for it and append what it asks for.
  */
 export interface VirtualScrollDataRequest {
   /**

--- a/src/components/virtualization/virtualization.spec.ts
+++ b/src/components/virtualization/virtualization.spec.ts
@@ -1,5 +1,5 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 import { defineComponents } from '../common/definitions/defineComponents.js';
 import { suppressResizeObserverLoopError } from '../common/utils.spec.js';
 import type { VirtualScrollItemContext, VirtualScrollState } from './types.js';
@@ -70,6 +70,36 @@ describe('VirtualScroll', () => {
 
       expect(el.getAttribute('orientation')).to.equal('vertical');
     });
+
+    it('re-reads the scroll offset from the new axis when it changes', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          orientation="horizontal"
+          style="width: 300px; height: 100px"
+          .data=${createItems(1000)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      el.scrollLeft = 500;
+      el.dispatchEvent(new Event('scroll'));
+      await elementUpdated(el);
+
+      const renderedIndices = () =>
+        Array.from(
+          el.querySelectorAll<HTMLElement>('[data-vs-index]'),
+          (item) => Number(item.dataset.vsIndex)
+        );
+
+      expect(Math.min(...renderedIndices())).to.be.greaterThan(0);
+
+      // The vertical axis was never scrolled, so switching to it must render
+      // from the top rather than reuse the horizontal offset.
+      el.orientation = 'vertical';
+      await elementUpdated(el);
+
+      expect(Math.min(...renderedIndices())).to.equal(0);
+    });
   });
 
   describe('Rendering', () => {
@@ -81,7 +111,7 @@ describe('VirtualScroll', () => {
         ></igc-virtual-scroll>`
       );
 
-      const content = el.querySelector('[part="igc-vs-content"]');
+      const content = el.querySelector('[part="virtualization-content"]');
       expect(content).to.be.null;
     });
 
@@ -94,8 +124,9 @@ describe('VirtualScroll', () => {
         ></igc-virtual-scroll>`
       );
 
-      expect(el.querySelector('[part="igc-vs-track"]')).to.not.be.null;
-      expect(el.querySelector('[part="igc-vs-content"]')).to.not.be.null;
+      expect(el.querySelector('[part="virtualization-track"]')).to.not.be.null;
+      expect(el.querySelector('[part="virtualization-content"]')).to.not.be
+        .null;
     });
   });
 
@@ -132,6 +163,132 @@ describe('VirtualScroll', () => {
 
       expect(eventSpy).calledWith('igcDataRequest');
     });
+
+    it('does not re-emit igcStateChange when the window is unchanged', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          .data=${createItems(500)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      const eventSpy = spy(el, 'emitEvent');
+
+      el.requestUpdate();
+      await elementUpdated(el);
+
+      expect(eventSpy).to.not.have.been.calledWith('igcStateChange');
+
+      el.scrollTop = 1000;
+      el.dispatchEvent(new Event('scroll'));
+      await elementUpdated(el);
+
+      expect(eventSpy).calledWith('igcStateChange');
+    });
+
+    it('does not re-request the same items when data is reassigned without growing', async () => {
+      const items = createItems(4);
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          .data=${items}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      const eventSpy = spy(el, 'emitEvent');
+
+      // A consumer whose source is exhausted, but which still reassigns in
+      // response to the request it can't fulfil. Without the guard this loops
+      // for as long as the consumer keeps answering.
+      el.data = items.slice();
+      await elementUpdated(el);
+      el.data = items.slice();
+      await elementUpdated(el);
+
+      expect(eventSpy).to.not.have.been.calledWith('igcDataRequest');
+    });
+
+    it('requests again once data actually grows', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          .data=${createItems(4)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      const eventSpy = spy(el, 'emitEvent');
+
+      el.data = createItems(8);
+      await elementUpdated(el);
+
+      expect(eventSpy).calledWith('igcDataRequest');
+    });
+  });
+
+  describe('Scroll handling', () => {
+    it('does not render for a scroll that stays within the same window', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          estimated-item-size="50"
+          over-scan="0"
+          .data=${createItems(500)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      const updateSpy = spy(el, 'requestUpdate');
+
+      // Items are 50px tall and the over-scan is off, so anything below the
+      // first item boundary renders exactly the same window.
+      el.scrollTop = 10;
+      el.dispatchEvent(new Event('scroll'));
+
+      expect(updateSpy).to.not.have.been.called;
+
+      el.scrollTop = 400;
+      el.dispatchEvent(new Event('scroll'));
+
+      expect(updateSpy).calledOnce;
+    });
+
+    it('re-registers its scroll handling after being reconnected', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          .data=${createItems(500)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      const parent = el.parentElement!;
+      el.remove();
+      parent.append(el);
+      await el.layoutComplete;
+
+      el.scrollTop = 2000;
+      el.dispatchEvent(new Event('scroll'));
+      await elementUpdated(el);
+
+      const rendered = Array.from(el.querySelectorAll('[data-vs-index]'));
+      expect(rendered).to.not.be.empty;
+      expect(
+        Number(rendered[0].getAttribute('data-vs-index'))
+      ).to.be.greaterThan(0);
+    });
   });
 
   describe('Public API', () => {
@@ -145,7 +302,7 @@ describe('VirtualScroll', () => {
       );
 
       await elementUpdated(el);
-      el.scrollToIndex(100);
+      await el.scrollToIndex(100);
 
       expect(el.scrollTop).to.be.greaterThan(0);
     });
@@ -161,9 +318,46 @@ describe('VirtualScroll', () => {
       );
 
       await elementUpdated(el);
-      el.scrollToIndex(100);
+      await el.scrollToIndex(100);
 
       expect(el.scrollLeft).to.be.greaterThan(0);
+    });
+
+    it('settles at the last index instead of waiting out the scroll timeout', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          .data=${createItems(1000)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await elementUpdated(el);
+
+      // The aligned offset for the final item lies past the reachable scroll
+      // range; unclamped, every correction pass would wait for a `scrollend`
+      // that the browser never fires.
+      await el.scrollToIndex(999, { block: 'end' });
+
+      expect(el.scrollTop).to.equal(el.scrollHeight - el.clientHeight);
+    });
+
+    it('does not scroll for block: nearest when the item is already in view', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          .data=${createItems(1000)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      const scrollToSpy = spy(el, 'scrollTo');
+      await el.scrollToIndex(1, { block: 'nearest' });
+
+      expect(scrollToSpy).to.not.have.been.called;
+      expect(el.scrollTop).to.equal(0);
     });
 
     it('keeps the requested index aligned once real item sizes differ from the estimate', async () => {
@@ -187,7 +381,9 @@ describe('VirtualScroll', () => {
       const targetIndex = 250;
       await el.scrollToIndex(targetIndex);
 
-      const content = el.querySelector<HTMLElement>('[part="igc-vs-content"]')!;
+      const content = el.querySelector<HTMLElement>(
+        '[part="virtualization-content"]'
+      )!;
       const renderedIndices = Array.from(
         content.querySelectorAll<HTMLElement>('[data-vs-index]')
       ).map((item) => Number(item.dataset.vsIndex));
@@ -219,7 +415,7 @@ describe('VirtualScroll', () => {
       await el.scrollToIndex(targetIndex, { behavior: 'smooth' });
 
       const content2 = el.querySelector<HTMLElement>(
-        '[part="igc-vs-content"]'
+        '[part="virtualization-content"]'
       )!;
       const renderedIndices2 = Array.from(
         content2.querySelectorAll<HTMLElement>('[data-vs-index]')
@@ -228,6 +424,61 @@ describe('VirtualScroll', () => {
       expect(Math.min(...renderedIndices2)).to.equal(
         Math.max(0, targetIndex - el.overScan)
       );
+    });
+
+    it('scrollToIndex with nearest leaves an item that already fills the viewport alone', async () => {
+      const tallTemplate: VirtualScrollItemTemplate<string> = (ctx) =>
+        html`<span style="display: block; height: 400px;">${ctx.value}</span>`;
+
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          estimated-item-size="400"
+          .data=${createItems(20)}
+          .itemTemplate=${tallTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      // Item 0 spans 0-400px; the viewport is 50-350px, so the item covers it
+      // end to end. It can never *fit* inside the viewport, but there is
+      // nothing to scroll to either.
+      el.scrollTop = 50;
+      el.dispatchEvent(new Event('scroll'));
+      await el.layoutComplete;
+
+      const scrollToSpy = spy(el, 'scrollTo');
+      await el.scrollToIndex(0, { block: 'nearest' });
+
+      expect(scrollToSpy).to.not.have.been.called;
+      expect(el.scrollTop).to.equal(50);
+    });
+
+    it('layoutComplete settles when no animation frames are served', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 300px"
+          .data=${createItems(100)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      await el.layoutComplete;
+
+      // A hidden tab or a disconnected element is never served frames. If
+      // `layoutComplete` waited on one unconditionally, this would hang and
+      // the test would time out.
+      const rafStub = stub(window, 'requestAnimationFrame').returns(0);
+
+      try {
+        el.data = createItems(200);
+        await el.layoutComplete;
+      } finally {
+        rafStub.restore();
+      }
+
+      expect(rafStub).to.have.been.called;
     });
   });
 
@@ -241,14 +492,16 @@ describe('VirtualScroll', () => {
       );
 
       const trackBefore = el.querySelector<HTMLElement>(
-        '[part="igc-vs-track"]'
+        '[part="virtualization-track"]'
       );
       expect(trackBefore?.style.height).to.equal(`${10 * 50}px`);
 
       el.data = createItems(20);
       await elementUpdated(el);
 
-      const trackAfter = el.querySelector<HTMLElement>('[part="igc-vs-track"]');
+      const trackAfter = el.querySelector<HTMLElement>(
+        '[part="virtualization-track"]'
+      );
       expect(trackAfter?.style.height).to.equal(`${20 * 50}px`);
     });
 
@@ -261,15 +514,62 @@ describe('VirtualScroll', () => {
       );
 
       const trackBefore = el.querySelector<HTMLElement>(
-        '[part="igc-vs-track"]'
+        '[part="virtualization-track"]'
       );
       expect(trackBefore?.style.height).to.equal(`${10 * 50}px`);
 
       el.estimatedItemSize = 80;
       await elementUpdated(el);
 
-      const trackAfter = el.querySelector<HTMLElement>('[part="igc-vs-track"]');
+      const trackAfter = el.querySelector<HTMLElement>(
+        '[part="virtualization-track"]'
+      );
       expect(trackAfter?.style.height).to.equal(`${10 * 80}px`);
+    });
+
+    it('retains measurements on append and discards them on replacement', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 100px"
+          .data=${createItems(20)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      const resizeSpy = spy(el['_engine'], 'resize');
+
+      // Appending leaves the identity of every existing index intact, so all
+      // 20 measurements are retained.
+      el.data = [...el.data, ...createItems(5)];
+      await elementUpdated(el);
+
+      expect(resizeSpy.lastCall.args).to.eql([25, 50, 20]);
+
+      // Replacing the collection invalidates every index from the first
+      // difference on - here, from the very beginning.
+      el.data = el.data.map((item) => `${item}!`);
+      await elementUpdated(el);
+
+      expect(resizeSpy.lastCall.args).to.eql([25, 50, 0]);
+    });
+
+    it('discards stale measurements when data of the same length is swapped', async () => {
+      const el = await fixture<IgcVirtualScrollComponent<string>>(
+        html`<igc-virtual-scroll
+          style="height: 100px"
+          .data=${createItems(20)}
+          .itemTemplate=${itemTemplate}
+        ></igc-virtual-scroll>`
+      );
+
+      const resizeSpy = spy(el['_engine'], 'resize');
+
+      // An identical item count used to make `resize` a no-op, stranding the
+      // previous data's measurements on the new items.
+      el.data = createItems(20).map((item) => `${item}!`);
+      await elementUpdated(el);
+
+      expect(resizeSpy.lastCall.args).to.eql([20, 50, 0]);
     });
 
     it('does not override the size of items already measured in the DOM', async () => {
@@ -294,13 +594,17 @@ describe('VirtualScroll', () => {
       await el.layoutComplete;
       await el.layoutComplete;
 
-      const content = el.querySelector<HTMLElement>('[part="igc-vs-content"]')!;
+      const content = el.querySelector<HTMLElement>(
+        '[part="virtualization-content"]'
+      )!;
       const measuredCount = content.querySelectorAll('[data-vs-index]').length;
 
       el.estimatedItemSize = 200;
       await elementUpdated(el);
 
-      const track = el.querySelector<HTMLElement>('[part="igc-vs-track"]');
+      const track = el.querySelector<HTMLElement>(
+        '[part="virtualization-track"]'
+      );
       const expectedHeight =
         measuredCount * realItemSize + (20 - measuredCount) * 200;
 
@@ -371,7 +675,9 @@ describe('VirtualScroll', () => {
       el.dispatchEvent(new Event('scroll'));
       await elementUpdated(el);
 
-      const content = el.querySelector<HTMLElement>('[part="igc-vs-content"]');
+      const content = el.querySelector<HTMLElement>(
+        '[part="virtualization-content"]'
+      );
       expect(content?.style.transform).to.match(/translateX\(-\d+(\.\d+)?px\)/);
     });
 
@@ -379,7 +685,10 @@ describe('VirtualScroll', () => {
       const el = await createRTLScroll();
 
       const eventSpy = spy(el, 'emitEvent');
-      el.data = createItems(1000);
+
+      // A different item count, so that the window genuinely changes - an
+      // equivalent one is deduplicated and emits nothing.
+      el.data = createItems(500);
       await elementUpdated(el);
 
       const stateCalls = eventSpy
@@ -400,7 +709,9 @@ describe('VirtualScroll', () => {
       const el = await createRTLScroll();
       await elementUpdated(el);
 
-      const content = el.querySelector<HTMLElement>('[part="igc-vs-content"]')!;
+      const content = el.querySelector<HTMLElement>(
+        '[part="virtualization-content"]'
+      )!;
       const items = Array.from(
         content.querySelectorAll<HTMLElement>('[data-vs-index]')
       );

--- a/src/components/virtualization/virtualization.ts
+++ b/src/components/virtualization/virtualization.ts
@@ -693,7 +693,7 @@ export default class IgcVirtualScrollComponent<
       return;
     }
 
-    this._lastEmittedState = detail;
+    this._lastEmittedState = { ...detail };
     this.emitEvent('igcStateChange', { detail });
   }
 

--- a/src/components/virtualization/virtualization.ts
+++ b/src/components/virtualization/virtualization.ts
@@ -1,5 +1,6 @@
 import {
   html,
+  isServer,
   LitElement,
   nothing,
   type PropertyValues,
@@ -12,12 +13,14 @@ import { createResizeObserverController } from '../common/controllers/resize-obs
 import { registerComponent } from '../common/definitions/register.js';
 import type { Constructor } from '../common/mixins/constructor.js';
 import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
-import { asNumber, isLTR } from '../common/util.js';
-import { VirtualScrollEngine, type VisibleRange } from './engine.js';
+import { asNumber, clamp, isLTR } from '../common/util.js';
+import { VirtualScrollEngine } from './engine.js';
 import {
+  type ScrollAlignment,
   type VirtualScrollDataRequest,
   VirtualScrollItemContext,
   type VirtualScrollState,
+  type VisibleRange,
 } from './types.js';
 
 export type VirtualScrollItemTemplate<T> = (
@@ -34,6 +37,28 @@ const MAX_LAYOUT_SETTLE_PASSES = 20;
 const MAX_SCROLL_CORRECTION_PASSES = 5;
 const SCROLL_END_TIMEOUT_MS = 2000;
 const SCROLL_OFFSET_EPSILON_PX = 1;
+/** Fallback for a non-positive `estimatedItemSize`; mirrors its default. */
+const DEFAULT_ESTIMATED_ITEM_SIZE = 50;
+/** How long the scroll position must stay put to count as settled. */
+const SCROLL_IDLE_MS = 100;
+/**
+ * Upper bound on a single `requestAnimationFrame` wait. Frames aren't served
+ * to a hidden tab or a disconnected element, where `layoutComplete` must
+ * still resolve.
+ */
+const LAYOUT_FRAME_TIMEOUT_MS = 100;
+
+/**
+ * `scrollend` reports precisely when a scroll has settled, but is missing on
+ * part of the supported browser matrix (Safari before 18.2), where
+ * `_scrollAndWaitForEnd` falls back to a scroll-idle timer.
+ */
+const SUPPORTS_SCROLL_END = !isServer && 'onscrollend' in window;
+
+const EMPTY_RANGE: VisibleRange = Object.freeze({
+  startIndex: 0,
+  endIndex: -1,
+});
 
 /**
  * A virtual scroll component that efficiently renders large lists by only
@@ -41,8 +66,13 @@ const SCROLL_OFFSET_EPSILON_PX = 1;
  *
  * @element igc-virtual-scroll
  *
- * @fires igcStateChange - Emitted after each render pass with a snapshot of the current virtual window.
- * @fires igcDataRequest - Emitted when the scroll position approaches the end of the available data.
+ * @fires igcStateChange - Emitted when the rendered virtual window changes.
+ * @fires igcDataRequest - Emitted whenever the rendered window comes within a few items of the
+ * end of `data` - including on the very first render, when the loaded items don't fill the viewport.
+ *
+ * @csspart virtualization-track - The full-size element that gives the host its scrollable extent.
+ * @csspart virtualization-content - The wrapper holding the currently rendered items, translated
+ * into position within the track.
  */
 export default class IgcVirtualScrollComponent<
   T = unknown,
@@ -57,19 +87,106 @@ export default class IgcVirtualScrollComponent<
     registerComponent(IgcVirtualScrollComponent);
   }
 
+  private static _styleSheet: CSSStyleSheet | null = null;
+
+  private static _getStyleSheet(): CSSStyleSheet {
+    if (!IgcVirtualScrollComponent._styleSheet) {
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync(`
+        :where(igc-virtual-scroll) {
+          display: block;
+          position: relative;
+          overflow: auto;
+          height: 18.75rem;
+        }
+
+        :where(igc-virtual-scroll[orientation='vertical']) {
+          overflow-y: auto;
+          overflow-x: hidden;
+        }
+
+        :where(igc-virtual-scroll[orientation='horizontal']) {
+          overflow-x: auto;
+          overflow-y: hidden;
+        }
+
+        :where(igc-virtual-scroll) [part="virtualization-track"] {
+          position: relative;
+          width: 100%;
+          min-height: 100%;
+        }
+
+        :where(igc-virtual-scroll) [part="virtualization-content"] {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          will-change: transform;
+          contain: layout style paint;
+        }
+
+        :where(igc-virtual-scroll[orientation='horizontal']) [part="virtualization-track"] {
+          height: 100%;
+          width: auto;
+          min-height: unset;
+        }
+
+        :where(igc-virtual-scroll[orientation='horizontal']) [part="virtualization-content"] {
+          display: flex;
+          flex-direction: row;
+          height: 100%;
+          width: auto;
+        }
+
+        :where(igc-virtual-scroll[orientation='horizontal']) [part="virtualization-content"] > [data-vs-index] {
+          flex-shrink: 0;
+          height: 100%;
+        }
+
+        :where(igc-virtual-scroll[orientation='horizontal']):dir(rtl) [part="virtualization-content"] {
+          left: auto;
+          right: 0;
+        }
+      `);
+      IgcVirtualScrollComponent._styleSheet = sheet;
+    }
+    return IgcVirtualScrollComponent._styleSheet;
+  }
+
   //#region Internal state
 
   protected readonly _engine = new VirtualScrollEngine();
-
   private readonly _contentRef = createRef<HTMLDivElement>();
-  private _itemResizeObserver: ResizeObserver | null = null;
-  private _onScroll: ((e: Event) => void) | null = null;
-  private _currentRange: VisibleRange = { startIndex: 0, endIndex: -1 };
+  private readonly _itemResizeController = createResizeObserverController(
+    this,
+    {
+      callback: this._handleItemResize,
+      target: null,
+      requestUpdate: false,
+    }
+  );
+
+  private _currentRange: VisibleRange = EMPTY_RANGE;
+  private _lastEmittedState: VirtualScrollState | null = null;
   private _hasPendingDataRequest = false;
   private _layoutCompletePromise: Promise<void> | null = null;
   private _scrollRequestId = 0;
 
-  @state()
+  /**
+   * The `startIndex` of the last emitted `igcDataRequest`, which is also the
+   * item count it was emitted at. See `_checkDataRequest`.
+   *
+   * Outlives a disconnect, like `_hasPendingDataRequest`: what the consumer has
+   * already been asked for does not become untrue by moving the element, and
+   * clearing only one of the two would re-open the request loop on reconnect.
+   */
+  private _lastDataRequestIndex = -1;
+
+  /**
+   * The live scroll offset on the active axis. Deliberately *not* reactive:
+   * nothing in `render` reads it except through `_currentRange`, so
+   * `_handleScroll` schedules an update only when the window actually moves.
+   */
   private _scrollPosition = 0;
 
   @state()
@@ -81,6 +198,10 @@ export default class IgcVirtualScrollComponent<
 
   /**
    * The array of items to virtualize.
+   *
+   * Compared by reference: mutating the array
+   * in place (`data.push(...)`) produces no update. Assign a new array
+   * instead, which is also what the `igcDataRequest` flow expects.
    */
   @property({ attribute: false })
   public data: T[] = [];
@@ -109,85 +230,32 @@ export default class IgcVirtualScrollComponent<
    * @default 50
    */
   @property({ type: Number, attribute: 'estimated-item-size' })
-  public estimatedItemSize = 50;
+  public estimatedItemSize = DEFAULT_ESTIMATED_ITEM_SIZE;
 
   /**
    * A function that renders each item in the virtual scroll list.
    * Receives a VirtualScrollItemContext<T> with the item data, its index, and the total count.
    * If not provided, nothing is rendered.
+   *
+   * Items are measured by their border box, so margins accumulate as drift
+   * down the list. Use padding on the item, or a gap on a wrapper, instead.
+   *
+   * Only the current window is ever in the DOM, so assistive technology
+   * cannot infer an item's position from the markup. Templates rendering a
+   * role with set semantics (`option`, `listitem`, `row`, ...) should map the
+   * context's `index` and `count` onto `aria-posinset` and `aria-setsize`.
    */
   @property({ attribute: false })
   public itemTemplate: VirtualScrollItemTemplate<T> | null = null;
 
   //#endregion
 
-  private static _styleSheet: CSSStyleSheet | null = null;
-
-  private static _getStyleSheet(): CSSStyleSheet {
-    if (!IgcVirtualScrollComponent._styleSheet) {
-      const sheet = new CSSStyleSheet();
-      sheet.replaceSync(`
-        :where(igc-virtual-scroll) {
-          display: block;
-          position: relative;
-          overflow: auto;
-          height: 18.75rem;
-        }
-
-        :where(igc-virtual-scroll[orientation='vertical']) {
-          overflow-y: auto;
-          overflow-x: hidden;
-        }
-
-        :where(igc-virtual-scroll[orientation='horizontal']) {
-          overflow-x: auto;
-          overflow-y: hidden;
-        }
-
-        :where(igc-virtual-scroll) [part="igc-vs-track"] {
-          position: relative;
-          width: 100%;
-          min-height: 100%;
-        }
-
-        :where(igc-virtual-scroll) [part="igc-vs-content"] {
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          will-change: transform;
-          contain: layout style paint;
-        }
-
-        :where(igc-virtual-scroll[orientation='horizontal']) [part="igc-vs-track"] {
-          height: 100%;
-          width: auto;
-          min-height: unset;
-        }
-
-        :where(igc-virtual-scroll[orientation='horizontal']) [part="igc-vs-content"] {
-          display: flex;
-          flex-direction: row;
-          height: 100%;
-          width: auto;
-        }
-
-        :where(igc-virtual-scroll[orientation='horizontal']) [part="igc-vs-content"] > [data-vs-index] {
-          flex-shrink: 0;
-          height: 100%;
-        }
-
-        :where(igc-virtual-scroll[orientation='horizontal']):dir(rtl) [part="igc-vs-content"] {
-          left: auto;
-          right: 0;
-        }
-      `);
-      IgcVirtualScrollComponent._styleSheet = sheet;
-    }
-    return IgcVirtualScrollComponent._styleSheet;
-  }
-
   private _adoptStyles(): void {
+    /* c8 ignore next 3 */
+    if (isServer) {
+      return;
+    }
+
     const root = this.getRootNode() as Document | ShadowRoot;
     const sheet = IgcVirtualScrollComponent._getStyleSheet();
     if (!root.adoptedStyleSheets.includes(sheet)) {
@@ -198,8 +266,7 @@ export default class IgcVirtualScrollComponent<
   constructor() {
     super();
     this._engine.onSizeChange = () => this.requestUpdate();
-    this._handleItemResize = this._handleItemResize.bind(this);
-    this._measureViewport = this._measureViewport.bind(this);
+    this._handleScroll = this._handleScroll.bind(this);
 
     // Viewport resize observer
     createResizeObserverController(this, {
@@ -220,61 +287,50 @@ export default class IgcVirtualScrollComponent<
     this._adoptStyles();
     this._engine.initMaxBrowserSize(this.ownerDocument);
     this._measureViewport();
-    this._setupScrollListener();
+    this.addEventListener('scroll', this._handleScroll, { passive: true });
   }
 
   /** @internal */
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._dispose();
+    this.removeEventListener('scroll', this._handleScroll);
   }
 
   protected override willUpdate(changed: PropertyValues<this>): void {
     // TODO: Either fix this in the theming controller or come up with some other solution.
 
-    // Re-verified (cheap, idempotent no-op when already present) on every
-    // update rather than only in `connectedCallback`. Hosts that render this
-    // component into light DOM inside an *ancestor's* shadow root (e.g. combo)
-    // may have that shadow root's `adoptedStyleSheets` wholesale replaced by
-    // the ancestor's own styling/theming logic, silently dropping this sheet
-    // without ever disconnecting/reconnecting this element.
+    // Re-verified on every update (an idempotent no-op when already present)
+    // rather than only in `connectedCallback`. A host rendering this component
+    // inside its own shadow root (e.g. combo) may have that root's
+    // `adoptedStyleSheets` wholesale replaced by its theming logic, silently
+    // dropping this sheet without this element ever reconnecting.
     this._adoptStyles();
 
-    if (changed.has('data') || changed.has('estimatedItemSize')) {
-      const estimatedSize = asNumber(this.estimatedItemSize);
-      const normalizedEstimate = estimatedSize > 0 ? estimatedSize : 50;
+    if (changed.has('data')) {
+      this._engine.resize(
+        this._items.length,
+        this._normalizedItemSize,
+        this._firstChangedIndex(changed.get('data'))
+      );
+      this._hasPendingDataRequest = false;
+    }
 
-      if (changed.has('data')) {
-        this._engine.resize(this.data.length, normalizedEstimate);
-        this._hasPendingDataRequest = false;
-      }
-
-      if (changed.has('estimatedItemSize')) {
-        this._engine.updateEstimatedSize(normalizedEstimate);
-      }
+    if (changed.has('estimatedItemSize')) {
+      this._engine.updateEstimatedSize(this._normalizedItemSize);
     }
 
     if (changed.has('orientation')) {
       this._measureViewport();
-      this._setupScrollListener();
+      this._scrollPosition = this._currentAxisScroll();
     }
+
+    this._currentRange = this._computeRange();
   }
 
   protected override updated(_changed: PropertyValues<this>): void {
     this._scheduleItemMeasurement();
     this._checkDataRequest();
-
-    const range = this._currentRange;
-    if (range.endIndex >= range.startIndex) {
-      this.emitEvent('igcStateChange', {
-        detail: {
-          startIndex: range.startIndex,
-          endIndex: range.endIndex,
-          viewportSize: this._viewportSize,
-          totalSize: this._engine.totalSize,
-        },
-      });
-    }
+    this._emitStateChange();
   }
 
   protected override render(): TemplateResult {
@@ -282,29 +338,29 @@ export default class IgcVirtualScrollComponent<
       return html`${nothing}`;
     }
 
-    this._currentRange = this._engine.getVisibleRange(
-      this._scrollPosition,
-      this._viewportSize,
-      this._normalizedOverScan,
-      this.data.length
-    );
-
+    const items = this._items;
     const range = this._currentRange;
-    const count = this.data.length;
+    const count = items.length;
     const isVertical = this._isVertical;
 
     const trackStyle = isVertical
       ? { height: `${this._engine.domSize}px` }
       : { width: `${this._engine.domSize}px` };
 
-    let contentPosition = this._engine.getContentPosition(range.startIndex);
+    // The content wrapper is absolutely positioned at the origin of a track
+    // that is `domSize` px tall/wide, so translating it to the first rendered
+    // item's scroll offset places that item at its virtual position.
+    let contentPosition = this._engine.getScrollOffsetForIndex(
+      range.startIndex
+    );
     const physicalRangeSize = this._engine.getPhysicalRangeSize(
       range.startIndex,
       range.endIndex
     );
-    contentPosition = Math.max(
+    contentPosition = clamp(
+      contentPosition,
       0,
-      Math.min(contentPosition, this._engine.domSize - physicalRangeSize)
+      this._engine.domSize - physicalRangeSize
     );
     const isRTL = !isVertical && !isLTR(this);
     const contentStyle = {
@@ -315,20 +371,25 @@ export default class IgcVirtualScrollComponent<
 
     const visibleItems =
       range.endIndex >= range.startIndex
-        ? this.data.slice(range.startIndex, range.endIndex + 1)
+        ? items.slice(range.startIndex, range.endIndex + 1)
         : [];
 
     return html`
-      <div part="igc-vs-track" style=${styleMap(trackStyle)}>
+      <div
+        part="virtualization-track"
+        role="presentation"
+        style=${styleMap(trackStyle)}
+      >
         <div
           ${ref(this._contentRef)}
-          part="igc-vs-content"
+          part="virtualization-content"
+          role="presentation"
           style=${styleMap(contentStyle)}
         >
           ${visibleItems.map((item, i) => {
             const itemIndex = range.startIndex + i;
             const ctx = new VirtualScrollItemContext(item, itemIndex, count);
-            return html`<div data-vs-index=${itemIndex}>
+            return html`<div role="presentation" data-vs-index=${itemIndex}>
               ${this.itemTemplate!(ctx)}
             </div>`;
           })}
@@ -350,32 +411,64 @@ export default class IgcVirtualScrollComponent<
     return Math.max(0, Math.floor(asNumber(this.overScan, 2)));
   }
 
+  /** The configured `estimatedItemSize`, normalized to a positive number. */
+  private get _normalizedItemSize(): number {
+    const size = asNumber(this.estimatedItemSize);
+    return size > 0 ? size : DEFAULT_ESTIMATED_ITEM_SIZE;
+  }
+
+  /** `data`, guarded against a consumer clearing it with a nullish value. */
+  private get _items(): T[] {
+    return this.data ?? [];
+  }
+
   /**
-   * Computes the scroll offset that aligns the given item index within the
-   * viewport according to `options`, using the engine's *current* size
-   * data. As more items get measured, calling this again for the same
-   * index/options can yield a different, more accurate result.
+   * The window to render for the current scroll position and viewport. Empty
+   * until an `itemTemplate` is set, since nothing renders without one.
+   */
+  private _computeRange(): VisibleRange {
+    return this.itemTemplate
+      ? this._engine.getVisibleRange(
+          this._scrollPosition,
+          this._viewportSize,
+          this._normalizedOverScan
+        )
+      : EMPTY_RANGE;
+  }
+
+  /**
+   * The scroll offset that aligns `index` within the viewport according to
+   * `options`, from the engine's *current* size data. As more items get
+   * measured, the same index/options can yield a different, more accurate
+   * result.
+   *
+   * For `block: 'nearest'` on an item already in view, returns the current
+   * offset, so that no scrolling takes place.
    */
   private _getAlignedScrollOffset(
     index: number,
     options?: ScrollIntoViewOptions
   ): number {
-    const itemStart = this._engine.getScrollOffsetForIndex(index);
-    const itemEnd = this._engine.getScrollOffsetForIndex(index + 1);
-    const itemSize = Math.max(0, itemEnd - itemStart);
-
-    const align = this._isVertical
+    const requested = this._isVertical
       ? (options?.block ?? 'start')
       : (options?.inline ?? options?.block ?? 'start');
+    const current = this._currentAxisScroll();
 
-    let offset = itemStart;
-    if (align === 'center') {
-      offset = itemStart - (this._viewportSize - itemSize) / 2;
-    } else if (align === 'end') {
-      offset = itemStart - (this._viewportSize - itemSize);
+    if (
+      requested === 'nearest' &&
+      this._engine.isIndexInView(index, current, this._viewportSize)
+    ) {
+      return current;
     }
 
-    return Math.max(0, offset);
+    const align: ScrollAlignment =
+      requested === 'center' || requested === 'end' ? requested : 'start';
+
+    return this._engine.getAlignedScrollOffset(
+      index,
+      this._viewportSize,
+      align
+    );
   }
 
   /** Applies a scroll offset to the correct axis, accounting for RTL. */
@@ -397,14 +490,13 @@ export default class IgcVirtualScrollComponent<
   }
 
   /**
-   * Applies a scroll offset to the active axis and waits for the browser to
-   * report, via the native `scrollend` event, that the resulting scroll -
-   * instant or smooth - has fully settled.
+   * Applies a scroll offset to the active axis and waits for the resulting
+   * scroll - instant or smooth - to settle.
    *
    * `scrollend` never fires when the requested offset doesn't actually move
-   * the scroll position, so that case is short-circuited instead of waiting
-   * forever. A timeout fallback guards against the rare case where the
-   * event never arrives at all (e.g. the element is disconnected mid-scroll).
+   * the scroll position, so that case is short-circuited rather than waiting
+   * for it. The timeout covers the rare case of the event never arriving at
+   * all, e.g. the element being disconnected mid-scroll.
    */
   private _scrollAndWaitForEnd(
     offset: number,
@@ -416,36 +508,122 @@ export default class IgcVirtualScrollComponent<
       return Promise.resolve();
     }
 
-    const settled = new Promise<void>((resolve) => {
-      this.addEventListener('scrollend', () => resolve(), { once: true });
+    return this._withDeadline(SCROLL_END_TIMEOUT_MS, (signal) => {
+      const settled = SUPPORTS_SCROLL_END
+        ? this._waitForScrollEnd(signal)
+        : this._waitForScrollIdle(signal);
+
+      // Applied only once the listener is attached, so an instant scroll
+      // can't settle before anything is watching for it.
+      this._applyScroll(offset, behavior);
+      return settled;
     });
-
-    this._applyScroll(offset, behavior);
-
-    return Promise.race([settled, this._timeout(SCROLL_END_TIMEOUT_MS)]);
   }
 
-  private _timeout(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  /**
+   * Resolves with whichever comes first, `task` or a deadline of `ms`.
+   * Whichever wins, the loser is torn down through the signal instead of
+   * being left behind as a live timer or a dangling listener.
+   */
+  private _withDeadline(
+    ms: number,
+    task: (signal: AbortSignal) => Promise<void>
+  ): Promise<void> {
+    const controller = new AbortController();
+
+    return Promise.race([
+      task(controller.signal),
+      this._timeout(ms, controller.signal),
+    ]).finally(() => controller.abort());
+  }
+
+  private _waitForScrollEnd(signal: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+      this.addEventListener('scrollend', () => resolve(), {
+        once: true,
+        signal,
+      });
+    });
+  }
+
+  /**
+   * Resolves once no `scroll` event has arrived for `SCROLL_IDLE_MS`, the
+   * closest approximation of `scrollend` without it. The first timer is armed
+   * immediately, so a scroll that never moves still settles.
+   */
+  private _waitForScrollIdle(signal: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+      let id = setTimeout(resolve, SCROLL_IDLE_MS);
+
+      this.addEventListener(
+        'scroll',
+        () => {
+          clearTimeout(id);
+          id = setTimeout(resolve, SCROLL_IDLE_MS);
+        },
+        { passive: true, signal }
+      );
+
+      signal.addEventListener('abort', () => clearTimeout(id), { once: true });
+    });
+  }
+
+  private _timeout(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+      const id = setTimeout(resolve, ms);
+      signal.addEventListener('abort', () => clearTimeout(id), { once: true });
+    });
   }
 
   private _measureViewport(): void {
-    const size = this._isVertical ? this.clientHeight : this.clientWidth;
-    if (size !== this._viewportSize) {
-      this._viewportSize = size;
+    this._viewportSize = this._isVertical
+      ? this.clientHeight
+      : this.clientWidth;
+  }
+
+  /**
+   * Records the new scroll offset and schedules a render only if it moves the
+   * rendered window.
+   *
+   * `render` derives the track size, the content translate and the item slice
+   * from `_currentRange`, and nothing from the scroll offset itself, so
+   * scrolling within a single item would otherwise re-run every item template
+   * for a pixel-identical result. `willUpdate` still recomputes
+   * `_currentRange` for every other trigger, so this can only suppress a
+   * redundant pass, never a needed one.
+   */
+  private _handleScroll(): void {
+    this._scrollPosition = this._currentAxisScroll();
+
+    const { startIndex, endIndex } = this._computeRange();
+    if (
+      startIndex !== this._currentRange.startIndex ||
+      endIndex !== this._currentRange.endIndex
+    ) {
+      this.requestUpdate();
     }
   }
 
-  private _setupScrollListener(): void {
-    if (this._onScroll) {
-      this.removeEventListener('scroll', this._onScroll);
+  /**
+   * The number of leading items that kept their identity across a `data`
+   * change, i.e. the index of the first item whose measured size no longer
+   * describes what is rendered there. Appending (the `igcDataRequest` flow)
+   * retains everything; filtering or replacing retains only the untouched
+   * prefix.
+   */
+  private _firstChangedIndex(previous: T[] | undefined): number {
+    if (!previous) {
+      return 0;
     }
 
-    this._onScroll = () => {
-      this._scrollPosition = this._currentAxisScroll();
-    };
-
-    this.addEventListener('scroll', this._onScroll, { passive: true });
+    const items = this._items;
+    const shared = Math.min(previous.length, items.length);
+    for (let i = 0; i < shared; i++) {
+      if (previous[i] !== items[i]) {
+        return i;
+      }
+    }
+    return shared;
   }
 
   private _handleItemResize(entries: ResizeObserverEntry[]): void {
@@ -464,69 +642,134 @@ export default class IgcVirtualScrollComponent<
     }
   }
 
+  /**
+   * Brings the item observer in sync with the rendered window, applying only
+   * the difference: re-observing an already observed element makes the browser
+   * deliver another initial measurement for it, so blanket re-registration
+   * would fire a callback for every rendered item on every update pass.
+   */
   private _scheduleItemMeasurement(): void {
-    if (!this._contentRef.value) return;
+    const content = this._contentRef.value;
+    if (!content) return;
 
-    if (!this._itemResizeObserver) {
-      this._itemResizeObserver = new ResizeObserver(this._handleItemResize);
+    const observed = this._itemResizeController.targets;
+
+    for (const element of observed) {
+      if (element.parentNode !== content) {
+        this._itemResizeController.unobserve(element);
+      }
     }
 
-    this._itemResizeObserver.disconnect();
-    for (const el of this._contentRef.value.children) {
-      this._itemResizeObserver.observe(el);
+    for (const element of content.children) {
+      if (!observed.has(element)) {
+        this._itemResizeController.observe(element);
+      }
     }
+  }
+
+  /**
+   * Emits `igcStateChange`, unless the window is empty or identical to the one
+   * last reported: measurement passes re-render without moving the window.
+   */
+  private _emitStateChange(): void {
+    const { startIndex, endIndex } = this._currentRange;
+    if (endIndex < startIndex) return;
+
+    const previous = this._lastEmittedState;
+    const detail: VirtualScrollState = {
+      startIndex,
+      endIndex,
+      viewportSize: this._viewportSize,
+      totalSize: this._engine.totalSize,
+    };
+
+    if (
+      previous &&
+      previous.startIndex === detail.startIndex &&
+      previous.endIndex === detail.endIndex &&
+      previous.viewportSize === detail.viewportSize &&
+      previous.totalSize === detail.totalSize
+    ) {
+      return;
+    }
+
+    this._lastEmittedState = detail;
+    this.emitEvent('igcStateChange', { detail });
   }
 
   private _checkDataRequest(): void {
     if (this._hasPendingDataRequest) return;
+
     const range = this._currentRange;
-    const total = this.data.length;
+    const total = this._items.length;
 
-    if (total > 0 && range.endIndex >= total - REMOTE_SCROLLING_THRESHOLD) {
-      this._hasPendingDataRequest = true;
-      this.emitEvent('igcDataRequest', {
-        detail: {
-          startIndex: total,
-          count: Math.max(this._normalizedOverScan * 4, 20),
-        },
-      });
+    if (total === 0 || range.endIndex < total - REMOTE_SCROLLING_THRESHOLD) {
+      return;
     }
+
+    // `_hasPendingDataRequest` is cleared by any `data` change, including one
+    // that appends nothing. Without this second guard, a consumer that
+    // reassigns `data` in response to a request it cannot fulfil - its source
+    // being exhausted - would be asked for the same items on every
+    // reassignment, indefinitely.
+    if (this._lastDataRequestIndex === total) {
+      return;
+    }
+
+    this._hasPendingDataRequest = true;
+    this._lastDataRequestIndex = total;
+
+    this.emitEvent('igcDataRequest', {
+      detail: {
+        startIndex: total,
+        count: Math.max(this._normalizedOverScan * 4, 20),
+      },
+    });
   }
 
-  private _dispose(): void {
-    if (this._onScroll) {
-      this.removeEventListener('scroll', this._onScroll);
-      this._onScroll = null;
-    }
-    this._itemResizeObserver?.disconnect();
-    this._itemResizeObserver = null;
-  }
-
+  /**
+   * Resolves on the next animation frame, or after `LAYOUT_FRAME_TIMEOUT_MS`
+   * if one never arrives. A hidden tab or a disconnected element is never
+   * served frames, and `layoutComplete` must still settle there. There is no
+   * layout to wait for in that state, so resolving early costs nothing.
+   */
   private _nextFrame(): Promise<void> {
-    return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    return this._withDeadline(
+      LAYOUT_FRAME_TIMEOUT_MS,
+      (signal) =>
+        new Promise((resolve) => {
+          const id = requestAnimationFrame(() => resolve());
+          signal.addEventListener('abort', () => cancelAnimationFrame(id), {
+            once: true,
+          });
+        })
+    );
   }
 
   /**
    * Waits for the current update to finish and then gives any
-   * ResizeObserver-driven item measurements a chance to run. If those
-   * measurements schedule a follow-up render (e.g. because an estimated
-   * item size was replaced with its real, measured size), the wait is
-   * repeated until no further renders are pending, up to a safety cap.
+   * ResizeObserver-driven item measurements a chance to run. If those schedule
+   * a follow-up render - an estimated size being replaced with a measured one
+   * - the wait repeats until nothing is pending, up to a safety cap.
    */
   private async _resolveLayoutComplete(): Promise<void> {
-    await this.updateComplete;
-
-    for (let i = 0; i < MAX_LAYOUT_SETTLE_PASSES; i++) {
-      await this._nextFrame();
-
-      if (!this.isUpdatePending) {
-        break;
-      }
-
+    try {
       await this.updateComplete;
-    }
 
-    this._layoutCompletePromise = null;
+      for (let i = 0; i < MAX_LAYOUT_SETTLE_PASSES; i++) {
+        await this._nextFrame();
+
+        if (!this.isUpdatePending) {
+          break;
+        }
+
+        await this.updateComplete;
+      }
+    } finally {
+      // Cleared here rather than after the loop, so a run that throws can't
+      // leave the getter handing out the same rejected promise forever.
+      this._layoutCompletePromise = null;
+    }
   }
 
   //#endregion
@@ -535,15 +778,13 @@ export default class IgcVirtualScrollComponent<
 
   /* blazorSuppress */
   /**
-   * A promise that resolves once the virtual scroll has fully settled:
-   * the current render pass has completed *and* any item-size
-   * measurements it triggers (and the renders those in turn schedule)
-   * have also completed.
+   * Resolves once the virtual scroll has fully settled: the current render
+   * pass has completed *and* so have any item-size measurements it triggers,
+   * along with the renders those in turn schedule.
    *
-   * Unlike `updateComplete`, which only reflects a single Lit render
-   * pass, `layoutComplete` is useful after changing `data`, scrolling,
-   * or resizing the viewport, when the final, stable DOM state may only
-   * be reached after one or more follow-up renders.
+   * Unlike `updateComplete`, which reflects a single Lit render pass, this
+   * covers changing `data`, scrolling or resizing the viewport, where the
+   * stable DOM state is only reached after one or more follow-up renders.
    */
   public get layoutComplete(): Promise<void> {
     if (!this._layoutCompletePromise) {
@@ -555,28 +796,25 @@ export default class IgcVirtualScrollComponent<
   /**
    * Programmatically scrolls to the specified item index.
    *
-   * Items outside the currently rendered window only have an *estimated*
-   * size, so the very first jump may land slightly off target. Once the
-   * scroll lands, the items around it are measured and, if that changes
-   * their computed offset, the scroll position is corrected. This repeats
-   * (each pass measuring items closer to the true target) until the offset
-   * stabilizes, so the requested index ends up precisely aligned even for
-   * far-away, never-before-rendered items.
+   * Items outside the rendered window only have an *estimated* size, so the
+   * first jump may land off target. The items around where it lands are then
+   * measured and the scroll position corrected, repeating - each pass landing
+   * closer to the true target - until the offset stabilizes.
    *
-   * Returns a promise that resolves once the scroll position has settled
-   * on the final, corrected offset. Callers that only care about the
-   * initial (approximate) scroll can ignore the returned promise.
+   * The returned promise resolves once the scroll has settled on that final,
+   * corrected offset, and can be ignored by callers that only care about the
+   * initial, approximate scroll.
    */
   public async scrollToIndex(
     index: number,
     options?: ScrollIntoViewOptions
   ): Promise<void> {
-    const maxIndex = Math.max(0, this.data.length - 1);
-    const clampedIndex = Math.max(0, Math.min(index, maxIndex));
+    const maxIndex = Math.max(0, this._items.length - 1);
+    const clampedIndex = clamp(index, 0, maxIndex);
     const behavior = options?.behavior ?? 'auto';
 
-    // A newer call supersedes any correction loop still running for a
-    // previous one (e.g. rapid, repeated calls to scrollToIndex).
+    // A newer call supersedes any correction loop still running for a previous
+    // one, e.g. under rapid, repeated calls.
     const requestId = ++this._scrollRequestId;
 
     let offset = this._getAlignedScrollOffset(clampedIndex, options);


### PR DESCRIPTION
## Description

Follow-up pass over the unreleased igc-virtual-scroll component.

Engine:
- Add the document's scroll offset back into the max browser size probe. The rect is viewport-relative, so probing from a scrolled page cached an understated ceiling for the document's lifetime.
- Only retain measured sizes up to the first changed index when `data` is reassigned; measurements previously carried over onto different items.
- `isIndexInView` is true for an item spanning the whole viewport, so `nearest` no longer scrolls an oversized item that already fills it.
- Drop `getContentPosition` and `getVisibleRange`'s `totalItems`, and clamp indices consistently against the tree length.

Component:
- Bound every unbounded wait. `layoutComplete` races rAF against a timeout so it settles on a hidden tab, and stops caching a dead promise once it does; `scrollend` falls back to a scroll-idle timer where the event is unsupported (Safari < 18.2), which `browserslist: defaults` still covers.
- Stop `igcDataRequest` re-firing on every `data` reassignment once the consumer's source is exhausted.
- Render once per item boundary crossed rather than once per scrolled frame.
- Rename the CSS parts to `virtualization-track` / `virtualization-content`, document them, and tolerate a null `data`.

Shared:
- `ResizeObserverController` takes a `requestUpdate` option and exposes its observed targets, so the virtual scroll can reuse it for item measurement while driving its own update cycle. Existing consumers are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
