### PR TITLE
refactor(tabs): fix selection state, add ARIA, rework scroll buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Added the `igcStateChange` event, emitted after each render pass with a snapshot of the current virtual window (`startIndex`, `endIndex`, `viewportSize`, `totalSize`).
     - Added the `layoutComplete` property - a promise that resolves once the current render pass, and any follow-up renders triggered by item measurement, have fully settled.
     - Transparently degrades past the maximum scroll coordinate supported by the browser, so lists far larger than the DOM would normally allow keep scrolling and rendering correctly.
+- #### Tabs
+  - `selectedTab` property, returning the selected `igc-tab` element or `null`.
+  - `select()` now matches a tab's `label` as well as its IDREF, so the value reported by `selected` can be passed back into it.
 
 ### Changed
 - #### Combo
@@ -47,6 +50,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - The value as it is being typed - including the result of spinning a date part or of `Ctrl + ;` - is available on the `detail` of the `igcInput` event, whose payload is unchanged.
     - Spinning a date part while the editor is focused now also defers to the commit on blur. A programmatic `stepUp()` / `stepDown()` on an unfocused component still updates `value` immediately, as do `clear()`, `setRangeText()`, and direct assignments.
     - For `igc-date-picker` and `igc-date-range-picker` the calendar keeps following the typed date while editing, as before.
+- #### Tabs
+  - **Behavioral change:** the scroll buttons now scroll to the nearest tab that is not fully in view, instead of stepping by a fixed 180px. A tab sitting underneath a scroll button counts as out of view, so one click brings exactly one tab into view without overshooting it.
+  - Improved accessibility: tab headers expose `aria-posinset` / `aria-setsize`, the strip declares its `aria-orientation`, and the selected panel is focusable so keyboard users can reach panel content that holds no focusable elements of its own. The strip also keeps a tab stop when nothing is selected.
+  - `igc-tab` elements projected through an intermediate slot are now picked up, so `igc-tabs` can be wrapped by another component.
 
 ### Fixed
 - #### Form associated components
@@ -60,6 +67,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - `tree.items`, `select()` over a whole `cascade` tree, and expanding or collapsing every item are each ~25-45% faster.
 - #### Tabs
   - See-through scroll buttons in the Indigo theme. The buttons are sticky and the tab headers scroll underneath them, but the theme leaves both the buttons and the tabs strip transparent, so the scrolled headers showed through. The buttons now paint an opaque surface backdrop below their themed background. [#1955](https://github.com/IgniteUI/igniteui-webcomponents/issues/1955)
+  - `igcChange` was never emitted when `activation` is `manual` and a tab was activated with Enter or Space, so the selection changed silently.
+  - The selection is now kept in sync with the DOM in cases that previously left the component inconsistent:
+    - Setting `selected` to `false` on the active tab hid its panel but kept the tab internally active, so it could never be selected again.
+    - Removing the last remaining tab left a dangling reference that `selected` kept reporting.
+    - `select()`, the `selected` attribute and the initial selection could all activate a disabled tab, which clicking has always refused, and a tab marked both `selected` and `disabled` showed its panel alongside the selected one.
+    - Disabling the active tab left its panel visible under a greyed out header. Selection now moves to the first enabled tab, or is cleared when every tab is disabled.
+  - The start scroll button stayed enabled at the start of the strip under browser zoom or a non-integer device pixel ratio, where the scroll offset is fractional.
+  - Clicking a partially visible tab header scrolled the strip twice.
+  - Reduced rendering work: scrolling the strip no longer schedules an update per scroll event, and changing the selection no longer triggers a redundant layout pass.
 
 ## [7.2.4] - 2026-06-29
 ### Added

--- a/src/components/tabs/tab-dom.ts
+++ b/src/components/tabs/tab-dom.ts
@@ -1,57 +1,61 @@
 import type { Ref } from 'lit/directives/ref.js';
-import { getScaleFactor, isLTR, setStyles } from '../common/util.js';
+import { asNumber, getScaleFactor, isLTR, setStyles } from '../common/util.js';
 import type IgcTabComponent from './tab.js';
 import type IgcTabsComponent from './tabs.js';
 
-const SCROLL_AMOUNT = 180;
+/** Tolerance for treating a tab edge as aligned with the visible region. */
+const EDGE_TOLERANCE = 1;
+
+type TabsStyleProperties = {
+  '--_tabs-count': string;
+  '--_ig-tabs-width': string;
+};
+
+type ScrollButtonsState = {
+  start: boolean;
+  end: boolean;
+};
 
 class TabsHelpers {
   private readonly _host: IgcTabsComponent;
   private readonly _container: Ref<HTMLElement>;
   private readonly _indicator: Ref<HTMLElement>;
 
-  private _styleProperties = {
+  private _styleProperties: TabsStyleProperties = {
     '--_tabs-count': '',
     '--_ig-tabs-width': '',
   };
 
   private _hasScrollButtons = false;
-  private _scrollButtonsDisabled = { start: true, end: false };
+  private _scrollButtonsDisabled: ScrollButtonsState = {
+    start: true,
+    end: false,
+  };
 
   private _isLeftToRight = false;
 
-  /**
-   * Returns the DOM container holding the tabs headers.
-   */
+  /** The DOM container holding the tab headers. */
   public get container(): HTMLElement | undefined {
     return this._container.value;
   }
 
-  /**
-   * Returns the selected indicator DOM element.
-   */
+  /** The selected tab indicator element. */
   public get indicator(): HTMLElement | undefined {
     return this._indicator.value;
   }
 
-  /**
-   * Returns the internal CSS variables used for the layout of the tabs component.
-   */
-  public get styleProperties() {
+  /** The internal CSS variables driving the layout of the tabs component. */
+  public get styleProperties(): TabsStyleProperties {
     return this._styleProperties;
   }
 
-  /**
-   * Whether the scroll buttons of the tabs header strip should be shown.
-   */
+  /** Whether the header strip overflows and needs its scroll buttons. */
   public get hasScrollButtons(): boolean {
     return this._hasScrollButtons;
   }
 
-  /**
-   * Returns the disabled state of the tabs header strip scroll buttons.
-   */
-  public get scrollButtonsDisabled() {
+  /** The disabled state of the header strip scroll buttons. */
+  public get scrollButtonsDisabled(): ScrollButtonsState {
     return this._scrollButtonsDisabled;
   }
 
@@ -67,14 +71,25 @@ class TabsHelpers {
 
   /**
    * Sets the internal CSS variables used for the layout of the tabs component.
-   * Triggers an update cycle (rerender) of the `igc-tabs` component.
+   * Triggers an update cycle (rerender) of the `igc-tabs` component if needed.
    */
   public setStyleProperties(): void {
+    const count = String(this._host.tabs.length);
+    const width = this.container
+      ? `${this.container.getBoundingClientRect().width}px`
+      : '';
+    const current = this._styleProperties;
+
+    if (
+      current['--_tabs-count'] === count &&
+      current['--_ig-tabs-width'] === width
+    ) {
+      return;
+    }
+
     this._styleProperties = {
-      '--_tabs-count': this._host.tabs.length.toString(),
-      '--_ig-tabs-width': this.container
-        ? `${this.container.getBoundingClientRect().width}px`
-        : '',
+      '--_tabs-count': count,
+      '--_ig-tabs-width': width,
     };
     this._host.requestUpdate();
   }
@@ -99,36 +114,85 @@ class TabsHelpers {
     }
   }
 
-  private _getStartOffset(container: HTMLElement): number {
-    const factor = isLTR(this._host) ? -1 : 1;
-    const delta = Math.abs(container.scrollLeft);
-    return (delta < SCROLL_AMOUNT ? delta : SCROLL_AMOUNT) * factor;
-  }
+  /**
+   * The horizontal bounds of the strip that are not covered by the sticky scroll
+   * buttons, which is the area a tab has to fit in to count as being in view.
+   */
+  private _getVisibleBounds(container: HTMLElement): {
+    min: number;
+    max: number;
+  } {
+    const { scrollPaddingInlineStart, scrollPaddingInlineEnd } =
+      getComputedStyle(container);
+    const { left, right } = container.getBoundingClientRect();
 
-  private _getEndOffset(container: HTMLElement): number {
-    const factor = isLTR(this._host) ? 1 : -1;
-    const delta =
-      container.scrollWidth -
-      container.clientWidth -
-      Math.abs(container.scrollLeft);
-    return (delta < SCROLL_AMOUNT ? delta : SCROLL_AMOUNT) * factor;
+    const start = asNumber(scrollPaddingInlineStart);
+    const end = asNumber(scrollPaddingInlineEnd);
+
+    return isLTR(this._host)
+      ? { min: left + start, max: right - end }
+      : { min: left + end, max: right - start };
   }
 
   /**
-   * Scrolls the tabs header strip in the given direction with `scroll-snap-align` set.
+   * The distance needed to bring the closest tab that is not fully in view for the
+   * given direction inside the visible bounds, or `0` when every tab is in view.
+   */
+  private _getScrollOffset(
+    container: HTMLElement,
+    direction: 'start' | 'end'
+  ): number {
+    const isEnd = direction === 'end';
+    const { min, max } = this._getVisibleBounds(container);
+
+    // Which edge a tab overflows depends on the scroll direction and the text
+    // direction alike - scrolling towards the end moves leftwards in RTL.
+    const useRightEdge = isEnd === isLTR(this._host);
+
+    const isOutOfView = (header: HTMLElement): boolean => {
+      const { left, right } = header.getBoundingClientRect();
+      return useRightEdge
+        ? right > max + EDGE_TOLERANCE
+        : left < min - EDGE_TOLERANCE;
+    };
+
+    const headers = this._host.tabs
+      .map((tab) => getTabHeader(tab))
+      .filter((header): header is HTMLElement => header !== null);
+
+    // Tabs are in document order, so the first match going forward and the last one
+    // going backwards are the ones closest to the visible region.
+    const target = isEnd
+      ? headers.find(isOutOfView)
+      : headers.findLast(isOutOfView);
+
+    if (!target) {
+      return 0;
+    }
+
+    const { left, right } = target.getBoundingClientRect();
+    return useRightEdge ? right - max : left - min;
+  }
+
+  /**
+   * Scrolls the tabs header strip to the closest tab that is out of view in the given
+   * direction, with `scroll-snap-align` set.
    */
   public scrollTabs(direction: 'start' | 'end'): void {
-    if (!this.container) {
+    const container = this.container;
+
+    if (!container) {
       return;
     }
 
-    const amount =
-      direction === 'start'
-        ? this._getStartOffset(this.container)
-        : this._getEndOffset(this.container);
+    const offset = this._getScrollOffset(container, direction);
+
+    if (!offset) {
+      return;
+    }
 
     this.setScrollSnap(direction);
-    this.container.scrollBy({ left: amount, behavior: 'smooth' });
+    container.scrollBy({ left: offset, behavior: 'smooth' });
   }
 
   /**
@@ -141,12 +205,22 @@ class TabsHelpers {
     }
 
     const { scrollLeft, scrollWidth, clientWidth } = this.container;
+    const disabled = this._scrollButtonsDisabled;
 
-    this._hasScrollButtons = scrollWidth > clientWidth;
-    this._scrollButtonsDisabled = {
-      start: scrollLeft === 0,
-      end: Math.abs(Math.abs(scrollLeft) + clientWidth - scrollWidth) <= 1,
-    };
+    const hasScrollButtons = scrollWidth > clientWidth;
+    const start = Math.abs(scrollLeft) <= 1;
+    const end = Math.abs(Math.abs(scrollLeft) + clientWidth - scrollWidth) <= 1;
+
+    if (
+      this._hasScrollButtons === hasScrollButtons &&
+      disabled.start === start &&
+      disabled.end === end
+    ) {
+      return;
+    }
+
+    this._hasScrollButtons = hasScrollButtons;
+    this._scrollButtonsDisabled = { start, end };
 
     this._host.requestUpdate();
   }
@@ -155,20 +229,23 @@ class TabsHelpers {
    * Updates the indicator DOM element styles based on the current "active" tab.
    */
   public async setIndicator(active?: IgcTabComponent): Promise<void> {
-    if (!(this.container && this.indicator)) {
+    await this._host.updateComplete;
+
+    const { container, indicator } = this;
+
+    if (!(container && indicator)) {
       return;
     }
 
+    const header = active ? getTabHeader(active) : null;
+
     const styles = {
-      visibility: active ? 'visible' : 'hidden',
+      visibility: header ? 'visible' : 'hidden',
     } satisfies Partial<CSSStyleDeclaration>;
 
-    await this._host.updateComplete;
-
-    if (active) {
-      const header = getTabHeader(active);
+    if (header) {
       const { offsetLeft: containerLeft, offsetWidth: containerWidth } =
-        this.container;
+        container;
       const scaledWidth =
         header.getBoundingClientRect().width * getScaleFactor(header).x;
 
@@ -182,7 +259,7 @@ class TabsHelpers {
       });
     }
 
-    setStyles(this.indicator, styles);
+    setStyles(indicator, styles);
   }
 }
 
@@ -190,10 +267,11 @@ export function createTabHelpers(
   host: IgcTabsComponent,
   container: Ref<HTMLElement>,
   indicator: Ref<HTMLElement>
-) {
+): TabsHelpers {
   return new TabsHelpers(host, container, indicator);
 }
 
-export function getTabHeader(tab: IgcTabComponent): HTMLElement {
-  return tab.renderRoot.querySelector('[part~="tab-header"]')!;
+/** Returns the header element of the given tab, or `null` if it has not rendered yet. */
+export function getTabHeader(tab: IgcTabComponent): HTMLElement | null {
+  return tab.renderRoot.querySelector('[part~="tab-header"]');
 }

--- a/src/components/tabs/tab.spec.ts
+++ b/src/components/tabs/tab.spec.ts
@@ -1,0 +1,185 @@
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { defineComponents } from '../common/definitions/defineComponents.js';
+import IgcTabComponent from './tab.js';
+import IgcTabsComponent from './tabs.js';
+
+describe('Tab component', () => {
+  before(() => {
+    defineComponents(IgcTabComponent, IgcTabsComponent);
+  });
+
+  let element: IgcTabsComponent;
+
+  beforeEach(async () => {
+    element = await fixture<IgcTabsComponent>(html`
+      <igc-tabs>
+        <igc-tab label="Tab 1">Content 1</igc-tab>
+        <igc-tab label="Tab 2">Content 2</igc-tab>
+        <igc-tab label="Tab 3" disabled>Content 3</igc-tab>
+      </igc-tabs>
+    `);
+  });
+
+  // See the note on the `igc-tabs` accessibility test for the suppressed rule.
+  it('is accessible', async () => {
+    await expect(element).to.be.accessible({
+      ignoredRules: ['aria-required-children'],
+    });
+  });
+
+  it('is initialized with the proper default values', async () => {
+    const tab = await fixture<IgcTabComponent>(html`<igc-tab></igc-tab>`);
+
+    expect(tab.label).to.be.empty;
+    expect(tab.selected).to.be.false;
+    expect(tab.disabled).to.be.false;
+  });
+
+  it('generates an id when none is provided and keeps an author set one', async () => {
+    const [first, second] = element.tabs;
+
+    expect(first.id).to.match(/^igc-tab-\d+$/);
+    expect(second.id).to.match(/^igc-tab-\d+$/);
+    expect(first.id).to.not.equal(second.id);
+
+    const tab = await fixture<IgcTabComponent>(
+      html`<igc-tab id="custom"></igc-tab>`
+    );
+    expect(tab.id).to.equal('custom');
+  });
+
+  it('wires the header and the panel through ARIA', () => {
+    for (const tab of element.tabs) {
+      const { header, body } = getTabDOM(tab);
+
+      expect(header.role).to.equal('tab');
+      expect(body.role).to.equal('tabpanel');
+      expect(header.getAttribute('aria-controls')).to.equal(body.id);
+      expect(body.getAttribute('aria-labelledby')).to.equal(header.id);
+    }
+  });
+
+  it('keeps the ARIA wiring when the public id changes', async () => {
+    const [tab] = element.tabs;
+    const { header, body } = getTabDOM(tab);
+    const controls = header.getAttribute('aria-controls');
+
+    tab.id = 'renamed';
+    await elementUpdated(tab);
+
+    expect(header.getAttribute('aria-controls')).to.equal(controls);
+    expect(body.id).to.equal(controls);
+  });
+
+  it('exposes the position of each tab in the set', () => {
+    const size = element.tabs.length;
+
+    element.tabs.forEach((tab, index) => {
+      const { header } = getTabDOM(tab);
+
+      expect(header.getAttribute('aria-posinset')).to.equal(`${index + 1}`);
+      expect(header.getAttribute('aria-setsize')).to.equal(`${size}`);
+    });
+  });
+
+  it('updates the set information when tabs are added and removed', async () => {
+    const tab = document.createElement(IgcTabComponent.tagName);
+    tab.label = 'Tab 4';
+    element.append(tab);
+
+    await elementUpdated(tab);
+    await elementUpdated(element);
+
+    expect(getTabDOM(tab).header.getAttribute('aria-posinset')).to.equal('4');
+
+    for (const each of element.tabs) {
+      expect(getTabDOM(each).header.getAttribute('aria-setsize')).to.equal('4');
+    }
+
+    element.tabs[0].remove();
+    await elementUpdated(element);
+
+    element.tabs.forEach((each, index) => {
+      const { header } = getTabDOM(each);
+
+      expect(header.getAttribute('aria-posinset')).to.equal(`${index + 1}`);
+      expect(header.getAttribute('aria-setsize')).to.equal('3');
+    });
+  });
+
+  it('does not expose set information for a standalone tab', async () => {
+    const tab = await fixture<IgcTabComponent>(
+      html`<igc-tab label="Standalone"></igc-tab>`
+    );
+    const { header } = getTabDOM(tab);
+
+    expect(header.hasAttribute('aria-posinset')).to.be.false;
+    expect(header.hasAttribute('aria-setsize')).to.be.false;
+  });
+
+  it('gives the selected tab the roving tab stop', async () => {
+    expect(getTabDOM(element.tabs[0]).header.tabIndex).to.equal(0);
+    expect(getTabDOM(element.tabs[1]).header.tabIndex).to.equal(-1);
+
+    element.select(element.tabs[1]);
+    await elementUpdated(element);
+
+    expect(getTabDOM(element.tabs[0]).header.tabIndex).to.equal(-1);
+    expect(getTabDOM(element.tabs[1]).header.tabIndex).to.equal(0);
+  });
+
+  it('keeps a tab stop when there is no selection', async () => {
+    element.tabs[0].selected = false;
+    await elementUpdated(element);
+
+    expect(element.selectedTab).to.be.null;
+    expect(getTabDOM(element.tabs[0]).header.tabIndex).to.equal(0);
+  });
+
+  it('makes only the selected panel focusable and inerts the rest', async () => {
+    const [first, second] = element.tabs;
+
+    expect(getTabDOM(first).body.tabIndex).to.equal(0);
+    expect(getTabDOM(first).body.inert).to.be.false;
+    expect(getTabDOM(second).body.tabIndex).to.equal(-1);
+    expect(getTabDOM(second).body.inert).to.be.true;
+
+    element.select(second);
+    await elementUpdated(element);
+
+    expect(getTabDOM(first).body.inert).to.be.true;
+    expect(getTabDOM(second).body.tabIndex).to.equal(0);
+    expect(getTabDOM(second).body.inert).to.be.false;
+  });
+
+  it('reflects the selected and disabled state to the header', async () => {
+    const [first, , third] = element.tabs;
+
+    expect(getTabDOM(first).header.getAttribute('aria-selected')).to.equal(
+      'true'
+    );
+    expect(getTabDOM(third).header.getAttribute('aria-disabled')).to.equal(
+      'true'
+    );
+
+    third.disabled = false;
+    await elementUpdated(third);
+
+    expect(getTabDOM(third).header.getAttribute('aria-disabled')).to.equal(
+      'false'
+    );
+  });
+});
+
+function getTabDOM(tab: IgcTabComponent) {
+  const root = tab.renderRoot;
+  return {
+    get header() {
+      return root.querySelector<HTMLElement>('[part~="tab-header"]')!;
+    },
+
+    get body() {
+      return root.querySelector<HTMLElement>('[part~="tab-body"]')!;
+    },
+  };
+}

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -1,5 +1,5 @@
-import { html, LitElement, type TemplateResult } from 'lit';
-import { property } from 'lit/decorators.js';
+import { html, LitElement, nothing, type TemplateResult } from 'lit';
+import { property, state } from 'lit/decorators.js';
 
 import { addThemingController } from '../../theming/theming-controller.js';
 import { registerComponent } from '../common/definitions/register.js';
@@ -34,6 +34,25 @@ export default class IgcTabComponent extends LitElement {
     registerComponent(IgcTabComponent);
   }
 
+  //#region Internal state & properties
+
+  private readonly _instanceId = nextId++;
+  private readonly _headerId = `igc-tab-header-${this._instanceId}`;
+  private readonly _contentId = `igc-tab-content-${this._instanceId}`;
+
+  @state()
+  private _posInSet = 0;
+
+  @state()
+  private _setSize = 0;
+
+  @state()
+  private _isTabStop = false;
+
+  //#endregion
+
+  //#region Public properties
+
   /**
    * The tab item label.
    * @attr label
@@ -59,6 +78,10 @@ export default class IgcTabComponent extends LitElement {
   @property({ type: Boolean, reflect: true })
   public disabled = false;
 
+  //#endregion
+
+  //#region Life-cycle hooks
+
   constructor() {
     super();
     addThemingController(this, all);
@@ -67,22 +90,46 @@ export default class IgcTabComponent extends LitElement {
   /** @internal */
   public override connectedCallback(): void {
     super.connectedCallback();
-    this.id = this.id || `igc-tab-${nextId++}`;
+    this.id = this.id || `igc-tab-${this._instanceId}`;
   }
 
-  protected override render(): TemplateResult {
-    const headerId = `${this.id}-header`;
-    const contentId = `${this.id}-content`;
+  //#endregion
 
+  //#region Internal API
+
+  /**
+   * @hidden @internal
+   * Applied by the parent `igc-tabs` whenever the tab set or the selection changes.
+   *
+   * `isTabStop` drives the roving tabindex, keeping the tab strip reachable even
+   * when no tab is selected.
+   */
+  public _setTabState(
+    posInSet: number,
+    setSize: number,
+    isTabStop: boolean
+  ): void {
+    this._posInSet = posInSet;
+    this._setSize = setSize;
+    this._isTabStop = isTabStop;
+  }
+
+  //#endregion
+
+  //#region Render
+
+  protected override render(): TemplateResult {
     return html`
       <div
         part="tab-header"
         role="tab"
-        id=${headerId}
+        id=${this._headerId}
         aria-disabled=${this.disabled}
         aria-selected=${this.selected}
-        aria-controls=${contentId}
-        tabindex=${this.selected ? 0 : -1}
+        aria-controls=${this._contentId}
+        aria-posinset=${this._posInSet || nothing}
+        aria-setsize=${this._setSize || nothing}
+        tabindex=${this.selected || this._isTabStop ? 0 : -1}
       >
         <div part="base">
           <slot name="prefix" part="prefix"></slot>
@@ -95,14 +142,17 @@ export default class IgcTabComponent extends LitElement {
       <div
         part="tab-body"
         role="tabpanel"
-        id=${contentId}
-        aria-labelledby=${headerId}
+        id=${this._contentId}
+        aria-labelledby=${this._headerId}
+        tabindex=${this.selected ? 0 : -1}
         .inert=${!this.selected}
       >
         <slot></slot>
       </div>
     `;
   }
+
+  //#endregion
 }
 
 declare global {

--- a/src/components/tabs/tabs.spec.ts
+++ b/src/components/tabs/tabs.spec.ts
@@ -67,6 +67,9 @@ describe('Tabs component', () => {
       `);
     });
 
+    // `aria-required-children` is suppressed as a false positive: axe walks the DOM and
+    // sees each tab's panel nested in the tablist, while browsers expose the flat tree
+    // where the roles resolve correctly. Screen readers announce the tabs as expected.
     it('is accessible', async () => {
       await expect(element).to.be.accessible({
         ignoredRules: ['aria-required-children'],
@@ -468,6 +471,233 @@ describe('Tabs component', () => {
     });
   });
 
+  describe('Selection state', () => {
+    function verifyNoSelection(tabs: IgcTabsComponent) {
+      expect(getTabsDOM(tabs).selected).to.be.empty;
+      expect(tabs.selectedTab).to.be.null;
+      expect(tabs.selected).to.be.empty;
+    }
+
+    beforeEach(async () => {
+      element = await fixture<IgcTabsComponent>(html`
+        <igc-tabs>
+          <igc-tab label="Tab 1">Content 1</igc-tab>
+          <igc-tab label="Tab 2">Content 2</igc-tab>
+          <igc-tab label="Tab 3" disabled>Content 3</igc-tab>
+        </igc-tabs>
+      `);
+    });
+
+    it('emits `igcChange` when activating a tab with `manual` activation', async () => {
+      element.activation = 'manual';
+      await elementUpdated(element);
+
+      simulateClick(getTabDOM(element.tabs[0]).header);
+      await elementUpdated(element);
+
+      const eventSpy = spy(element, 'emitEvent');
+
+      simulateKeyboard(getTabDOM(element.tabs[0]).header, arrowRight);
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[0]);
+      expect(eventSpy.callCount).to.equal(0);
+
+      simulateKeyboard(getTabDOM(element.tabs[1]).header, enterKey);
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[1]);
+      expect(eventSpy).calledOnceWithExactly('igcChange', {
+        detail: element.tabs[1],
+      });
+    });
+
+    it('clears the selection when the active tab is deselected', async () => {
+      const active = element.tabs[0];
+
+      active.selected = false;
+      await elementUpdated(element);
+
+      verifyNoSelection(element);
+
+      simulateClick(getTabDOM(active).header);
+      await elementUpdated(element);
+
+      verifySelection(element, active);
+    });
+
+    it('clears the selection when the last remaining tab is removed', async () => {
+      for (const tab of element.tabs.slice(1)) {
+        tab.remove();
+      }
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[0]);
+
+      element.tabs[0].remove();
+      await elementUpdated(element);
+
+      verifyNoSelection(element);
+    });
+
+    it('recovers the selection when a tab is added while nothing is selected', async () => {
+      for (const tab of element.tabs) {
+        tab.remove();
+      }
+      await elementUpdated(element);
+
+      verifyNoSelection(element);
+
+      const tab = document.createElement(IgcTabComponent.tagName);
+      tab.label = 'New tab';
+      element.append(tab);
+
+      await elementUpdated(tab);
+      await elementUpdated(element);
+
+      verifySelection(element, tab);
+    });
+
+    it('ignores disabled tabs in the `select` method', async () => {
+      const disabled = element.tabs[2];
+
+      element.select(disabled);
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[0]);
+
+      element.select(disabled.id);
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[0]);
+    });
+
+    it('reverts a `selected` state applied to a disabled tab', async () => {
+      const disabled = element.tabs[2];
+
+      disabled.selected = true;
+      await elementUpdated(element);
+
+      expect(disabled.selected).to.be.false;
+      verifySelection(element, element.tabs[0]);
+    });
+
+    it('does not select a disabled tab marked as selected in the template', async () => {
+      const tabs = await fixture<IgcTabsComponent>(html`
+        <igc-tabs>
+          <igc-tab label="Tab 1">Content 1</igc-tab>
+          <igc-tab label="Tab 2" disabled selected>Content 2</igc-tab>
+        </igc-tabs>
+      `);
+
+      verifySelection(tabs, tabs.tabs[0]);
+      expect(tabs.tabs[1].selected).to.be.false;
+    });
+
+    it('ignores tabs which are not children of the component', async () => {
+      const foreign = await fixture<IgcTabComponent>(
+        html`<igc-tab label="Foreign"></igc-tab>`
+      );
+
+      element.select(foreign);
+      await elementUpdated(element);
+
+      expect(foreign.selected).to.be.false;
+      verifySelection(element, element.tabs[0]);
+    });
+
+    it('`select` accepts a label and round-trips with the `selected` getter', async () => {
+      element.select('Tab 2');
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[1]);
+      expect(element.selected).to.equal('Tab 2');
+
+      const token = element.selected;
+
+      element.select(element.tabs[0]);
+      await elementUpdated(element);
+
+      element.select(token);
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[1]);
+    });
+
+    it('`select` does not emit `igcChange`', async () => {
+      const eventSpy = spy(element, 'emitEvent');
+
+      element.select(element.tabs[1]);
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[1]);
+      expect(eventSpy.callCount).to.equal(0);
+    });
+
+    it('hands over the selection when the active tab is disabled', async () => {
+      const [firstTab, secondTab] = element.tabs;
+
+      firstTab.disabled = true;
+      await elementUpdated(element);
+      await elementUpdated(secondTab);
+
+      verifySelection(element, secondTab);
+      expect(firstTab.selected).to.be.false;
+    });
+
+    it('keeps the selection when another tab is disabled', async () => {
+      element.tabs[1].disabled = true;
+      await elementUpdated(element);
+
+      verifySelection(element, element.tabs[0]);
+    });
+
+    it('clears the selection when every tab is disabled', async () => {
+      for (const tab of element.tabs) {
+        tab.disabled = true;
+      }
+      await elementUpdated(element);
+
+      verifyNoSelection(element);
+    });
+
+    it('restores a tab stop when a disabled tab is enabled again', async () => {
+      for (const tab of element.tabs) {
+        tab.disabled = true;
+      }
+      await elementUpdated(element);
+
+      verifyNoSelection(element);
+
+      element.tabs[1].disabled = false;
+      await elementUpdated(element);
+      await elementUpdated(element.tabs[1]);
+
+      expect(getTabDOM(element.tabs[1]).header.tabIndex).to.equal(0);
+    });
+
+    it('selects a tab that has not rendered yet', async () => {
+      const tab = document.createElement(IgcTabComponent.tagName);
+      tab.label = 'Pending';
+      tab.selected = true;
+      element.append(tab);
+
+      await elementUpdated(tab);
+      await elementUpdated(element);
+
+      verifySelection(element, tab);
+    });
+
+    it('exposes the selected tab through `selectedTab`', async () => {
+      expect(element.selectedTab).to.equal(element.tabs[0]);
+
+      element.select(element.tabs[1]);
+      await elementUpdated(element);
+
+      expect(element.selectedTab).to.equal(element.tabs[1]);
+    });
+  });
+
   describe('Scrolling', () => {
     beforeEach(async () => {
       element = await fixture<IgcTabsComponent>(html`
@@ -569,6 +799,109 @@ describe('Tabs component', () => {
       );
     });
 
+    function isInView(container: HTMLElement, header: HTMLElement) {
+      const padding = Number.parseFloat(
+        getComputedStyle(container).scrollPaddingInlineStart
+      );
+      const bounds = container.getBoundingClientRect();
+      const rect = header.getBoundingClientRect();
+
+      return (
+        rect.left >= bounds.left + padding - 1 &&
+        rect.right <= bounds.right - padding + 1
+      );
+    }
+
+    function tabHeaders() {
+      return element.tabs.map((tab) => getTabDOM(tab).header);
+    }
+
+    it('scrolls the next out of view tab into view', async () => {
+      element.style.width = '400px';
+      await elementUpdated(element);
+
+      const { container } = getTabsDOM(element);
+      const target = tabHeaders().find(
+        (header) => !isInView(container, header)
+      )!;
+
+      expect(target, 'No tab is out of view to begin with').to.not.be.undefined;
+
+      endScrollButton().click();
+
+      await waitUntil(
+        () => isInView(container, target),
+        'The next out of view tab was not scrolled into view'
+      );
+    });
+
+    it('scrolls the previous out of view tab into view', async () => {
+      element.style.width = '400px';
+      await elementUpdated(element);
+
+      element.select('18');
+      await elementUpdated(element);
+      await waitUntil(
+        () => endScrollButton().disabled,
+        'Did not reach the end of the strip'
+      );
+
+      const { container } = getTabsDOM(element);
+      // The closest tab hidden past the start edge of the strip.
+      const target = tabHeaders().findLast(
+        (header) =>
+          header.getBoundingClientRect().left <
+          container.getBoundingClientRect().left
+      )!;
+
+      expect(target, 'No tab is hidden past the start edge').to.not.be
+        .undefined;
+
+      startScrollButton().click();
+
+      await waitUntil(
+        () => isInView(container, target),
+        'The previous out of view tab was not scrolled into view'
+      );
+    });
+
+    it('does not overshoot past the tab brought into view', async () => {
+      element.style.width = '400px';
+      await elementUpdated(element);
+
+      const { container } = getTabsDOM(element);
+      const headers = tabHeaders();
+      const target = headers.find((header) => !isInView(container, header))!;
+      const next = headers[headers.indexOf(target) + 1];
+
+      endScrollButton().click();
+
+      await waitUntil(
+        () => isInView(container, target),
+        'The next out of view tab was not scrolled into view'
+      );
+
+      expect(
+        isInView(container, next),
+        'Scrolled further than the first out of view tab'
+      ).to.be.false;
+    });
+
+    it('does not re-render when the scroll state is unchanged', async () => {
+      const { container } = getTabsDOM(element);
+
+      container.dispatchEvent(new Event('scroll'));
+      await elementUpdated(element);
+
+      const updateSpy = spy(element, 'requestUpdate');
+
+      container.dispatchEvent(new Event('scroll'));
+      container.dispatchEvent(new Event('scroll'));
+      await elementUpdated(element);
+
+      expect(updateSpy.callCount).to.equal(0);
+    });
+
     it('displays scroll buttons (RTL)', async () => {
       element.setAttribute('dir', 'rtl');
       await elementUpdated(element);
@@ -628,6 +961,41 @@ describe('Tabs component', () => {
         () => !startScrollButton().disabled,
         'Start scroll button is disabled on opposite scroll'
       );
+    });
+  });
+
+  describe('Composition', () => {
+    before(() => {
+      if (customElements.get('tabs-wrapper')) {
+        return;
+      }
+
+      customElements.define(
+        'tabs-wrapper',
+        class extends HTMLElement {
+          connectedCallback() {
+            if (!this.shadowRoot) {
+              this.attachShadow({ mode: 'open' }).innerHTML =
+                '<igc-tabs><slot></slot></igc-tabs>';
+            }
+          }
+        }
+      );
+    });
+
+    it('picks up tabs projected through an intermediate slot', async () => {
+      const wrapper = await fixture<HTMLElement>(html`
+        <tabs-wrapper>
+          <igc-tab label="Tab 1">Content 1</igc-tab>
+          <igc-tab label="Tab 2">Content 2</igc-tab>
+        </tabs-wrapper>
+      `);
+
+      const tabs = wrapper.shadowRoot!.querySelector(IgcTabsComponent.tagName)!;
+      await elementUpdated(tabs);
+
+      expect(tabs.tabs).lengthOf(2);
+      expect(tabs.selectedTab).to.equal(tabs.tabs[0]);
     });
   });
 

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -1,9 +1,14 @@
-import { html, LitElement, nothing, type PropertyValues } from 'lit';
+import {
+  html,
+  LitElement,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import {
   eventOptions,
   property,
   queryAssignedElements,
-  state,
 } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import { createRef, ref } from 'lit/directives/ref.js';
@@ -46,10 +51,13 @@ import { styles } from './themes/tabs.base.css.js';
 import { all } from './themes/tabs-themes.js';
 
 type TabSelectionOptions = {
+  /** The tab to select. Omitting it clears the current selection. */
   tab?: IgcTabComponent;
   shouldEmit?: boolean;
   shouldScroll?: boolean;
 };
+
+type TabMutations = MutationControllerParams<IgcTabComponent>['changes'];
 
 export interface IgcTabsComponentEventMap {
   igcChange: CustomEvent<IgcTabComponent>;
@@ -108,14 +116,13 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     this._indicatorRef
   );
 
-  @queryAssignedElements({ selector: IgcTabComponent.tagName })
+  @queryAssignedElements({ selector: IgcTabComponent.tagName, flatten: true })
   private _tabs!: IgcTabComponent[];
 
   protected get _enabledTabs(): IgcTabComponent[] {
     return this._tabs.filter((tab) => !tab.disabled);
   }
 
-  @state()
   private _activeTab?: IgcTabComponent;
 
   //#endregion
@@ -158,6 +165,12 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     return '';
   }
 
+  /* blazorSuppress */
+  /** Returns the currently selected tab, if any. */
+  public get selectedTab(): IgcTabComponent | null {
+    return this._activeTab ?? null;
+  }
+
   //#endregion
 
   //#region Life-cycle hooks
@@ -182,7 +195,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     createMutationController(this, {
       callback: this._mutationCallback,
       config: {
-        attributeFilter: ['selected'],
+        attributeFilter: ['selected', 'disabled'],
         childList: true,
         subtree: true,
       },
@@ -194,15 +207,11 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     await this.updateComplete;
 
     const selectedTab =
-      this._tabs.findLast((tab) => tab.selected) ?? first(this._enabledTabs);
+      this._tabs.findLast((tab) => tab.selected && !tab.disabled) ??
+      first(this._enabledTabs);
 
-    this._domHelpers.setStyleProperties();
-    this._domHelpers.setScrollButtonState();
-    this._setSelectedTab({
-      tab: selectedTab,
-      shouldEmit: false,
-      shouldScroll: false,
-    });
+    this._updateLayout();
+    this._syncSelection(selectedTab);
 
     this._resizeController.observe(this._headerRef.value!);
   }
@@ -211,6 +220,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
   public override connectedCallback(): void {
     super.connectedCallback();
     this.role = 'tablist';
+    this.ariaOrientation = 'horizontal';
   }
 
   protected override update(props: PropertyValues<this>): void {
@@ -227,76 +237,83 @@ export default class IgcTabsComponent extends EventEmitterMixin<
 
   //#region Observers callbacks
 
-  private _refreshLayout(): void {
+  private _updateLayout(): void {
     this._domHelpers.setStyleProperties();
     this._domHelpers.setScrollButtonState();
+  }
+
+  private _refreshLayout(): void {
+    this._updateLayout();
     this._domHelpers.setIndicator(this._activeTab);
   }
 
-  private _mutationCallback(
-    parameters: MutationControllerParams<IgcTabComponent>
-  ): void {
-    this._selectedAttributeChanged(parameters);
-    this._handleTabsRemoved(parameters);
-    this._handleTabsAdded(parameters);
-
-    this._refreshLayout();
-  }
-
-  private _selectedAttributeChanged({
+  private _mutationCallback({
     changes,
   }: MutationControllerParams<IgcTabComponent>): void {
-    const selected = changes.attributes.find(
-      ({ node: tab }) => this._tabs.includes(tab) && tab.selected
-    )?.node;
-    this._setSelectedTab({
-      tab: selected,
-      shouldEmit: false,
-      shouldScroll: false,
-    });
-  }
+    const structural = !isEmpty(changes.added) || !isEmpty(changes.removed);
 
-  private _handleTabsAdded({
-    changes,
-  }: MutationControllerParams<IgcTabComponent>): void {
-    if (!isEmpty(changes.added)) {
-      const lastAdded = changes.added.findLast(
-        (change) =>
-          change.target.closest(this.tagName) === this && change.node.selected
-      )?.node;
+    this._handleAttributeChanges(changes);
+    this._handleTabsRemoved(changes);
+    this._handleTabsAdded(changes);
 
-      this._setSelectedTab({
-        tab: lastAdded,
-        shouldEmit: false,
-        shouldScroll: false,
-      });
+    // Positions shift on any add/removal, including ones that leave the selection intact.
+    this._updateTabsState();
+
+    // Only a changed tab set moves the indicator on its own - selection changes
+    // reposition it through `_setSelectedTab`.
+    if (structural) {
+      this._refreshLayout();
+    } else {
+      this._updateLayout();
     }
   }
 
-  private _handleTabsRemoved({
-    changes,
-  }: MutationControllerParams<IgcTabComponent>): void {
-    if (!isEmpty(changes.removed)) {
-      let nextSelectedTab: IgcTabComponent | null = null;
+  private _handleAttributeChanges(changes: TabMutations): void {
+    const own = changes.attributes.filter(({ node }) =>
+      this._tabs.includes(node)
+    );
 
-      const removed = changes.removed.filter(
-        (change) => change.target.closest(this.tagName) === this
+    if (isEmpty(own)) {
+      return;
+    }
+
+    const selected = own.findLast(
+      ({ node, attributeName }) => attributeName === 'selected' && node.selected
+    )?.node;
+
+    if (selected) {
+      // A tab turning selected takes over.
+      this._syncSelection(selected);
+    } else if (own.some(({ node }) => node === this._activeTab)) {
+      // The active tab was either deselected from the outside, which leaves the
+      // component without a selection, or disabled and has to hand over.
+      this._syncSelection(
+        this._activeTab?.disabled ? first(this._enabledTabs) : undefined
       );
+    }
+  }
 
-      for (const each of removed) {
-        if (each.node.selected && each.node === this._activeTab) {
-          nextSelectedTab = first(this._enabledTabs);
-          break;
-        }
-      }
+  private _handleTabsAdded(changes: TabMutations): void {
+    const added = changes.added.filter(({ node }) => this._tabs.includes(node));
 
-      if (nextSelectedTab) {
-        this._setSelectedTab({
-          tab: nextSelectedTab,
-          shouldEmit: false,
-          shouldScroll: false,
-        });
-      }
+    if (isEmpty(added)) {
+      return;
+    }
+
+    // An added selected tab takes over, otherwise keep the current selection or
+    // recover from an empty one.
+    const selected = added.findLast(
+      ({ node }) => node.selected && this._isSelectable(node)
+    )?.node;
+
+    this._syncSelection(
+      selected ?? this._activeTab ?? first(this._enabledTabs)
+    );
+  }
+
+  private _handleTabsRemoved(changes: TabMutations): void {
+    if (changes.removed.some(({ node }) => node === this._activeTab)) {
+      this._syncSelection(first(this._enabledTabs));
     }
   }
 
@@ -310,38 +327,70 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     return tab ? this._enabledTabs.indexOf(tab) : -1;
   }
 
-  private _setSelectedTab(options: TabSelectionOptions): void {
-    const { tab, shouldEmit = true, shouldScroll = true } = options;
+  /** A tab can be selected if it is a direct child of this component and is not disabled. */
+  private _isSelectable(tab?: IgcTabComponent): tab is IgcTabComponent {
+    return tab != null && !tab.disabled && this._tabs.includes(tab);
+  }
 
-    if (!tab || tab === this._activeTab) {
-      return;
-    }
+  /** Pushes the ARIA set information and the roving tab stop down to the tab children. */
+  private _updateTabsState(): void {
+    const tabs = this._tabs;
+    const tabStop = this._activeTab ?? first(this._enabledTabs);
 
-    if (this._activeTab) {
-      this._activeTab.selected = false;
-    }
-
-    tab.selected = true;
-    this._activeTab = tab;
-
-    if (shouldScroll) {
-      scrollIntoView(getTabHeader(tab));
-    }
-    this._domHelpers.setIndicator(this._activeTab);
-
-    if (shouldEmit) {
-      this.emitEvent('igcChange', { detail: this._activeTab });
+    for (const [index, tab] of tabs.entries()) {
+      tab._setTabState(index + 1, tabs.length, tab === tabStop);
     }
   }
 
-  private _keyboardActivateTab(tab: IgcTabComponent) {
+  /** Applies a selection driven by the DOM rather than by user interaction. */
+  private _syncSelection(tab?: IgcTabComponent): void {
+    this._setSelectedTab({ tab, shouldEmit: false, shouldScroll: false });
+  }
+
+  private _setSelectedTab(options: TabSelectionOptions): void {
+    const { tab, shouldEmit = true, shouldScroll = true } = options;
+
+    // An explicit `undefined` clears the selection, while a tab that cannot be
+    // selected leaves the current one in place.
+    const next =
+      tab === undefined || this._isSelectable(tab) ? tab : this._activeTab;
+    const changed = next !== this._activeTab;
+
+    // Runs on every pass so that tabs holding a stale `selected` state are reconciled.
+    for (const each of this._tabs) {
+      each.selected = each === next;
+    }
+
+    this._activeTab = next;
+    this._updateTabsState();
+
+    if (!changed) {
+      return;
+    }
+
+    if (next && shouldScroll) {
+      scrollIntoView(getTabHeader(next));
+    }
+
+    this._domHelpers.setIndicator(next);
+
+    if (next && shouldEmit) {
+      this.emitEvent('igcChange', { detail: next });
+    }
+  }
+
+  private _keyboardActivateTab(tab?: IgcTabComponent, activate = false): void {
+    if (!tab) {
+      return;
+    }
+
     const header = getTabHeader(tab);
 
     this._domHelpers.setScrollSnap();
     scrollIntoView(header);
-    header.focus({ preventScroll: true });
+    header?.focus({ preventScroll: true });
 
-    if (this.activation === 'auto') {
+    if (activate || this.activation === 'auto') {
       this._setSelectedTab({ tab });
     }
   }
@@ -353,8 +402,8 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     );
   }
 
-  private _isEventFromTabHeader(event: Event) {
-    return getElementFromPath('[part~="tab-header"]', event);
+  private _isEventFromTabHeader(event: Event): boolean {
+    return Boolean(getElementFromPath('[part~="tab-header"]', event));
   }
 
   //#endregion
@@ -377,12 +426,10 @@ export default class IgcTabsComponent extends EventEmitterMixin<
   }
 
   protected _handleActivationKeys(): void {
-    const tabs = this._enabledTabs;
     const index = this._getClosestActiveTabIndex();
 
     if (index > -1) {
-      this._setSelectedTab({ tab: tabs[index], shouldEmit: false });
-      this._keyboardActivateTab(tabs[index]);
+      this._keyboardActivateTab(this._enabledTabs[index], true);
     }
   }
 
@@ -393,12 +440,12 @@ export default class IgcTabsComponent extends EventEmitterMixin<
 
     const tab = getElementFromPath(IgcTabComponent.tagName, event);
 
-    if (!(tab && this._tabs.includes(tab)) || tab?.disabled) {
+    if (!this._isSelectable(tab)) {
       return;
     }
 
     this._domHelpers.setScrollSnap();
-    getTabHeader(tab).focus();
+    getTabHeader(tab)?.focus({ preventScroll: true });
     this._setSelectedTab({ tab });
   }
 
@@ -411,15 +458,21 @@ export default class IgcTabsComponent extends EventEmitterMixin<
 
   //#region Public API methods
 
-  /** Selects the specified tab and displays the corresponding panel.  */
-  public select(id: string): void;
+  /**
+   * Selects the tab matching the passed IDREF or label and displays the corresponding panel.
+   *
+   * Disabled tabs and values not matching any tab are ignored.
+   */
+  public select(idOrLabel: string): void;
   /* blazorSuppress (ref is reserved) */
   public select(ref: IgcTabComponent): void;
   /* blazorSuppress (ref is reserved) */
   public select(ref: IgcTabComponent | string): void {
-    const tab = isString(ref) ? this._tabs.find((t) => t.id === ref) : ref;
+    const tab = isString(ref)
+      ? this._tabs.find((each) => each.id === ref || each.label === ref)
+      : ref;
 
-    if (tab) {
+    if (this._isSelectable(tab)) {
       this._setSelectedTab({ tab, shouldEmit: false });
     }
   }
@@ -428,7 +481,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
 
   //#region Render
 
-  protected _renderScrollButton(direction: 'start' | 'end') {
+  protected _renderScrollButton(direction: 'start' | 'end'): TemplateResult {
     const isStart = direction === 'start';
     const { start, end } = this._domHelpers.scrollButtonsDisabled;
 
@@ -451,7 +504,7 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     )}`;
   }
 
-  protected override render() {
+  protected override render(): TemplateResult {
     return html`
       <div
         ${ref(this._headerRef)}


### PR DESCRIPTION
## Description

Selection was tracked by a single `_activeTab` field that could only ever be reassigned, never cleared, and was never reconciled against the `selected` attributes it shadowed. Deselecting the active tab left its panel hidden while the tab stayed internally active, so it could never be selected again, and removing the last tab left the field pointing at a detached element that `selected` kept reporting. Selection is now applied by reconciling every tab against the resolved one, which makes an explicit clear possible and normalizes stale `selected` state on the way through.

Disabled tabs were only honored on the click path, so `select()`, the `selected` attribute and the initial pick could each activate one, and disabling the active tab left its panel visible under a greyed-out header. A single selectability rule now covers every path, and a disabled active tab hands over to the first enabled one or clears when there is none. The mutation observer watches `disabled` for that.

Enter and Space with `activation="manual"` changed the selection without emitting `igcChange`: the handler selected with `shouldEmit: false` and then delegated to the keyboard path, which only re-selects in `auto` mode, where the tab was already selected. Both now go through one emitting call.

Adds `aria-posinset` / `aria-setsize`, `aria-orientation` and a focusable selected panel. The roving tabindex no longer keys off the selection alone, so the strip keeps a tab stop when nothing is selected - now a reachable state. Header and panel ids are per-instance rather than derived from the public `id`, which is not reactive and left `aria-controls` dangling.

The scroll buttons stepped by a fixed 180px, unrelated to the strip width. They now scroll to the nearest tab not fully inside the region the sticky buttons leave uncovered, so one click reveals exactly one tab. Direction and text direction collapse into a single edge flag, and the offset is plain viewport geometry, which keeps RTL out of the arithmetic.

Also, dirty-checks the layout updates, which used to schedule a render on every scroll event and re-run a full refresh on every selection change; adds `selectedTab` and label matching in `select()`; guards the header lookup, genuinely null for a tab that has not rendered; and flattens the slot query so tabs projected through an intermediate slot are picked up.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Behavioral change (fix or feature that causes existing functionality to change)
- [x] Refactoring (code improvements without functional changes)


## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] Behavioral changes are documented in the description
