### PR TITLE
refactor(tree): fix toggle/RTL staleness, speed up internals, add ARIA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - #### Form associated components
   - Validation messages no longer disappear right after the first failed form submission. The submit-driven invalid state used to hold only for the update the submission itself scheduled, so any re-render that followed - a `slotchange` from the validation slots the submission had just projected, for instance - silently dropped the projected messages while the invalid styling stayed on.
   - Invalid styling now follows the validity state, so a control that turns valid again (a cleared `required`, a widened `min`/`max`, a disabled control) drops the styles it picked up from an earlier interaction or submission.
+- #### Tree
+  - Substantially reduced the cost of several operations on large or deeply nested trees:
+    - Reading `path` on a tree item, and anything built on it such as activating a nested item, cost `2^depth` rather than `depth` because the ancestor chain was re-walked twice per level. A single read at depth 20 took ~23ms; it is now under a microsecond at any depth.
+    - Keyboard navigation is roughly 5x faster (~1.24ms to ~0.24ms per keypress on a 1554-item tree). The navigable set is derived by a lazy walk that prunes collapsed branches, instead of materializing every item and filtering it by climbing each one's ancestors.
+    - Removing a subtree while items are selected is roughly 2x faster (~134ms to ~71ms for 259 items in `cascade` mode). Each removed item used to re-run the full cascade reconciliation, although the topmost removed item already covers its whole subtree.
+    - `tree.items`, `select()` over a whole `cascade` tree, and expanding or collapsing every item are each ~25-45% faster.
 - #### Tabs
   - See-through scroll buttons in the Indigo theme. The buttons are sticky and the tab headers scroll underneath them, but the theme leaves both the buttons and the tabs strip transparent, so the scrolled headers showed through. The buttons now paint an opaque surface backdrop below their themed background. [#1955](https://github.com/IgniteUI/igniteui-webcomponents/issues/1955)
 

--- a/src/components/tree/themes/item.base.scss
+++ b/src/components/tree/themes/item.base.scss
@@ -64,7 +64,7 @@
     min-width: rem(24px);
 }
 
-[part='indicator rtl'] {
+:host(:dir(rtl)) [part~='indicator'] {
     transform: scaleX(-1);
 }
 

--- a/src/components/tree/tree-item.ts
+++ b/src/components/tree/tree-item.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, nothing, type PropertyValues } from 'lit';
+import { html, LitElement, type PropertyValues } from 'lit';
 import {
   property,
   query,
@@ -16,7 +16,6 @@ import { partMap } from '../common/part-map.js';
 import {
   addSafeEventListener,
   getElementFromPath,
-  isLTR,
   scrollIntoView,
 } from '../common/util.js';
 import IgcIconComponent from '../icon/icon.js';
@@ -24,12 +23,17 @@ import IgcCircularProgressComponent from '../progress/circular-progress.js';
 import { styles } from './themes/item.base.css.js';
 import { all } from './themes/item.js';
 import { styles as shared } from './themes/shared/item.common.css.js';
+import {
+  clearTreeItemAria,
+  getTreeItemChildren,
+  hasTreeItemChildren,
+  setAriaState,
+  TREE_ITEM_TAG,
+  TREE_TAG,
+} from './tree.common.js';
 import type IgcTreeComponent from './tree.js';
 import type { IgcTreeNavigationService } from './tree.navigation.js';
 import type { IgcTreeSelectionService } from './tree.selection.js';
-
-const TREE_ITEM_TAG = 'igc-tree-item';
-const TREE_TAG = 'igc-tree';
 
 /**
  * The tree-item component represents a child item of the tree component or another tree item.
@@ -67,6 +71,7 @@ export default class IgcTreeItemComponent extends LitElement {
 
   private _tabbableEl?: HTMLElement[];
   private _focusedProgrammatically = false;
+  private _ariaDelegate?: HTMLElement;
 
   private _groupRef: Ref<HTMLElement> = createRef();
 
@@ -108,21 +113,14 @@ export default class IgcTreeItemComponent extends LitElement {
     };
   }
 
-  /**
-   * Direct `igc-tree-item` light-DOM children. Tree items are expected to be nested directly
-   * (wrapping a nested item in another element, e.g. a `<div>`, is not supported) — this keeps
-   * child resolution a cheap, native `.children` scan instead of a subtree-wide DOM query.
-   */
+  /** Direct `igc-tree-item` light-DOM children. */
   private get _directChildren(): IgcTreeItemComponent[] {
-    return Array.from(this.children).filter(
-      (el): el is IgcTreeItemComponent =>
-        el.tagName.toLowerCase() === TREE_ITEM_TAG
-    );
+    return getTreeItemChildren(this);
   }
 
   private get _allChildren(): IgcTreeItemComponent[] {
     const result: IgcTreeItemComponent[] = [];
-    this._collectAllChildren(result);
+    this._collectDescendants(result);
     return result;
   }
 
@@ -214,7 +212,7 @@ export default class IgcTreeItemComponent extends LitElement {
         ? (this.parentElement as IgcTreeItemComponent)
         : null;
     this.level = this.parent ? this.parent.level + 1 : 0;
-    this.setAttribute('role', 'treeitem');
+    this._syncAria();
     this._activeChange();
     // if the item is not added/moved runtime
     if (this.init) {
@@ -235,13 +233,6 @@ export default class IgcTreeItemComponent extends LitElement {
 
   protected override willUpdate(changed: PropertyValues<this>): void {
     super.willUpdate(changed);
-
-    if (
-      this.hasUpdated &&
-      (changed.has('expanded') || changed.has('hasChildren'))
-    ) {
-      this._bothChange();
-    }
 
     if (changed.has('expanded')) {
       const oldValue = changed.get('expanded') as boolean;
@@ -265,23 +256,35 @@ export default class IgcTreeItemComponent extends LitElement {
     }
   }
 
+  protected override updated(changed: PropertyValues<this>): void {
+    super.updated(changed);
+
+    // ARIA state lives outside the shadow template, so it is refreshed once per
+    // update rather than tracked per property.
+    this._syncAria();
+  }
+
   /**
-   * Appends every descendant (pre-order) into `out` in a single pass.
-   *
-   * Building this iteratively (rather than the more obvious `flatMap` + spread recursion)
-   * avoids repeatedly copying already-collected arrays at every level of the tree, which would
-   * otherwise turn a deeply nested tree's flatten cost from linear into quadratic.
+   * @hidden @internal
+   * Appends every descendant (pre-order) into `out`. Accumulating into a single
+   * array keeps a deep tree's flatten cost linear rather than quadratic.
    */
-  private _collectAllChildren(out: IgcTreeItemComponent[]): void {
-    for (const child of this._directChildren) {
+  public _collectDescendants(out: IgcTreeItemComponent[]): void {
+    for (const child of getTreeItemChildren(this)) {
       out.push(child);
-      child._collectAllChildren(out);
+      child._collectDescendants(out);
     }
   }
 
-  /** The full path to the tree item, starting from the top-most ancestor. */
+  /**
+   * The full path to the tree item, starting from the top-most ancestor.
+   *
+   * `parent` is read into a local first: reading `parent.path` twice per level
+   * would make a single access cost 2^depth instead of `depth`.
+   */
   public get path(): IgcTreeItemComponent[] {
-    return this.parent?.path ? [...this.parent.path, this] : [this];
+    const parent = this.parent;
+    return parent ? [...parent.path, this] : [this];
   }
 
   private _itemClick(event: MouseEvent): void {
@@ -296,7 +299,9 @@ export default class IgcTreeItemComponent extends LitElement {
   }
 
   private _expandIndicatorClick(): void {
-    if (this.disabled) return;
+    if (this.disabled || this.tree?.toggleNodeOnClick) {
+      return;
+    }
     this.expanded ? this.collapseWithEvent() : this.expandWithEvent();
   }
 
@@ -323,11 +328,7 @@ export default class IgcTreeItemComponent extends LitElement {
       scrollIntoView(this.wrapper, { behavior: 'smooth' });
     }
     if (this._tabbableEl?.length) {
-      // set tabIndex = 0 to all tabbable elements
-      // focus the first one
-      this._tabbableEl.forEach((element: HTMLElement) => {
-        element.tabIndex = 0;
-      });
+      this._setTabbable(0);
       this._focusedProgrammatically = true;
       this._tabbableEl[0].focus();
       return;
@@ -344,9 +345,7 @@ export default class IgcTreeItemComponent extends LitElement {
     if (!this.disabled) {
       // clicking directly over tabbable element when the item is not focused
       if (!this._focusedProgrammatically) {
-        this._tabbableEl?.forEach((element: HTMLElement) => {
-          element.tabIndex = 0;
-        });
+        this._setTabbable(0);
       }
       this.removeAttribute('tabIndex');
       this._isFocused = true;
@@ -357,9 +356,7 @@ export default class IgcTreeItemComponent extends LitElement {
   private _onFocusOut(ev: Event): void {
     ev?.stopPropagation();
     this._isFocused = false;
-    this._tabbableEl?.forEach((element: HTMLElement) => {
-      element.tabIndex = -1;
-    });
+    this._setTabbable(-1);
 
     if (this._navService?.focusedItem === this) {
       // called twice when clicking on already focused item with link (itemClick handler)
@@ -379,29 +376,59 @@ export default class IgcTreeItemComponent extends LitElement {
       this._tabbableEl.splice(0, 0, firstElement);
     }
 
-    if (this._tabbableEl?.length) {
-      this.setAttribute('role', 'none');
-      this._tabbableEl[0].setAttribute('role', 'treeitem');
+    this._setTabbable(-1);
+    this._syncAria();
+  }
 
-      this._tabbableEl.forEach((element: HTMLElement) => {
-        element.tabIndex = -1;
-      });
-    } else {
-      this.setAttribute('role', 'treeitem');
+  /** Applies `value` as the tabIndex of every focusable element in the label. */
+  private _setTabbable(value: number): void {
+    for (const element of this._tabbableEl ?? []) {
+      element.tabIndex = value;
     }
+  }
+
+  /**
+   * The element carrying the item's `treeitem` semantics: the host, or the
+   * first focusable element in the label slot when there is one, so that what
+   * the user reaches by keyboard is what gets announced. All ARIA state has to
+   * move with the role - left on a `role="none"` host it would be ignored.
+   */
+  private get _ariaTarget(): HTMLElement {
+    return this._tabbableEl?.length ? this._tabbableEl[0] : this;
+  }
+
+  private _syncAria(): void {
+    const target = this._ariaTarget;
+    const delegated = target !== this;
+
+    if (this._ariaDelegate && this._ariaDelegate !== target) {
+      clearTreeItemAria(this._ariaDelegate);
+      this._ariaDelegate.removeAttribute('role');
+    }
+    this._ariaDelegate = delegated ? target : undefined;
+
+    this.setAttribute('role', delegated ? 'none' : 'treeitem');
+    if (delegated) {
+      target.setAttribute('role', 'treeitem');
+      clearTreeItemAria(this);
+    }
+
+    setAriaState(
+      target,
+      'aria-expanded',
+      this.hasChildren ? String(this.expanded) : null
+    );
+    setAriaState(
+      target,
+      'aria-selected',
+      this.tree && this.tree.selection !== 'none' ? String(this.selected) : null
+    );
+    setAriaState(target, 'aria-disabled', this.disabled ? 'true' : null);
   }
 
   private async _toggleAnimation(dir: 'open' | 'close') {
     const animation = dir === 'open' ? growVerIn : growVerOut;
     return this._animationPlayer.playExclusive(animation());
-  }
-
-  private _bothChange(): void {
-    if (this.hasChildren) {
-      this.setAttribute('aria-expanded', this.expanded.toString());
-    } else {
-      this.removeAttribute('aria-expanded');
-    }
   }
 
   private _expandedChange(oldValue: boolean): void {
@@ -446,7 +473,7 @@ export default class IgcTreeItemComponent extends LitElement {
   }
 
   private _handleChange(): void {
-    this.hasChildren = !!this._directChildren.length;
+    this.hasChildren = hasTreeItemChildren(this);
   }
 
   /* blazorSuppress */
@@ -481,9 +508,9 @@ export default class IgcTreeItemComponent extends LitElement {
     }
 
     if (this.tree?.singleBranchExpand) {
-      const pathSet = new Set(this.path.splice(0, this.path.length - 1));
+      const ancestors = new Set(this.path.slice(0, -1));
       for (const item of this.tree.items) {
-        if (!pathSet.has(item)) {
+        if (!ancestors.has(item)) {
           item.collapseWithEvent();
         }
       }
@@ -536,11 +563,6 @@ export default class IgcTreeItemComponent extends LitElement {
   }
 
   protected override render() {
-    const indicatorParts = {
-      indicator: true,
-      rtl: !(this.tree ? isLTR(this.tree) : true),
-    };
-
     return html`
       <div id="wrapper" part=${partMap(this._parts)}>
         <div
@@ -550,7 +572,7 @@ export default class IgcTreeItemComponent extends LitElement {
         >
           <slot name="indentation"></slot>
         </div>
-        <div part=${partMap(indicatorParts)} aria-hidden="true">
+        <div part="indicator" aria-hidden="true">
           ${
             this.loading
               ? html`
@@ -561,14 +583,7 @@ export default class IgcTreeItemComponent extends LitElement {
                   </slot>
                 `
               : html`
-                  <slot
-                    name="indicator"
-                    @click=${
-                      this.tree?.toggleNodeOnClick
-                        ? nothing
-                        : this._expandIndicatorClick
-                    }
-                  >
+                  <slot name="indicator" @click=${this._expandIndicatorClick}>
                     ${
                       this.hasChildren
                         ? html`

--- a/src/components/tree/tree-navigation.spec.ts
+++ b/src/components/tree/tree-navigation.spec.ts
@@ -6,7 +6,12 @@ import type { TreeSelectionEventInit } from './tree.common.js';
 import IgcTreeComponent from './tree.js';
 import type { IgcTreeNavigationService } from './tree.navigation.js';
 import IgcTreeItemComponent from './tree-item.js';
-import { navigationTree, SLOTS, TreeTestFunctions } from './tree-utils.spec.js';
+import {
+  disabledItemsTree,
+  navigationTree,
+  SLOTS,
+  TreeTestFunctions,
+} from './tree-utils.spec.js';
 
 describe('Tree Navigation', () => {
   before(() => {
@@ -23,6 +28,166 @@ describe('Tree Navigation', () => {
     treeNavService = tree.navService;
     topLevelItems = tree.items.filter((i) => i.level === 0);
     eventSpy = spy(tree, 'emitEvent');
+  });
+
+  describe('Initial focus', () => {
+    it('Should not move DOM focus into the tree when it is added to the document', async () => {
+      const outside = document.createElement('button');
+      document.body.append(outside);
+      outside.focus();
+      expect(document.activeElement).to.equal(outside);
+
+      const added = await TreeTestFunctions.createTreeElement(navigationTree);
+
+      // Connecting a tree seeds the roving tabindex, but must not steal focus
+      // from whatever the user was already on.
+      expect(document.activeElement).to.equal(outside);
+      expect(added.contains(document.activeElement)).to.be.false;
+
+      outside.remove();
+    });
+
+    it('Should seed the roving tabindex on the first non-disabled item', async () => {
+      const first = tree.items.find((i) => !i.disabled)!;
+
+      expect(treeNavService.focusedItem).to.equal(first);
+      expect(first.tabIndex).to.equal(0);
+      // Active state is a separate concern and must not be implied by focus.
+      expect(treeNavService.activeItem).to.be.null;
+    });
+
+    it('Should focus the seeded item once the user tabs into the tree', async () => {
+      const first = tree.items.find((i) => !i.disabled)!;
+
+      first.focus();
+      await elementUpdated(tree);
+
+      expect(document.activeElement).to.equal(first);
+      expect(treeNavService.focusedItem).to.equal(first);
+    });
+  });
+
+  describe('Navigable set semantics', () => {
+    let disabledTree: IgcTreeComponent;
+
+    const labels = (items: IgcTreeItemComponent[]) => items.map((i) => i.label);
+
+    const press = (key: string) =>
+      disabledTree.dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      );
+
+    beforeEach(async () => {
+      disabledTree =
+        await TreeTestFunctions.createTreeElement(disabledItemsTree);
+    });
+
+    it('Should skip a disabled item but still navigate into its subtree', async () => {
+      // "Tree Item 1" and "Tree Item 1.1" are both disabled and expanded, so
+      // neither is navigable, but their enabled descendants are.
+      press('Home');
+      await elementUpdated(disabledTree);
+
+      expect(disabledTree.navService.focusedItem?.label).to.equal(
+        'Tree Item 1.1.1'
+      );
+    });
+
+    it('Should not navigate into a collapsed subtree', async () => {
+      // "Tree Item 1.2" is disabled and collapsed, so neither it nor its
+      // children take part; the walk continues at the next top level item.
+      press('Home');
+      await elementUpdated(disabledTree);
+      press('ArrowDown');
+      await elementUpdated(disabledTree);
+
+      expect(disabledTree.navService.focusedItem?.label).to.equal(
+        'Tree Item 1.1.2'
+      );
+
+      press('ArrowDown');
+      await elementUpdated(disabledTree);
+
+      expect(disabledTree.navService.focusedItem?.label).to.equal(
+        'Tree Item 2'
+      );
+    });
+
+    it('Should walk the navigable set in document order', async () => {
+      const visited: string[] = [];
+
+      press('Home');
+      await elementUpdated(disabledTree);
+      visited.push(disabledTree.navService.focusedItem!.label);
+
+      for (let i = 0; i < 12; i++) {
+        press('ArrowDown');
+        await elementUpdated(disabledTree);
+        const current = disabledTree.navService.focusedItem!.label;
+        if (current === visited.at(-1)) {
+          break; // reached the end of the navigable set
+        }
+        visited.push(current);
+      }
+
+      const expected = labels(
+        disabledTree.items.filter((item) => {
+          if (item.disabled) return false;
+          for (let a = item.parent; a; a = a.parent) {
+            if (!a.expanded) return false;
+          }
+          return true;
+        })
+      );
+
+      expect(visited).to.eql(expected);
+    });
+
+    it('Should move to the first navigable item when the focused item is collapsed out of view', async () => {
+      // Focus a descendant, then collapse its ancestor so the focused item is
+      // no longer part of the navigable set.
+      press('Home');
+      await elementUpdated(disabledTree);
+      const focused = disabledTree.navService.focusedItem!;
+      expect(focused.label).to.equal('Tree Item 1.1.1');
+
+      focused.parent!.expanded = false;
+      await elementUpdated(disabledTree);
+
+      press('ArrowDown');
+      await elementUpdated(disabledTree);
+      expect(disabledTree.navService.focusedItem?.label).to.equal(
+        'Tree Item 2'
+      );
+    });
+
+    it('Should stay put on Arrow Up when the focused item is collapsed out of view', async () => {
+      press('Home');
+      await elementUpdated(disabledTree);
+      const focused = disabledTree.navService.focusedItem!;
+
+      focused.parent!.expanded = false;
+      await elementUpdated(disabledTree);
+
+      press('ArrowUp');
+      await elementUpdated(disabledTree);
+      expect(disabledTree.navService.focusedItem).to.equal(focused);
+    });
+
+    it('Should land on the last navigable item on End', async () => {
+      press('End');
+      await elementUpdated(disabledTree);
+
+      const navigable = disabledTree.items.filter((item) => {
+        if (item.disabled) return false;
+        for (let a = item.parent; a; a = a.parent) {
+          if (!a.expanded) return false;
+        }
+        return true;
+      });
+
+      expect(disabledTree.navService.focusedItem).to.equal(navigable.at(-1));
+    });
   });
 
   it('Should focus and activate the first tree item on Home key press and the last tree item on End key press', async () => {

--- a/src/components/tree/tree-selection.spec.ts
+++ b/src/components/tree/tree-selection.spec.ts
@@ -771,4 +771,69 @@ describe('Tree Selection', () => {
       TreeTestFunctions.verifyItemSelection(item2Children[2], true);
     });
   });
+
+  describe('Removal', () => {
+    beforeEach(async () => {
+      tree = await TreeTestFunctions.createTreeElement(cascadeSelectionTree);
+      treeSelectionService = tree.selectionService;
+    });
+
+    it('Should reconcile a removed subtree in a single pass', async () => {
+      tree.select();
+      await elementUpdated(tree);
+
+      const target = tree.items.find(
+        (item) => item.label === 'Tree Item 3.1.1'
+      )!;
+      const removed = [target, ...target.getChildren({ flatten: true })];
+      expect(removed.length).to.be.greaterThan(1);
+
+      const deselectSpy = spy(treeSelectionService, 'deselectItemsWithNoEvent');
+      target.remove();
+      await elementUpdated(tree);
+
+      // The topmost removed item covers its whole subtree; each descendant
+      // repeating the reconciliation would be redundant work.
+      expect(deselectSpy.callCount).to.equal(1);
+      expect(deselectSpy.firstCall.args[0]).to.have.members(removed);
+    });
+
+    it('Should update the ancestors of a removed subtree', async () => {
+      const parent = tree.items.find((item) => item.label === 'Tree Item 3.1')!;
+      const target = parent
+        .getChildren()
+        .find((item) => item.label === 'Tree Item 3.1.1')!;
+
+      tree.select([target]);
+      await elementUpdated(tree);
+
+      expect(treeSelectionService.isItemIndeterminate(parent)).to.be.true;
+
+      target.remove();
+      await elementUpdated(tree);
+
+      // With the only selected child gone, the parent is no longer partially
+      // selected.
+      expect(treeSelectionService.isItemIndeterminate(parent)).to.be.false;
+      expect(treeSelectionService.isItemSelected(parent)).to.be.false;
+    });
+
+    it('Should keep the selection state of a moved subtree', async () => {
+      const target = tree.items.find(
+        (item) => item.label === 'Tree Item 3.1.1'
+      )!;
+      tree.select([target]);
+      await elementUpdated(tree);
+
+      const newParent = tree.items.find(
+        (item) => item.label === 'Tree Item 2.2'
+      )!;
+      newParent.append(target);
+      await elementUpdated(tree);
+
+      TreeTestFunctions.verifyItemSelection(target, true);
+      expect(treeSelectionService.isItemIndeterminate(newParent)).to.be.false;
+      expect(treeSelectionService.isItemSelected(newParent)).to.be.true;
+    });
+  });
 });

--- a/src/components/tree/tree.common.ts
+++ b/src/components/tree/tree.common.ts
@@ -1,6 +1,69 @@
 import type { RequiredProps } from '../common/util.js';
 import type IgcTreeItemComponent from './tree-item.js';
 
+export const TREE_TAG = 'igc-tree';
+export const TREE_ITEM_TAG = 'igc-tree-item';
+
+/** ARIA state a tree item owns, and which moves with its role. */
+const TREE_ITEM_ARIA_STATE = [
+  'aria-expanded',
+  'aria-selected',
+  'aria-disabled',
+] as const;
+
+function isTreeItem(element: Element): element is IgcTreeItemComponent {
+  return element.tagName.toLowerCase() === TREE_ITEM_TAG;
+}
+
+/**
+ * The direct `igc-tree-item` light-DOM children of `parent`.
+ *
+ * Items must be nested directly - wrapping one in another element is not
+ * supported - which keeps this a cheap `.children` scan rather than a
+ * subtree-wide query.
+ */
+export function getTreeItemChildren(parent: Element): IgcTreeItemComponent[] {
+  const result: IgcTreeItemComponent[] = [];
+
+  for (const child of parent.children) {
+    if (isTreeItem(child)) {
+      result.push(child);
+    }
+  }
+
+  return result;
+}
+
+/** Whether `parent` has at least one direct `igc-tree-item` child. */
+export function hasTreeItemChildren(parent: Element): boolean {
+  for (const child of parent.children) {
+    if (isTreeItem(child)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** Sets an ARIA attribute, or removes it when `value` is null. */
+export function setAriaState(
+  element: Element,
+  name: string,
+  value: string | null
+): void {
+  if (value === null) {
+    element.removeAttribute(name);
+  } else {
+    element.setAttribute(name, value);
+  }
+}
+
+export function clearTreeItemAria(element: Element): void {
+  for (const name of TREE_ITEM_ARIA_STATE) {
+    element.removeAttribute(name);
+  }
+}
+
 export interface IgcTreeComponentEventMap {
   /* alternateName: selectionChanged */
   igcSelection: CustomEvent<IgcTreeSelectionEventArgs>;
@@ -10,6 +73,7 @@ export interface IgcTreeComponentEventMap {
   igcItemCollapsed: CustomEvent<IgcTreeItemComponent>;
   igcActiveItem: CustomEvent<IgcTreeItemComponent>;
 }
+
 export type TreeSelectionEventInit = RequiredProps<
   CustomEventInit<IgcTreeSelectionEventArgs>,
   'detail' | 'cancelable'

--- a/src/components/tree/tree.navigation.ts
+++ b/src/components/tree/tree.navigation.ts
@@ -17,13 +17,13 @@ import type { IgcTreeSelectionService } from './tree.selection.js';
 import type IgcTreeItemComponent from './tree-item.js';
 
 /**
- * Handles roving-tabindex keyboard navigation and active/focused item tracking for the tree.
+ * Handles roving-tabindex keyboard navigation and active/focused item tracking
+ * for the tree.
  *
- * Unlike the previous implementation, "visible" (keyboard-navigable) items are **not** cached.
- * They are derived on demand, only when a navigation key is actually pressed, directly from each
- * item's live `expanded`/`disabled`/`parent` state. This avoids doing any work on every single
- * item mount/expand/disable — the dominant cost in trees with many items — since navigation only
- * needs to know the visible set at the moment of a keypress, not continuously.
+ * The navigable set is never cached. It is derived on demand, only on an actual
+ * keypress, by a lazy walk that prunes collapsed branches — so no work happens
+ * on item mount/expand/disable, and callers needing a single item stop as soon
+ * as they have it.
  *
  * @hidden @internal
  */
@@ -38,8 +38,8 @@ export class IgcTreeNavigationService {
     addKeybindings(tree, {
       bindingDefaults: { preventDefault: true, repeat: true },
     })
-      .set(homeKey, () => this.setFocusedAndActiveItem(this._navigable[0]))
-      .set(endKey, () => this.setFocusedAndActiveItem(this._lastVisible()))
+      .set(homeKey, () => this.setFocusedAndActiveItem(this._firstNavigable()))
+      .set(endKey, () => this.setFocusedAndActiveItem(this._lastNavigable()))
       .set(arrowLeft, this._arrowLeft)
       .set(arrowRight, this._arrowRight)
       .set(arrowUp, () => this._arrowVertical(-1, true))
@@ -74,7 +74,7 @@ export class IgcTreeNavigationService {
     if (this._focusedItem && shouldFocus) {
       this._focusedItem.tabIndex = 0;
       this._focusedItem.focus({ preventScroll: true });
-      this._scrollIntoView(this._focusedItem);
+      scrollIntoView(this._focusedItem.wrapper);
     }
   }
 
@@ -132,39 +132,66 @@ export class IgcTreeNavigationService {
 
   //#region Visible/navigable item resolution (computed on demand, not cached)
 
-  private _isNavigable(item: IgcTreeItemComponent): boolean {
-    if (item.disabled) {
-      return false;
-    }
-    for (let ancestor = item.parent; ancestor; ancestor = ancestor.parent) {
-      if (!ancestor.expanded) {
-        return false;
+  /**
+   * Yields the keyboard-navigable items in document order.
+   *
+   * A disabled item is skipped but does not hide its subtree: only a
+   * *collapsed* ancestor removes descendants from the navigable set.
+   */
+  private *_navigable(
+    items: IgcTreeItemComponent[] = this.tree._rootItems
+  ): Generator<IgcTreeItemComponent, undefined> {
+    for (const item of items) {
+      if (!item.disabled) {
+        yield item;
+      }
+      if (item.expanded) {
+        yield* this._navigable(item.getChildren());
       }
     }
-    return true;
   }
 
-  private get _navigable(): IgcTreeItemComponent[] {
-    return this.tree.items.filter((item) => this._isNavigable(item));
+  private _firstNavigable(): IgcTreeItemComponent | undefined {
+    return this._navigable().next().value;
   }
 
-  private _lastVisible(): IgcTreeItemComponent {
-    const items = this._navigable;
-    return items[items.length - 1];
+  private _lastNavigable(): IgcTreeItemComponent | undefined {
+    let last: IgcTreeItemComponent | undefined;
+    for (const item of this._navigable()) {
+      last = item;
+    }
+    return last;
   }
 
-  /** Next/previous navigable item relative to `item`, or `item` itself if there isn't one. */
+  /**
+   * Next/previous navigable item relative to `item`, or `item` itself if there
+   * isn't one.
+   */
   private _adjacent(
     item: IgcTreeItemComponent,
     dir: 1 | -1
   ): IgcTreeItemComponent {
-    const items = this._navigable;
-    const index = items.indexOf(item);
-    return items[index + dir] ?? item;
-  }
+    const items = this._navigable();
+    let first: IgcTreeItemComponent | undefined;
+    let previous: IgcTreeItemComponent | undefined;
 
-  private _scrollIntoView(item: IgcTreeItemComponent): void {
-    scrollIntoView(item.wrapper);
+    for (const current of items) {
+      first ??= current;
+
+      if (current === item) {
+        if (dir === -1) {
+          return previous ?? item;
+        }
+        const next = items.next();
+        return next.done ? item : next.value;
+      }
+      previous = current;
+    }
+
+    // `item` is not navigable itself - it can be focused while an ancestor is
+    // collapsed out from under it. Going forward that lands on the first
+    // navigable item; going backwards it stays put.
+    return (dir === 1 ? first : undefined) ?? item;
   }
 
   //#endregion
@@ -233,7 +260,7 @@ export class IgcTreeNavigationService {
     }
     const siblings = item.parent
       ? item.parent.getChildren()
-      : this.tree.items.filter((i) => i.level === 0);
+      : this.tree._rootItems;
 
     for (const sibling of siblings) {
       if (!sibling.disabled && !sibling.expanded && sibling.hasChildren) {
@@ -248,12 +275,11 @@ export class IgcTreeNavigationService {
       return;
     }
 
+    this.setActiveItem(item);
+
     if (this.tree.selection === 'none') {
-      this.setActiveItem(item);
       return;
     }
-
-    this.setActiveItem(item);
 
     if (shiftKey) {
       this.selection.selectMultipleItems(item);

--- a/src/components/tree/tree.selection.ts
+++ b/src/components/tree/tree.selection.ts
@@ -3,82 +3,109 @@ import type { TreeSelectionEventInit } from './tree.common.js';
 import type IgcTreeComponent from './tree.js';
 import type IgcTreeItemComponent from './tree-item.js';
 
+type ItemSet = Set<IgcTreeItemComponent>;
+
+/**
+ * The sets being built up during a single cascade update. Passed explicitly
+ * between the cascade helpers rather than kept as scratch fields on the service,
+ * so no half-built state is observable outside the update that produced it.
+ */
+type CascadeState = {
+  selected: ItemSet;
+  indeterminate: ItemSet;
+};
+
 /* blazorSuppress */
 export class IgcTreeSelectionService {
-  private tree!: IgcTreeComponent;
-  private itemSelection: Set<IgcTreeItemComponent> =
-    new Set<IgcTreeItemComponent>();
-  private indeterminateItems: Set<IgcTreeItemComponent> =
-    new Set<IgcTreeItemComponent>();
-  private itemsToBeSelected!: Set<IgcTreeItemComponent>;
-  private itemsToBeIndeterminate!: Set<IgcTreeItemComponent>;
+  private readonly _tree: IgcTreeComponent;
+
+  private _itemSelection: ItemSet = new Set();
+  private _indeterminateItems: ItemSet = new Set();
 
   constructor(tree: IgcTreeComponent) {
-    this.tree = tree;
+    this._tree = tree;
   }
+
+  private get _isCascade(): boolean {
+    return this._tree.selection === 'cascade';
+  }
+
+  //#region Public API
 
   /** Select range from last selected item to the current specified item. */
   public selectMultipleItems(item: IgcTreeItemComponent): void {
-    if (!this.itemSelection.size) {
+    if (isEmpty(this._itemSelection)) {
       this.selectItem(item);
       return;
     }
-    const lastSelectedItemIndex = this.tree.items.indexOf(
-      this.getSelectedItems()[this.itemSelection.size - 1]
-    );
-    const currentItemIndex = this.tree.items.indexOf(item);
-    const items = this.tree.items.slice(
-      Math.min(currentItemIndex, lastSelectedItemIndex),
-      Math.max(currentItemIndex, lastSelectedItemIndex) + 1
-    );
 
-    const added = items.filter(
-      (_item: IgcTreeItemComponent) => !this.isItemSelected(_item)
+    const items = this._tree.items;
+    const selected = this._selectedSnapshot();
+    const lastSelectedIndex = items.indexOf(selected[selected.length - 1]);
+    const currentIndex = items.indexOf(item);
+
+    const range = items.slice(
+      Math.min(currentIndex, lastSelectedIndex),
+      Math.max(currentIndex, lastSelectedIndex) + 1
     );
-    const newSelection = this.getSelectedItems().concat(added);
-    this.emitItemSelectionEvent(newSelection, added, []);
+    const added = range.filter((i) => !this.isItemSelected(i));
+
+    this._emitSelectionEvent(selected.concat(added), added, []);
   }
 
   /** Select the specified item and emit event. */
   public selectItem(item: IgcTreeItemComponent): void {
-    if (this.tree.selection === 'none') {
+    if (this._tree.selection === 'none') {
       return;
     }
-    this.emitItemSelectionEvent([...this.getSelectedItems(), item], [item], []);
+    this._emitSelectionEvent([...this._itemSelection, item], [item], []);
   }
 
   /** Deselect the specified item and emit event. */
   public deselectItem(item: IgcTreeItemComponent): void {
-    const newSelection = this.getSelectedItems().filter(
-      (_item: IgcTreeItemComponent) => _item !== item
-    );
-    this.emitItemSelectionEvent(newSelection, [], [item]);
+    const newSelection = this._selectedSnapshot().filter((i) => i !== item);
+    this._emitSelectionEvent(newSelection, [], [item]);
   }
 
   /** Clears item selection */
   public clearItemsSelection(): void {
-    const oldSelection = this.getSelectedItems();
-    const oldIndeterminate = this.getIndeterminateItems();
-    this.itemSelection.clear();
-    this.indeterminateItems.clear();
-    oldSelection.forEach((i: IgcTreeItemComponent) => {
-      i.selected = false;
-    });
-    oldIndeterminate.forEach((i: IgcTreeItemComponent) => {
-      i.indeterminate = false;
-    });
+    const oldSelection = this._selectedSnapshot();
+    const oldIndeterminate = this._indeterminateSnapshot();
+
+    this._itemSelection.clear();
+    this._indeterminateItems.clear();
+
+    for (const item of oldSelection) {
+      item.selected = false;
+    }
+    for (const item of oldIndeterminate) {
+      item.indeterminate = false;
+    }
   }
 
   public isItemSelected(item: IgcTreeItemComponent): boolean {
-    return this.itemSelection.has(item);
+    return this._itemSelection.has(item);
   }
 
   public isItemIndeterminate(item: IgcTreeItemComponent): boolean {
-    return this.indeterminateItems.has(item);
+    return this._indeterminateItems.has(item);
   }
 
   /** Called on item`s disconnectedCallback */
   public ensureStateOnItemDelete(item: IgcTreeItemComponent): void {
+    // Removing a subtree fires `disconnectedCallback` for the topmost item
+    // first and then for every descendant. That first call already covers the
+    // whole subtree below it, so a detached parent means an ancestor is
+    // handling this removal and repeating the work here would be redundant.
+    if (item.parent && !item.parent.isConnected) {
+      return;
+    }
+
+    // Nothing to reconcile if no item is in a selected or indeterminate state.
+    if (isEmpty(this._itemSelection) && isEmpty(this._indeterminateItems)) {
+      return;
+    }
+
     // Don't update the internal state of the deleted items because when moving they should keep it
     // However update the state of their parents
     this.deselectItemsWithNoEvent(
@@ -90,62 +117,28 @@ export class IgcTreeSelectionService {
   /** Retrigger the selection state of the item. */
   public retriggerItemState(item: IgcTreeItemComponent): void {
     if (item.selected) {
-      this.itemSelection.delete(item);
+      this._itemSelection.delete(item);
       this.selectItemsWithNoEvent([item]);
     } else {
-      this.itemSelection.add(item);
+      this._itemSelection.add(item);
       this.deselectItemsWithNoEvent([item]);
-    }
-  }
-
-  private emitItemSelectionEvent(
-    newSelection: IgcTreeItemComponent[],
-    added: IgcTreeItemComponent[],
-    removed: IgcTreeItemComponent[]
-  ): void {
-    const currSelection = this.getSelectedItems();
-    if (this.areEqualCollections(currSelection, newSelection)) {
-      return;
-    }
-
-    if (this.tree.selection === 'cascade') {
-      this.emitCascadeItemSelectionEvent(currSelection, added, removed);
-      return;
-    }
-
-    const args: TreeSelectionEventInit = {
-      detail: {
-        newSelection,
-      },
-      cancelable: true,
-    };
-
-    const allowed = this.tree.emitEvent('igcSelection', args);
-    if (!allowed) {
-      return;
-    }
-
-    // if newSelection is overwritten do not proceed (Blazor)
-    if (this.areEqualCollections(newSelection, args.detail.newSelection)) {
-      this.itemSelection = new Set(newSelection);
-      this.updateItemsState(currSelection);
     }
   }
 
   /** Select specified items. No event is emitted. */
   public selectItemsWithNoEvent(items: IgcTreeItemComponent[]): void {
-    const oldSelection = this.getSelectedItems();
+    const oldSelection = this._selectedSnapshot();
 
-    if (this.tree && this.tree.selection === 'cascade') {
-      this.cascadeSelectItemsWithNoEvent(items, oldSelection);
+    if (this._isCascade) {
+      this._cascadeSelectWithNoEvent(items, oldSelection);
       return;
     }
 
     for (const item of items) {
-      this.itemSelection.add(item);
+      this._itemSelection.add(item);
     }
 
-    this.updateItemsState(oldSelection);
+    this._updateItemsState(oldSelection);
   }
 
   /** Deselect specified items. No event is emitted. */
@@ -153,141 +146,156 @@ export class IgcTreeSelectionService {
     items?: IgcTreeItemComponent[],
     onDelete = false
   ): void {
-    if (this.tree && this.tree.selection === 'cascade') {
-      this.cascadeDeselectItemsWithNoEvent(items, onDelete);
+    if (this._isCascade) {
+      this._cascadeDeselectWithNoEvent(items, onDelete);
       return;
     }
-    const itemSet = new Set(items);
-    const oldSelection = onDelete
-      ? this.getSelectedItems().filter(
-          (i: IgcTreeItemComponent) => !itemSet!.has(i)
-        )
-      : this.getSelectedItems();
 
-    if (!items) {
-      this.itemSelection.clear();
-    } else {
+    // On delete the removed items keep their own state, so they are excluded
+    // from the "before" snapshot and never get their `selected` flag cleared.
+    const oldSelection = onDelete
+      ? this._excluding(this._itemSelection, items)
+      : this._selectedSnapshot();
+
+    if (items) {
       for (const item of items) {
-        this.itemSelection.delete(item);
+        this._itemSelection.delete(item);
       }
+    } else {
+      this._itemSelection.clear();
     }
 
-    this.updateItemsState(oldSelection);
+    this._updateItemsState(oldSelection);
   }
 
-  private emitCascadeItemSelectionEvent(
-    currSelection: IgcTreeItemComponent[],
+  //#endregion
+
+  //#region Selection events
+
+  private _emitSelectionEvent(
+    newSelection: IgcTreeItemComponent[],
     added: IgcTreeItemComponent[],
     removed: IgcTreeItemComponent[]
   ): void {
-    const oldIndeterminate = this.getIndeterminateItems();
+    const currSelection = this._selectedSnapshot();
 
-    this.calculateItemsNewSelectionState(currSelection, added, removed);
+    if (this._sameSelection(currSelection, newSelection)) {
+      return;
+    }
+
+    if (this._isCascade) {
+      this._emitCascadeSelectionEvent(currSelection, added, removed);
+      return;
+    }
 
     const args: TreeSelectionEventInit = {
-      detail: {
-        newSelection: Array.from(this.itemsToBeSelected),
-      },
+      detail: { newSelection },
       cancelable: true,
     };
 
-    const allowed = this.tree.emitEvent('igcSelection', args);
-
-    if (!allowed) {
+    if (!this._tree.emitEvent('igcSelection', args)) {
       return;
     }
 
     // if newSelection is overwritten do not proceed (Blazor)
-    if (
-      this.areEqualCollections(
-        Array.from(this.itemsToBeSelected),
-        args.detail.newSelection
-      )
-    ) {
-      this.itemSelection = new Set<IgcTreeItemComponent>(
-        this.itemsToBeSelected
-      );
-      this.indeterminateItems = new Set(this.itemsToBeIndeterminate);
-      this.updateItemsState(currSelection, oldIndeterminate);
+    if (this._sameSelection(newSelection, args.detail.newSelection)) {
+      this._itemSelection = new Set(newSelection);
+      this._updateItemsState(currSelection);
     }
   }
 
-  private cascadeSelectItemsWithNoEvent(
+  private _emitCascadeSelectionEvent(
+    currSelection: IgcTreeItemComponent[],
+    added: IgcTreeItemComponent[],
+    removed: IgcTreeItemComponent[]
+  ): void {
+    const oldIndeterminate = this._indeterminateSnapshot();
+    const state = this._calculateCascadeState(currSelection, added, removed);
+    const newSelection = Array.from(state.selected);
+
+    const args: TreeSelectionEventInit = {
+      detail: { newSelection },
+      cancelable: true,
+    };
+
+    if (!this._tree.emitEvent('igcSelection', args)) {
+      return;
+    }
+
+    // if newSelection is overwritten do not proceed (Blazor)
+    if (this._sameSelection(newSelection, args.detail.newSelection)) {
+      this._commit(state);
+      this._updateItemsState(currSelection, oldIndeterminate);
+    }
+  }
+
+  //#endregion
+
+  //#region Cascade selection
+
+  private _cascadeSelectWithNoEvent(
     items: IgcTreeItemComponent[],
     oldSelection: IgcTreeItemComponent[]
   ): void {
-    const oldIndeterminate = this.getIndeterminateItems();
-
+    const oldIndeterminate = this._indeterminateSnapshot();
     const newSelection = [...oldSelection, ...items];
 
     // retrieve only the rows without their parents/children which has to be added to the selection
     const newSelectionSet = new Set(newSelection);
-    const removed = oldSelection!.filter((x) => !newSelectionSet.has(x));
-    const added = newSelection!.filter((x) => !this.itemSelection.has(x));
+    const removed = oldSelection.filter((i) => !newSelectionSet.has(i));
+    const added = newSelection.filter((i) => !this._itemSelection.has(i));
 
-    this.calculateItemsNewSelectionState(oldSelection, added, removed);
-
-    this.itemSelection = new Set(this.itemsToBeSelected);
-    this.indeterminateItems = new Set(this.itemsToBeIndeterminate);
-
-    this.updateItemsState(oldSelection, oldIndeterminate);
+    this._commit(this._calculateCascadeState(oldSelection, added, removed));
+    this._updateItemsState(oldSelection, oldIndeterminate);
   }
 
-  private cascadeDeselectItemsWithNoEvent(
+  private _cascadeDeselectWithNoEvent(
     items?: IgcTreeItemComponent[],
     onDelete = false
   ): void {
-    const itemSet = new Set(items);
     const oldSelection = onDelete
-      ? this.getSelectedItems().filter(
-          (i: IgcTreeItemComponent) => !itemSet!.has(i)
-        )
-      : this.getSelectedItems();
+      ? this._excluding(this._itemSelection, items)
+      : this._selectedSnapshot();
     const oldIndeterminate = onDelete
-      ? this.getIndeterminateItems().filter(
-          (i: IgcTreeItemComponent) => !itemSet!.has(i)
-        )
-      : this.getIndeterminateItems();
+      ? this._excluding(this._indeterminateItems, items)
+      : this._indeterminateSnapshot();
 
-    if (!items) {
-      this.itemSelection.clear();
-      this.indeterminateItems.clear();
+    if (items) {
+      this._commit(this._calculateCascadeState(oldSelection, [], items));
     } else {
-      this.calculateItemsNewSelectionState(oldSelection, [], items);
-
-      this.itemSelection = new Set<IgcTreeItemComponent>(
-        this.itemsToBeSelected
-      );
-      this.indeterminateItems = new Set<IgcTreeItemComponent>(
-        this.itemsToBeIndeterminate
-      );
+      this._itemSelection.clear();
+      this._indeterminateItems.clear();
     }
 
-    this.updateItemsState(oldSelection, oldIndeterminate);
+    this._updateItemsState(oldSelection, oldIndeterminate);
   }
 
-  // OK (disabled children?)
   /**
-   * populates the itemsToBeSelected and itemsToBeIndeterminate sets
-   * with the items which will be eventually in selected/indeterminate state
+   * The sets resulting from applying `added` and `removed` on top of
+   * `oldSelection`.
+   *
+   * Disabled items cascade exactly like enabled ones: selected and deselected
+   * with their ancestors, and counted towards a parent's state.
    */
-  private calculateItemsNewSelectionState(
+  private _calculateCascadeState(
     oldSelection: IgcTreeItemComponent[],
     added: IgcTreeItemComponent[],
     removed: IgcTreeItemComponent[]
-  ): void {
-    this.itemsToBeSelected = new Set<IgcTreeItemComponent>(oldSelection);
-    this.itemsToBeIndeterminate = new Set<IgcTreeItemComponent>(
-      this.getIndeterminateItems()
-    );
+  ): CascadeState {
+    const state: CascadeState = {
+      selected: new Set(oldSelection),
+      indeterminate: new Set(this._indeterminateItems),
+    };
 
-    this.cascadeSelectionState(removed, false);
-    this.cascadeSelectionState(added, true);
+    this._cascadeInto(state, removed, false);
+    this._cascadeInto(state, added, true);
+
+    return state;
   }
 
-  // OK (disabled children?)
-  /** Ensures proper selection state for all predescessors and descendants during a selection event */
-  private cascadeSelectionState(
+  /** Applies `selected` to each item and its descendants, then reconciles ancestors. */
+  private _cascadeInto(
+    state: CascadeState,
     items: IgcTreeItemComponent[] | undefined,
     selected: boolean
   ): void {
@@ -295,146 +303,170 @@ export class IgcTreeSelectionService {
       return;
     }
 
-    const parents = new Set<IgcTreeItemComponent>();
-    items.forEach((item: IgcTreeItemComponent) => {
-      // select/deselect items passed by event/api
-      this.selectDeselectItem(item, selected);
+    const parents: ItemSet = new Set();
 
-      // select/deselect all of their children
-      const itemAndAllChildren = item.getChildren({ flatten: true }) || [];
-      itemAndAllChildren.forEach((i: IgcTreeItemComponent) => {
-        this.selectDeselectItem(i, selected);
-      });
+    for (const item of items) {
+      this._setItemState(state, item, selected);
 
-      // add their direct parent to the set
-      if (item?.parent) {
+      for (const child of item.getChildren({ flatten: true })) {
+        this._setItemState(state, child, selected);
+      }
+
+      if (item.parent) {
         parents.add(item.parent);
       }
-    });
+    }
 
-    // handle direct parents from the set
     for (const parent of parents) {
-      this.handleParentSelectionState(parent);
+      this._updateAncestors(state, parent);
     }
   }
 
-  // OK (disabled children?)
-  /**
-   * recursively handle the selection state of the direct and indirect parents
-   */
-  private handleParentSelectionState(item: IgcTreeItemComponent): void {
-    if (!item) {
+  /** Reconciles `item` and every ancestor above it against their children. */
+  private _updateAncestors(
+    state: CascadeState,
+    item: IgcTreeItemComponent
+  ): void {
+    for (
+      let current: IgcTreeItemComponent | null = item;
+      current;
+      current = current.parent
+    ) {
+      this._applyItemState(state, current);
+    }
+  }
+
+  /** Derives an item's state from the states of its direct children. */
+  private _applyItemState(
+    state: CascadeState,
+    item: IgcTreeItemComponent
+  ): void {
+    const children = item.getChildren();
+
+    if (isEmpty(children)) {
+      // An item whose children were deleted keeps whatever state it had.
+      this._setItemState(state, item, this.isItemSelected(item));
       return;
     }
-    this.handleItemSelectionState(item);
-    if (item.parent) {
-      this.handleParentSelectionState(item.parent);
-    }
-  }
 
-  // OK (disabled children?)
-  /**
-   * Handle the selection state of a given item based the selection states of its direct children
-   */
-  private handleItemSelectionState(item: IgcTreeItemComponent): void {
-    const itemsArray = item?.getChildren() ? item.getChildren() : [];
-    if (itemsArray.length) {
-      if (
-        itemsArray.every((i: IgcTreeItemComponent) =>
-          this.itemsToBeSelected.has(i)
-        )
-      ) {
-        this.selectDeselectItem(item, true);
-      } else if (
-        itemsArray.some(
-          (i: IgcTreeItemComponent) =>
-            this.itemsToBeSelected.has(i) || this.itemsToBeIndeterminate.has(i)
-        )
-      ) {
-        this.selectDeselectItem(item, false, true);
-      } else {
-        this.selectDeselectItem(item, false);
-      }
-    } else if (this.isItemSelected(item)) {
-      // if the children of the item has been deleted and the item was selected do not change its state
-      this.selectDeselectItem(item, true);
+    if (children.every((child) => state.selected.has(child))) {
+      this._setItemState(state, item, true);
+    } else if (
+      children.some(
+        (child) => state.selected.has(child) || state.indeterminate.has(child)
+      )
+    ) {
+      this._setItemState(state, item, false, true);
     } else {
-      this.selectDeselectItem(item, false);
+      this._setItemState(state, item, false);
     }
   }
 
-  /** Emits the `selectedChange` event for each item affected by the selection */
-  private updateItemsState(
-    oldSelection: IgcTreeItemComponent[],
-    oldIndeterminate: IgcTreeItemComponent[] = []
-  ): void {
-    const selected = new Set<IgcTreeItemComponent>(oldSelection);
-    const indeterminated = new Set<IgcTreeItemComponent>(oldIndeterminate);
-
-    this.getSelectedItems().forEach((i: IgcTreeItemComponent) => {
-      if (!selected.has(i)) {
-        i.selected = true;
-      }
-    });
-
-    oldSelection.forEach((i: IgcTreeItemComponent) => {
-      if (!this.itemSelection.has(i)) {
-        i.selected = false;
-      }
-    });
-
-    if (this.tree.selection === 'cascade') {
-      this.indeterminateItems.forEach((i: IgcTreeItemComponent) => {
-        if (!indeterminated.has(i)) {
-          i.indeterminate = true;
-        }
-      });
-
-      oldIndeterminate.forEach((i: IgcTreeItemComponent) => {
-        if (!this.indeterminateItems.has(i)) {
-          i.indeterminate = false;
-        }
-      });
-    }
-  }
-
-  /** Returns array of the selected items. */
-  private getSelectedItems(): IgcTreeItemComponent[] {
-    return Array.from(this.itemSelection);
-  }
-
-  /** Returns array of the items in indeterminate state. */
-  private getIndeterminateItems(): IgcTreeItemComponent[] {
-    return Array.from(this.indeterminateItems);
-  }
-
-  private areEqualCollections(
-    first: IgcTreeItemComponent[],
-    second: IgcTreeItemComponent[]
-  ): boolean {
-    return (
-      first.length === second.length &&
-      new Set(first.concat(second)).size === first.length
-    );
-  }
-
-  private selectDeselectItem(
+  private _setItemState(
+    state: CascadeState,
     item: IgcTreeItemComponent,
     select: boolean,
     indeterminate = false
   ): void {
     if (indeterminate) {
-      this.itemsToBeIndeterminate.add(item);
-      this.itemsToBeSelected.delete(item);
+      state.indeterminate.add(item);
+      state.selected.delete(item);
       return;
     }
 
     if (select) {
-      this.itemsToBeSelected.add(item);
-      this.itemsToBeIndeterminate.delete(item);
+      state.selected.add(item);
+      state.indeterminate.delete(item);
     } else {
-      this.itemsToBeSelected.delete(item);
-      this.itemsToBeIndeterminate.delete(item);
+      state.selected.delete(item);
+      state.indeterminate.delete(item);
     }
   }
+
+  private _commit(state: CascadeState): void {
+    this._itemSelection = state.selected;
+    this._indeterminateItems = state.indeterminate;
+  }
+
+  //#endregion
+
+  //#region Internal helpers
+
+  /** Reflects the computed selection onto the affected items. */
+  private _updateItemsState(
+    oldSelection: IgcTreeItemComponent[],
+    oldIndeterminate: IgcTreeItemComponent[] = []
+  ): void {
+    this._reflect(this._itemSelection, oldSelection, (item, value) => {
+      item.selected = value;
+    });
+
+    if (this._isCascade) {
+      this._reflect(
+        this._indeterminateItems,
+        oldIndeterminate,
+        (item, value) => {
+          item.indeterminate = value;
+        }
+      );
+    }
+  }
+
+  /** Applies the transition from `previous` to `current` to the items that moved. */
+  private _reflect(
+    current: ItemSet,
+    previous: IgcTreeItemComponent[],
+    apply: (item: IgcTreeItemComponent, value: boolean) => void
+  ): void {
+    const before = new Set(previous);
+
+    for (const item of current) {
+      if (!before.has(item)) {
+        apply(item, true);
+      }
+    }
+    for (const item of previous) {
+      if (!current.has(item)) {
+        apply(item, false);
+      }
+    }
+  }
+
+  private _selectedSnapshot(): IgcTreeItemComponent[] {
+    return Array.from(this._itemSelection);
+  }
+
+  private _indeterminateSnapshot(): IgcTreeItemComponent[] {
+    return Array.from(this._indeterminateItems);
+  }
+
+  /** Snapshot of `source` without any of `excluded`. */
+  private _excluding(
+    source: ItemSet,
+    excluded?: IgcTreeItemComponent[]
+  ): IgcTreeItemComponent[] {
+    const skip = new Set(excluded);
+    const result: IgcTreeItemComponent[] = [];
+
+    for (const item of source) {
+      if (!skip.has(item)) {
+        result.push(item);
+      }
+    }
+
+    return result;
+  }
+
+  private _sameSelection(
+    first: IgcTreeItemComponent[],
+    second: IgcTreeItemComponent[]
+  ): boolean {
+    if (first.length !== second.length) {
+      return false;
+    }
+    const set = new Set(first);
+    return second.every((item) => set.has(item));
+  }
+
+  //#endregion
 }

--- a/src/components/tree/tree.spec.ts
+++ b/src/components/tree/tree.spec.ts
@@ -66,6 +66,19 @@ describe('Tree', () => {
       });
     });
 
+    it('Should report the full ancestor path of an item, root first', async () => {
+      tree = await TreeTestFunctions.createTreeElement(simpleHierarchyTree);
+
+      const root = tree.items[0];
+      const child = root.getChildren()[0];
+      const grandChild = child.getChildren()[1];
+
+      expect(root.path).to.eql([root]);
+      expect(child.path).to.eql([root, child]);
+      expect(grandChild.path).to.eql([root, child, grandChild]);
+      expect(grandChild.path.at(-1)).to.equal(grandChild);
+    });
+
     it('Should support multiple levels of nesting', async () => {
       tree = await TreeTestFunctions.createTreeElement(simpleHierarchyTree);
 
@@ -793,6 +806,65 @@ describe('Tree', () => {
       expect(cb.checked).to.be.true;
     });
 
+    it('Should toggle an item exactly once on indicator click after `toggleNodeOnClick` is enabled at runtime', async () => {
+      // Enabling `toggleNodeOnClick` on its own must not leave a stale
+      // indicator handler behind: the click would then be handled both by the
+      // indicator and by the bubbling item click, cancelling itself out.
+      tree.toggleNodeOnClick = true;
+      await elementUpdated(tree);
+
+      expect(topLevelItems[0].expanded).to.be.false;
+
+      const indicator = TreeTestFunctions.getSlot(
+        topLevelItems[0],
+        SLOTS.indicator
+      );
+      indicator.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true })
+      );
+      await elementUpdated(tree);
+
+      TreeTestFunctions.verifyExpansionState(topLevelItems[0], true);
+      await waitUntil(() => eventSpy.calledWith('igcItemExpanded'));
+
+      // Exactly one expansion, and nothing collapsed it back.
+      expect(eventSpy.withArgs('igcItemExpanding').callCount).to.equal(1);
+      expect(eventSpy.withArgs('igcItemExpanded').callCount).to.equal(1);
+      expect(eventSpy.calledWith('igcItemCollapsing')).to.be.false;
+    });
+
+    it('Should toggle an item on indicator click after `toggleNodeOnClick` is disabled at runtime', async () => {
+      tree.toggleNodeOnClick = true;
+      await elementUpdated(tree);
+
+      // Any unrelated re-render while `toggleNodeOnClick` is enabled used to
+      // drop the indicator handler for good, since turning the flag back off
+      // does not re-render the item.
+      topLevelItems[0].requestUpdate();
+      await elementUpdated(tree);
+
+      tree.toggleNodeOnClick = false;
+      await elementUpdated(tree);
+
+      expect(topLevelItems[0].expanded).to.be.false;
+
+      const indicator = TreeTestFunctions.getSlot(
+        topLevelItems[0],
+        SLOTS.indicator
+      );
+      indicator.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true })
+      );
+      await elementUpdated(tree);
+
+      TreeTestFunctions.verifyExpansionState(topLevelItems[0], true);
+      await waitUntil(() => eventSpy.calledWith('igcItemExpanded'));
+
+      expect(eventSpy.withArgs('igcItemExpanding').callCount).to.equal(1);
+      expect(eventSpy.withArgs('igcItemExpanded').callCount).to.equal(1);
+      expect(eventSpy.calledWith('igcItemCollapsing')).to.be.false;
+    });
+
     it('Should toggle item state when item.toggle() is called', async () => {
       expect(topLevelItems[1].expanded).to.be.true;
 
@@ -1294,6 +1366,127 @@ describe('Tree', () => {
 
       expect(initiallyExpandedItem).to.have.attribute('aria-expanded', 'false');
     });
+
+    it('Should not advertise selection when `selection` is `none`', async () => {
+      expect(tree.selection).to.equal('none');
+      expect(tree).not.to.have.attribute('aria-multiselectable');
+
+      for (const item of tree.items) {
+        expect(item, item.label).not.to.have.attribute('aria-selected');
+      }
+    });
+
+    it("Should reflect an item's selection state in aria-selected", async () => {
+      tree.selection = 'multiple';
+      await elementUpdated(tree);
+
+      expect(tree).to.have.attribute('aria-multiselectable', 'true');
+      expect(topLevelItems[0]).to.have.attribute('aria-selected', 'false');
+
+      tree.select([topLevelItems[0]]);
+      await elementUpdated(tree);
+
+      expect(topLevelItems[0]).to.have.attribute('aria-selected', 'true');
+
+      tree.deselect([topLevelItems[0]]);
+      await elementUpdated(tree);
+
+      expect(topLevelItems[0]).to.have.attribute('aria-selected', 'false');
+    });
+
+    it('Should drop aria-selected when selection is turned back off', async () => {
+      tree.selection = 'cascade';
+      await elementUpdated(tree);
+      expect(topLevelItems[0]).to.have.attribute('aria-selected');
+
+      tree.selection = 'none';
+      await elementUpdated(tree);
+
+      expect(tree).not.to.have.attribute('aria-multiselectable');
+      expect(topLevelItems[0]).not.to.have.attribute('aria-selected');
+    });
+
+    it("Should reflect an item's disabled state in aria-disabled", async () => {
+      const disabled = tree.items.find((item) => item.disabled)!;
+      expect(disabled).to.have.attribute('aria-disabled', 'true');
+
+      // Absent rather than "false" for enabled items.
+      expect(topLevelItems[0]).not.to.have.attribute('aria-disabled');
+
+      topLevelItems[0].disabled = true;
+      await elementUpdated(tree);
+      expect(topLevelItems[0]).to.have.attribute('aria-disabled', 'true');
+
+      topLevelItems[0].disabled = false;
+      await elementUpdated(tree);
+      expect(topLevelItems[0]).not.to.have.attribute('aria-disabled');
+    });
+
+    it('Should move ARIA state onto the focusable label element along with the role', async () => {
+      tree.selection = 'multiple';
+      await elementUpdated(tree);
+
+      const item = topLevelItems[1].getChildren()[0].getChildren()[0];
+      const anchor = TreeTestFunctions.getSlot(
+        item,
+        SLOTS.label
+      ).assignedElements()[0].children[0] as HTMLElement;
+
+      expect(item).to.have.attribute('role', 'none');
+      expect(anchor).to.have.attribute('role', 'treeitem');
+
+      // State left on a role="none" host would be ignored by assistive tech.
+      expect(anchor).to.have.attribute('aria-selected', 'false');
+      expect(item).not.to.have.attribute('aria-selected');
+
+      tree.select([item]);
+      await elementUpdated(tree);
+
+      expect(anchor).to.have.attribute('aria-selected', 'true');
+      expect(item).not.to.have.attribute('aria-selected');
+    });
+
+    it('Should be accessible', async () => {
+      await expect(tree).to.be.accessible();
+
+      tree.expand();
+      await elementUpdated(tree);
+      await expect(tree).to.be.accessible();
+    });
+
+    /**
+     * `aria-hidden-focus` is a known, pre-existing violation, not something
+     * these trees get wrong: the selection checkbox is deliberately hidden from
+     * assistive tech (selection is conveyed by `aria-selected` on the item), but
+     * `igc-checkbox` does not forward the host's `tabindex="-1"` to its inner
+     * `<input>`, so that input stays in the tab order inside an `aria-hidden`
+     * container. Fixing it means changing `igc-checkbox`. Only this one rule is
+     * suppressed, so every other check still runs against these states.
+     */
+    const SELECTION_A11Y_OPTIONS = {
+      ignoredRules: ['aria-hidden-focus'],
+    };
+
+    it('Should be accessible with selection enabled', async () => {
+      for (const selection of ['multiple', 'cascade'] as const) {
+        tree.selection = selection;
+        tree.expand();
+        await elementUpdated(tree);
+        await expect(tree).to.be.accessible(SELECTION_A11Y_OPTIONS);
+
+        tree.select();
+        await elementUpdated(tree);
+        await expect(tree).to.be.accessible(SELECTION_A11Y_OPTIONS);
+      }
+    });
+
+    it('Should be accessible with disabled items', async () => {
+      tree = await TreeTestFunctions.createTreeElement(disabledItemsTree);
+      tree.expand();
+      await elementUpdated(tree);
+
+      await expect(tree).to.be.accessible(SELECTION_A11Y_OPTIONS);
+    });
   });
 
   describe('RTL', () => {
@@ -1306,6 +1499,22 @@ describe('Tree', () => {
       eventSpy = spy(tree, 'emitEvent');
       tree.dir = 'rtl';
       await elementUpdated(tree);
+    });
+
+    it('Should mirror the expand indicator after the direction changes at runtime', async () => {
+      const indicator = topLevelItems[0].renderRoot.querySelector(
+        'div[part~="indicator"]'
+      )!;
+
+      // scaleX(-1)
+      expect(getComputedStyle(indicator).transform).to.equal(
+        'matrix(-1, 0, 0, 1, 0, 0)'
+      );
+
+      tree.dir = 'ltr';
+      await elementUpdated(tree);
+
+      expect(getComputedStyle(indicator).transform).to.equal('none');
     });
 
     it('Should collapse expanded tree items on Arrow Right key press when the direction is RTL', async () => {

--- a/src/components/tree/tree.ts
+++ b/src/components/tree/tree.ts
@@ -13,10 +13,25 @@ import { EventEmitterMixin } from '../common/mixins/event-emitter.js';
 import type { TreeSelection } from '../types.js';
 import { styles } from './themes/container.base.css.js';
 import { all } from './themes/container.js';
-import type { IgcTreeComponentEventMap } from './tree.common.js';
+import {
+  getTreeItemChildren,
+  type IgcTreeComponentEventMap,
+  setAriaState,
+} from './tree.common.js';
 import { IgcTreeNavigationService } from './tree.navigation.js';
 import { IgcTreeSelectionService } from './tree.selection.js';
 import IgcTreeItemComponent from './tree-item.js';
+
+/**
+ * Tree properties that items read while rendering. The tree is not a reactive
+ * source for them, so changing one has to re-render the items by hand or they
+ * keep rendering stale output.
+ *
+ * Prefer reading tree state at event time over extending this - a handler
+ * always sees the current value and costs no re-render. Direction is handled in
+ * CSS via `:dir()` for the same reason.
+ */
+const ITEM_RENDER_DEPENDENCIES = ['selection', 'resourceStrings'] as const;
 
 /**
  * The tree allows users to represent hierarchical data in a tree-view structure,
@@ -106,18 +121,28 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     return this._i18nController.resourceStrings;
   }
 
+  /**
+   * @hidden @internal
+   * The tree's top-most items, i.e. its direct `igc-tree-item` light-DOM children.
+   */
+  public get _rootItems(): IgcTreeItemComponent[] {
+    return getTreeItemChildren(this);
+  }
+
   /* blazorSuppress */
   /**
    * Returns all of the tree's items.
    */
   public get items(): IgcTreeItemComponent[] {
+    // A shared accumulator, rather than spreading each root's flattened
+    // descendants, which would copy every subtree an extra time.
     const result: IgcTreeItemComponent[] = [];
-    for (const el of this.children) {
-      if (el.tagName.toLowerCase() === IgcTreeItemComponent.tagName) {
-        const item = el as IgcTreeItemComponent;
-        result.push(item, ...item.getChildren({ flatten: true }));
-      }
+
+    for (const item of this._rootItems) {
+      result.push(item);
+      item._collectDescendants(result);
     }
+
     return result;
   }
 
@@ -132,16 +157,20 @@ export default class IgcTreeComponent extends EventEmitterMixin<
 
   public override connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('role', 'tree');
+    this._syncAria();
     const items = this.items;
+
     // set init to true for all items which are rendered along with the tree
     for (const item of items) {
       item.init = true;
     }
+
+    // Seed the roving tabindex without moving DOM focus - connecting a tree must
+    // not pull focus away from wherever the user currently is.
     const firstNotDisabledItem = items.find((i) => !i.disabled);
     if (firstNotDisabledItem) {
       firstNotDisabledItem.tabIndex = 0;
-      this.navService.focusItem(firstNotDisabledItem);
+      this.navService.focusItem(firstNotDisabledItem, false);
     }
   }
 
@@ -149,39 +178,48 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     super.willUpdate(changed);
 
     if (this.hasUpdated && changed.has('selection')) {
-      this._selectionModeChange();
+      this.selectionService.clearItemsSelection();
     }
 
     if (changed.has('singleBranchExpand')) {
       this._singleBranchExpandChange();
     }
 
-    if (changed.has('selection') || changed.has('resourceStrings')) {
+    if (ITEM_RENDER_DEPENDENCIES.some((prop) => changed.has(prop))) {
       for (const item of this.items) {
         item.requestUpdate();
       }
     }
   }
 
-  private _selectionModeChange(): void {
-    this.selectionService.clearItemsSelection();
+  protected override updated(changed: PropertyValues<this>): void {
+    super.updated(changed);
+    this._syncAria();
+  }
+
+  private _syncAria(): void {
+    this.setAttribute('role', 'tree');
+
+    // A tree that cannot be selected should not advertise itself as selectable.
+    setAriaState(
+      this,
+      'aria-multiselectable',
+      this.selection === 'none' ? null : 'true'
+    );
   }
 
   private _singleBranchExpandChange(): void {
-    if (this.singleBranchExpand) {
-      // if activeItem -> do not collapse its branch
-      if (this.navService.activeItem) {
-        const path = this.navService.activeItem.path;
-        const remainExpanded = new Set(path.splice(0, path.length - 1));
-        this.items.forEach((item) => {
-          if (!remainExpanded.has(item)) {
-            item.collapseWithEvent();
-          }
-        });
-      } else {
-        for (const item of this.items) {
-          item.collapseWithEvent();
-        }
+    if (!this.singleBranchExpand) {
+      return;
+    }
+
+    // The active item's branch stays open; everything else collapses.
+    const active = this.navService.activeItem;
+    const keepExpanded = new Set(active ? active.path.slice(0, -1) : []);
+
+    for (const item of this.items) {
+      if (!keepExpanded.has(item)) {
+        item.collapseWithEvent();
       }
     }
   }
@@ -189,12 +227,8 @@ export default class IgcTreeComponent extends EventEmitterMixin<
   /* blazorSuppress */
   /** @hidden @internal */
   public expandToItem(item: IgcTreeItemComponent): void {
-    if (item?.parent) {
-      item.path.forEach((i) => {
-        if (i !== item && !i.expanded) {
-          i.expanded = true;
-        }
-      });
+    for (const ancestor of item.path.slice(0, -1)) {
+      ancestor.expanded = true;
     }
   }
 
@@ -204,15 +238,16 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     /* alternateType: TreeItemCollection */
     items?: IgcTreeItemComponent[]
   ): void {
-    if (!items) {
-      this.selectionService.selectItemsWithNoEvent(
-        this.selection === 'cascade'
-          ? this.items.filter((item) => item.level === 0)
-          : this.items
-      );
-    } else {
+    if (items) {
       this.selectionService.selectItemsWithNoEvent(items);
+      return;
     }
+
+    // Cascading down from the roots already covers every descendant, so there
+    // is no need to walk the whole tree to build the list.
+    this.selectionService.selectItemsWithNoEvent(
+      this.selection === 'cascade' ? this._rootItems : this.items
+    );
   }
 
   /* blazorSuppress */
@@ -233,10 +268,9 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     /* alternateType: TreeItemCollection */
     items?: IgcTreeItemComponent[]
   ): void {
-    const _items = items || this.items;
-    _items.forEach((item) => {
+    for (const item of items ?? this.items) {
       item.expanded = true;
-    });
+    }
   }
 
   /* blazorSuppress */
@@ -248,10 +282,9 @@ export default class IgcTreeComponent extends EventEmitterMixin<
     /* alternateType: TreeItemCollection */
     items?: IgcTreeItemComponent[]
   ): void {
-    const _items = items || this.items;
-    _items.forEach((item) => {
+    for (const item of items ?? this.items) {
       item.expanded = false;
-    });
+    }
   }
 
   protected override render() {


### PR DESCRIPTION
## Description

Two bugs where items render from non-reactive tree state: the expand indicator stopped toggling after `toggleNodeOnClick` changed at runtime, and was not mirrored when the direction changed after first render.

Performance on large and deeply nested trees:
- `path` re-walked the ancestor chain twice per level, costing 2^depth (~23ms at depth 20, now sub-microsecond at any depth)
- keyboard navigation ~5x faster: the navigable set is a lazy walk that prunes collapsed branches instead of filtering every item by climbing its ancestors
- subtree removal ~2x faster: the topmost removed item already covers its whole subtree, so descendants no longer redo the cascade reconciliation
- `tree.items`, cascade `select()`, expand/collapse all: 25-45% faster

Adds `aria-selected`, `aria-disabled` and `aria-multiselectable`, and moves all ARIA state onto the delegated element when the label holds focusable content, where `aria-expanded` was previously stranded on a `role="none"` host. Adds the missing accessibility audits.

Rewrites the selection service to thread cascade state through explicit parameters rather than scratch fields on the service.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)


## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally

