### PR TITLE
refactor(a11y): project composite ARIA onto the native editors

### DIFF
--- a/.github/CODING_GUIDELINES.md
+++ b/.github/CODING_GUIDELINES.md
@@ -403,6 +403,25 @@ Accessibility is a first-class requirement for all components.
   this._internals.setARIA({ ariaExpanded: `${this.open}` });
   ```
 
+- When tooling that only reads content attributes (axe, for one) must see the
+  role, enable `reflectRole` instead of writing `this.role = '…'` by hand:
+
+  ```ts
+  private readonly _internals = addInternalsController(this, {
+    initialARIA: { role: 'option' },
+    reflectRole: true, // mirrors the internals role as a `role` content attribute
+  });
+  ```
+
+  The controller reflects the current internals role on connect and whenever
+  `setARIA()` changes it, and yields to an author-supplied `role` attribute.
+
+- Internal code that needs another component's internals controller (composite
+  hosts, specs) reaches it through the `internalsOf()` registry lookup in
+  `#internals/controllers/internals.js`. Never add `public` members tagged
+  `@hidden`/`@internal` for cross-component access — the registry keeps the
+  compiled public API clean.
+
 - **Keyboard navigation** is required for interactive components:
   - Tab navigation should work naturally
   - Arrow keys for list navigation
@@ -427,6 +446,87 @@ Accessibility is a first-class requirement for all components.
 - Ensure **focus management** - visible focus indicators and logical focus order.
 - Provide **text alternatives** for non-text content.
 - Meet **WCAG 2.1 Level AA** standards minimum.
+
+### ARIA across shadow boundaries
+
+Shadow DOM breaks two things ARIA depends on: the identity of the focused
+element, and IDREF resolution. Both matter for composite components (select,
+combo, the date pickers) that wrap an input-shaped component:
+
+- A host using `delegatesFocus` must **not** publish `role`/`aria-*` on itself
+  or on the wrapper element — assistive technology reports from the native
+  editor that actually receives focus, one shadow root deeper.
+- IDREF-valued relations (`aria-controls`, `aria-describedby`,
+  `aria-labelledby`, `aria-activedescendant`) resolve within a single tree
+  scope, so a reference from the native editor to an element in the host's
+  shadow root is silently dead. Such relations must travel as **element
+  references** through ARIA element reflection (`ariaControlsElements`, …),
+  which does resolve into ancestor tree scopes. For a given relation, the
+  content attribute and the reflection property are two views of one
+  association — assigning the property detaches the attribute — so a relation
+  is either all IDREF or all element references.
+
+`#internals/controllers/aria-projection.js` packages the solution as a
+controller pair:
+
+- **Editor side** — every input-shaped component (input, textarea, mask input,
+  date-time input) registers as a projection target and applies the resolved
+  bindings onto its native editor with the `ariaBindings()` element-expression
+  directive:
+
+  ```ts
+  protected readonly _ariaTarget = addAriaTarget(this, {
+    labels: () => this._internals.labels,
+    description: () => this._helperText, // own helper-text element, or null
+  });
+
+  protected _renderInput() {
+    return html`
+      <input ${ariaBindings(this._ariaTarget.resolveBindings())} ... />
+    `;
+  }
+  ```
+
+- **Host side** — the composite component declares what it projects; after
+  every host update the state is pushed onto the target (with an equality
+  guard and a retry for targets that upgrade late):
+
+  ```ts
+  // in the select component
+  private readonly _ariaProjector = addAriaProjector(this, {
+    target: () => this._input,
+    state: () => ({
+      role: 'combobox',
+      hasPopup: 'listbox',
+      expanded: `${this.open}`,
+      controls: this._list ? [this._list] : null,
+      describedBy: this._container ? [this._container] : null,
+      labelledBy: this._internals.labels,
+    }),
+  });
+  ```
+
+- The target mirrors the projected `role`/`hasPopup` as
+  `data-role`/`data-haspopup` attributes on the input component itself. These
+  are **styling hooks** for the themes — `:host()` selectors cannot observe
+  ARIA living on the native editor inside the shadow root — so key theme
+  selectors for composite anchors off the `data-*` attributes, never off
+  `role`/`aria-*` host attributes.
+
+Testing cross-root ARIA:
+
+- Reuse the shared suites in `src/internals/testing/form-testbed.spec.ts`:
+  `runExternalLabelAssociationTests` (external `<label>` association through
+  `for`/nesting) and `runAriaProjectionTests` (host semantics landing on the
+  native editor).
+- Assert reflected relations by identity readback
+  (`input.ariaControlsElements[0] === list`), never by content attribute —
+  reflection blanks the attribute by spec.
+- For the same reason axe reports `aria-controls` as missing on
+  `role="combobox"` editors (`aria-required-attr`). Suppress that single rule
+  with the shared `axeReflectedRelationsOptions` from
+  `#internals/testing/helpers.spec.js`, next to a test asserting the real
+  relation.
 
 ## Testing
 

--- a/.github/skills/create-new-component/SKILL.md
+++ b/.github/skills/create-new-component/SKILL.md
@@ -610,6 +610,21 @@ See: `src/components/card/card.ts`
 - **No Native Private Fields**: Use `_prefix` or TypeScript `private`, not `#`
 - **Accessibility First**: Every component must pass a11y audits
 
+### ARIA in Shadow DOM
+
+- Set ARIA through `addInternalsController` (`initialARIA`, `setARIA()`); add
+  `reflectRole: true` when the role must be visible to attribute-only tooling
+  like axe — never assign `this.role` by hand.
+- A composite component that wraps an input-shaped component and delegates
+  focus must project its semantics onto the native editor with the
+  `addAriaProjector`/`addAriaTarget` pair from
+  `#internals/controllers/aria-projection.js` — ARIA set on the host or the
+  wrapper is invisible to assistive technology, and IDREFs cannot cross shadow
+  boundaries.
+- See the [Accessibility section of the Coding Guidelines](../../CODING_GUIDELINES.md#accessibility)
+  for the full contract, including the `ariaBindings()` directive, the
+  `data-role`/`data-haspopup` theme styling hooks, and the shared test suites.
+
 ### Build System
 
 - SCSS transpiles to Lit `css` template literals

--- a/.github/skills/review-component-pr/SKILL.md
+++ b/.github/skills/review-component-pr/SKILL.md
@@ -234,6 +234,12 @@ protected override render() {
 - [ ] **Color contrast** meets WCAG standards
 - [ ] **Focus indicators** visible
 - [ ] **`addInternalsController`** used for ARIA management if needed
+- [ ] **`reflectRole: true`** used when the role must be visible to attribute-only tooling (axe) — no hand-written `this.role = '…'` assignments
+- [ ] **ARIA lands on the focused element**: a composite host wrapping an input-shaped component (select/combo/date-picker pattern) projects its semantics with `addAriaProjector`/`addAriaTarget` from `#internals/controllers/aria-projection.js` instead of setting `role`/`aria-*` on itself or the wrapper
+- [ ] **Cross-root relations use element references** (ARIA element reflection), never IDREFs — an IDREF cannot cross a shadow boundary
+- [ ] **Theme selectors for composite anchors** key off the mirrored `data-role`/`data-haspopup` attributes, not `role`/`aria-*` host attributes
+- [ ] **No `@hidden`/`@internal` public members** added for cross-component access — use the `internalsOf()` registry lookup (or the projection controllers) instead
+- [ ] **Shared ARIA suites reused** where applicable: `runExternalLabelAssociationTests` / `runAriaProjectionTests` from `src/internals/testing/form-testbed.spec.ts`; reflected relations asserted by identity readback, with `axeReflectedRelationsOptions` suppressing the known `aria-required-attr` false positive
 
 **Check**:
 

--- a/src/components/calendar/days-view/days-view.ts
+++ b/src/components/calendar/days-view/days-view.ts
@@ -1,6 +1,7 @@
 import { getDateFormatter, getDisplayNamesFormatter } from 'igniteui-i18n-core';
 import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
+import { addInternalsController } from '#internals/controllers/internals.js';
 import { addKeybindings } from '#internals/controllers/key-bindings.js';
 import { CalendarDay, DAYS_IN_WEEK } from '#internals/date/model.js';
 import { blazorIndirectRender } from '#internals/decorators/blazorIndirectRender.js';
@@ -186,15 +187,13 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
   constructor() {
     super();
 
+    addInternalsController(this, {
+      initialARIA: { role: 'grid' },
+      reflectRole: true,
+    });
     addThemingController(this, all);
     addKeybindings(this).setActivateHandler(this._handleInteraction);
     addSafeEventListener(this, 'click', this._handleInteraction);
-  }
-
-  /** @internal */
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    this.role = 'grid';
   }
 
   /** @internal */

--- a/src/components/calendar/year-month-view.base.ts
+++ b/src/components/calendar/year-month-view.base.ts
@@ -1,6 +1,7 @@
 import { html, LitElement, type TemplateResult } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { addInternalsController } from '#internals/controllers/internals.js';
 import { addKeybindings } from '#internals/controllers/key-bindings.js';
 import { CalendarDay } from '#internals/date/model.js';
 import type { Constructor } from '#internals/mixins/constructor.js';
@@ -72,15 +73,13 @@ export abstract class IgcYearMonthViewBaseComponent extends EventEmitterMixin<
   constructor() {
     super();
 
+    addInternalsController(this, {
+      initialARIA: { role: 'grid' },
+      reflectRole: true,
+    });
     addThemingController(this, all);
     addKeybindings(this).setActivateHandler(this._handleInteraction);
     addSafeEventListener(this, 'click', this._handleInteraction);
-  }
-
-  /** @internal */
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    this.role = 'grid';
   }
 
   //#endregion

--- a/src/components/carousel/carousel-indicator.ts
+++ b/src/components/carousel/carousel-indicator.ts
@@ -32,6 +32,7 @@ export default class IgcCarouselIndicatorComponent extends LitElement {
 
   private readonly _internals = addInternalsController(this, {
     initialARIA: { role: 'tab' },
+    reflectRole: true,
   });
 
   @consume({ context: carouselContext, subscribe: true })
@@ -52,7 +53,6 @@ export default class IgcCarouselIndicatorComponent extends LitElement {
   /** @internal */
   public override connectedCallback(): void {
     super.connectedCallback();
-    this.role = 'tab';
     this.slot = this.slot || 'indicator';
   }
 

--- a/src/components/combo/combo-item.ts
+++ b/src/components/combo/combo-item.ts
@@ -24,6 +24,7 @@ export default class IgcComboItemComponent extends LitElement {
       role: 'option',
       ariaSelected: 'false',
     },
+    reflectRole: true,
   });
 
   @property({ attribute: false })
@@ -56,12 +57,6 @@ export default class IgcComboItemComponent extends LitElement {
   constructor() {
     super();
     addThemingController(this, all);
-  }
-
-  /** @internal */
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    this.role = 'option';
   }
 
   protected override willUpdate(props: PropertyValues<this>): void {

--- a/src/components/combo/combo.spec.ts
+++ b/src/components/combo/combo.spec.ts
@@ -21,9 +21,11 @@ import {
 import { defineComponents } from '#internals/definitions/defineComponents.js';
 import {
   createFormAssociatedTestBed,
+  runAriaProjectionTests,
   runExternalLabelAssociationTests,
 } from '#internals/testing/form-testbed.spec.js';
 import {
+  axeReflectedRelationsOptions,
   isFocused,
   suppressResizeObserverLoopError,
 } from '#internals/testing/helpers.spec.js';
@@ -251,8 +253,10 @@ describe('Combo', () => {
       await elementUpdated(combo);
       await layoutComplete(combo);
 
-      await expect(combo).shadowDom.to.be.accessible();
-      await expect(combo).to.be.accessible();
+      await expect(combo).shadowDom.to.be.accessible(
+        axeReflectedRelationsOptions
+      );
+      await expect(combo).to.be.accessible(axeReflectedRelationsOptions);
     });
 
     it('picks up items appended to the data array in place', async () => {
@@ -1977,5 +1981,23 @@ describe('Combo', () => {
       (host as IgcComboComponent).renderRoot
         .querySelector<IgcInputComponent>('#target')!
         .renderRoot.querySelector('input')!,
+  });
+
+  runAriaProjectionTests({
+    tagName: IgcComboComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcComboComponent).renderRoot
+        .querySelector<IgcInputComponent>('#target')!
+        .renderRoot.querySelector('input')!,
+    expected: { role: 'combobox', hasPopup: 'listbox' },
+    getControls: (host) => [
+      (host as IgcComboComponent).renderRoot.querySelector('#dropdown')!,
+    ],
+    getDescription: (host) => [
+      (host as IgcComboComponent).renderRoot.querySelector(
+        '#combo-helper-text'
+      )!,
+    ],
+    openProperty: 'open',
   });
 });

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -3,9 +3,10 @@ import {
   type IComboResourceStrings,
 } from 'igniteui-i18n-core';
 import { html, type PropertyValues, type TemplateResult } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { createRef, ref } from 'lit/directives/ref.js';
+import { addAriaProjector } from '#internals/controllers/aria-projection.js';
 import { addRootClickController } from '#internals/controllers/root-click.js';
 import { addSlotController, setSlots } from '#internals/controllers/slot.js';
 import { blazorAdditionalDependencies } from '#internals/decorators/blazorAdditionalDependencies.js';
@@ -199,6 +200,9 @@ export default class IgcComboComponent<
 
   /** The primary input of the combo component. */
   private readonly _inputRef = createRef<IgcInputComponent>();
+
+  @query('#combo-helper-text')
+  private readonly _helperText!: IgcValidationContainerComponent | null;
 
   /** The search input of the combo component. */
   private readonly _searchRef = createRef<IgcInputComponent>();
@@ -585,6 +589,24 @@ export default class IgcComboComponent<
     addThemingController(this, all, {
       themeChange: () => this._listRef.value?.requestUpdate(),
     });
+
+    // Projects the host's labels and combobox semantics onto the native
+    // input inside `igc-input` (see ProjectedARIA for why the host cannot
+    // publish these itself). `aria-activedescendant` stays on the listbox,
+    // which holds DOM focus while the list is navigated.
+    addAriaProjector(this, {
+      target: () => this._inputRef.value,
+      state: () => ({
+        role: 'combobox',
+        hasPopup: 'listbox',
+        expanded: `${this.open}`,
+        disabled: `${this.disabled}`,
+        label: this._mainAriaLabel,
+        controls: this._listRef.value ? [this._listRef.value] : null,
+        describedBy: this._helperText ? [this._helperText] : null,
+        labelledBy: this._internals.labels,
+      }),
+    });
     addSafeEventListener(this, 'blur', this._handleBlur);
     addSafeEventListener(this, 'focusin', this._handleFocusIn);
   }
@@ -626,13 +648,6 @@ export default class IgcComboComponent<
       callback();
     } finally {
       this._pristine = pristine;
-    }
-  }
-
-  protected override updated(props: PropertyValues<this>): void {
-    super.updated(props);
-    if (this._inputRef.value) {
-      this._inputRef.value._labelElements = this._internals.labels;
     }
   }
 
@@ -1205,6 +1220,7 @@ export default class IgcComboComponent<
       <span
         slot="suffix"
         part="clear-icon"
+        role="button"
         @click=${this._handleClearIconClick}
         ?hidden=${this.disableClear || isEmpty(this._selected)}
         aria-label=${ifDefined(
@@ -1231,13 +1247,6 @@ export default class IgcComboComponent<
         ${ref(this._inputRef)}
         id="target"
         slot="anchor"
-        role="combobox"
-        aria-controls="dropdown"
-        aria-owns="dropdown"
-        aria-expanded=${this.open}
-        aria-describedby="combo-helper-text"
-        aria-disabled=${this.disabled}
-        aria-label=${this._mainAriaLabel}
         exportparts="container: input, input: native-input, label, prefix, suffix"
         @click=${this._handleAnchorClick}
         placeholder=${ifDefined(this.placeholder)}

--- a/src/components/date-picker/date-picker.base.ts
+++ b/src/components/date-picker/date-picker.base.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { addAriaProjector } from '#internals/controllers/aria-projection.js';
 import {
   addKeybindings,
   altKey,
@@ -124,6 +125,9 @@ export abstract class IgcDatePickerBaseComponent<
   @query(IgcCalendarComponent.tagName)
   protected readonly _calendar!: IgcCalendarComponent;
 
+  @query('#helper-text')
+  protected readonly _helperText!: IgcValidationContainerComponent | null;
+
   protected get _isDropDown(): boolean {
     return this.mode === 'dropdown';
   }
@@ -177,10 +181,12 @@ export abstract class IgcDatePickerBaseComponent<
   /** The localized label of the calendar picker. */
   protected abstract get _selectDateLabel(): string | undefined;
 
-  /** The editor which the associated labels of the host are forwarded to. */
-  protected abstract get _labelTarget(): {
-    _labelElements: ReadonlyArray<Element> | null;
-  } | null;
+  /**
+   * The editor the host's ARIA state is projected onto — its associated
+   * labels and the `aria-haspopup="dialog"` semantics of the picker, both of
+   * which must land on the native input assistive technology reports.
+   */
+  protected abstract get _projectionTarget(): Element | null;
 
   /** Moves focus to the editor of the picker. */
   protected abstract _focusInput(): void;
@@ -475,6 +481,18 @@ export abstract class IgcDatePickerBaseComponent<
   constructor() {
     super();
 
+    // Projects the host's labels and popup semantics onto the native input
+    // inside the editor (see ProjectedARIA for why the host cannot publish
+    // these itself).
+    addAriaProjector(this, {
+      target: () => this._projectionTarget,
+      state: () => ({
+        hasPopup: 'dialog',
+        labelledBy: this._internals.labels,
+        describedBy: this._helperText ? [this._helperText] : null,
+      }),
+    });
+
     addSafeEventListener(this, 'focusout', this._handleFocusOut);
 
     addKeybindings(this, {
@@ -494,16 +512,6 @@ export abstract class IgcDatePickerBaseComponent<
       if (this.open) {
         this._oldValue = this._value;
       }
-    }
-  }
-
-  protected override updated(changedProperties: PropertyValues<this>): void {
-    super.updated(changedProperties);
-
-    const target = this._labelTarget;
-
-    if (target) {
-      target._labelElements = this._internals.labels;
     }
   }
 

--- a/src/components/date-picker/date-picker.spec.ts
+++ b/src/components/date-picker/date-picker.spec.ts
@@ -13,7 +13,10 @@ import {
   getDayViewDOM,
   getDOMDate,
 } from '#internals/testing/calendar.spec.js';
-import { runExternalLabelAssociationTests } from '#internals/testing/form-testbed.spec.js';
+import {
+  runAriaProjectionTests,
+  runExternalLabelAssociationTests,
+} from '#internals/testing/form-testbed.spec.js';
 import { checkDatesEqual, isFocused } from '#internals/testing/helpers.spec.js';
 import {
   simulateClick,
@@ -36,6 +39,22 @@ describe('Date picker', () => {
           IgcDateTimeInputComponent.tagName
         )!
         .renderRoot.querySelector('input')!,
+  });
+
+  runAriaProjectionTests({
+    tagName: IgcDatePickerComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcDatePickerComponent).renderRoot
+        .querySelector<IgcDateTimeInputComponent>(
+          IgcDateTimeInputComponent.tagName
+        )!
+        .renderRoot.querySelector('input')!,
+    expected: { hasPopup: 'dialog' },
+    getDescription: (host) => [
+      (host as IgcDatePickerComponent).renderRoot.querySelector(
+        '#helper-text'
+      )!,
+    ],
   });
 
   const pickerShowIcon = 'today';

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -241,7 +241,7 @@ export default class IgcDatePickerComponent extends EventEmitterMixin<
     return this._input?.inputFormat;
   }
 
-  protected override get _labelTarget() {
+  protected override get _projectionTarget() {
     return this._input ?? null;
   }
 
@@ -422,7 +422,6 @@ export default class IgcDatePickerComponent extends EventEmitterMixin<
     return html`
       <igc-date-time-input
         id=${id}
-        aria-haspopup="dialog"
         label=${bindIf(this._isMaterial, this.label)}
         input-format=${ifDefined(this._inputFormat)}
         display-format=${ifDefined(format)}

--- a/src/components/date-range-picker/date-range-picker-single.spec.ts
+++ b/src/components/date-range-picker/date-range-picker-single.spec.ts
@@ -17,7 +17,10 @@ import {
 } from '#internals/controllers/key-bindings.js';
 import { CalendarDay } from '#internals/date/model.js';
 import { defineComponents } from '#internals/definitions/defineComponents.js';
-import { runExternalLabelAssociationTests } from '#internals/testing/form-testbed.spec.js';
+import {
+  runAriaProjectionTests,
+  runExternalLabelAssociationTests,
+} from '#internals/testing/form-testbed.spec.js';
 import { isFocused } from '#internals/testing/helpers.spec.js';
 import {
   simulateClick,
@@ -46,6 +49,22 @@ describe('Date range picker - single input', () => {
           IgcDateRangeInputComponent.tagName
         )!
         .renderRoot.querySelector('input')!,
+  });
+
+  runAriaProjectionTests({
+    tagName: IgcDateRangePickerComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcDateRangePickerComponent).renderRoot
+        .querySelector<IgcDateRangeInputComponent>(
+          IgcDateRangeInputComponent.tagName
+        )!
+        .renderRoot.querySelector('input')!,
+    expected: { hasPopup: 'dialog' },
+    getDescription: (host) => [
+      (host as IgcDateRangePickerComponent).renderRoot.querySelector(
+        '#helper-text'
+      )!,
+    ],
   });
 
   let picker: IgcDateRangePickerComponent;

--- a/src/components/date-range-picker/date-range-picker-two-inputs.spec.ts
+++ b/src/components/date-range-picker/date-range-picker-two-inputs.spec.ts
@@ -14,7 +14,10 @@ import {
 } from '#internals/controllers/key-bindings.js';
 import { CalendarDay } from '#internals/date/model.js';
 import { defineComponents } from '#internals/definitions/defineComponents.js';
-import { runExternalLabelAssociationTests } from '#internals/testing/form-testbed.spec.js';
+import {
+  runAriaProjectionTests,
+  runExternalLabelAssociationTests,
+} from '#internals/testing/form-testbed.spec.js';
 import { checkDatesEqual, isFocused } from '#internals/testing/helpers.spec.js';
 import {
   simulateClick,
@@ -46,6 +49,39 @@ describe('Date range picker - two inputs', () => {
           IgcDateTimeInputComponent.tagName
         )!
         .renderRoot.querySelector('input')!,
+  });
+
+  // The start editor.
+  runAriaProjectionTests({
+    tagName: IgcDateRangePickerComponent.tagName,
+    hostAttributes: 'use-two-inputs',
+    getNativeInput: (host) =>
+      (host as IgcDateRangePickerComponent).renderRoot
+        .querySelector<IgcDateTimeInputComponent>(
+          IgcDateTimeInputComponent.tagName
+        )!
+        .renderRoot.querySelector('input')!,
+    expected: { hasPopup: 'dialog' },
+    getDescription: (host) => [
+      (host as IgcDateRangePickerComponent).renderRoot.querySelector(
+        '#helper-text'
+      )!,
+    ],
+  });
+
+  // The end editor receives the popup semantics as well, labels excluded.
+  runAriaProjectionTests({
+    tagName: IgcDateRangePickerComponent.tagName,
+    hostAttributes: 'use-two-inputs',
+    getNativeInput: (host) =>
+      Array.from(
+        (
+          host as IgcDateRangePickerComponent
+        ).renderRoot.querySelectorAll<IgcDateTimeInputComponent>(
+          IgcDateTimeInputComponent.tagName
+        )
+      )[1]!.renderRoot.querySelector('input')!,
+    expected: { hasPopup: 'dialog' },
   });
 
   let picker: IgcDateRangePickerComponent;

--- a/src/components/date-range-picker/date-range-picker.ts
+++ b/src/components/date-range-picker/date-range-picker.ts
@@ -10,6 +10,7 @@ import { property, query, queryAll, state } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
+import { addAriaProjector } from '#internals/controllers/aria-projection.js';
 import { addSlotController, setSlots } from '#internals/controllers/slot.js';
 import { convertToDateRange } from '#internals/date/converters.js';
 import { CalendarDay } from '#internals/date/model.js';
@@ -316,8 +317,8 @@ export default class IgcDateRangePickerComponent extends EventEmitterMixin<
     return this._defaultMask;
   }
 
-  protected override get _labelTarget() {
-    // Forward the host's associated labels only to the start input.
+  protected override get _projectionTarget() {
+    // The host's associated labels are projected only onto the start input.
     return this._input ?? this._inputs?.[0] ?? null;
   }
 
@@ -487,6 +488,17 @@ export default class IgcDateRangePickerComponent extends EventEmitterMixin<
   // #endregion
 
   // #region Life-cycle hooks
+
+  constructor() {
+    super();
+
+    // The base class projector covers the start editor. In two-input mode the
+    // end editor needs the picker popup semantics as well, labels excluded.
+    addAriaProjector(this, {
+      target: () => this._inputs[1] ?? null,
+      state: () => ({ hasPopup: 'dialog' }),
+    });
+  }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
@@ -804,7 +816,6 @@ export default class IgcDateRangePickerComponent extends EventEmitterMixin<
     return html`
       <igc-date-time-input
         id=${id}
-        aria-haspopup="dialog"
         input-format=${ifDefined(this._inputFormat)}
         display-format=${ifDefined(format)}
         ?disabled=${this.disabled}
@@ -854,7 +865,6 @@ export default class IgcDateRangePickerComponent extends EventEmitterMixin<
         id=${id}
         .value=${live(this.value)}
         .placeholder=${this.placeholder}
-        aria-haspopup="dialog"
         label=${this.label}
         ?readonly=${this._isEditorReadOnly}
         ?required=${this.required}

--- a/src/components/date-time-input/date-time-input.base.ts
+++ b/src/components/date-time-input/date-time-input.base.ts
@@ -1,7 +1,8 @@
 import { getDateFormatter } from 'igniteui-i18n-core';
 import { LitElement, type PropertyValues, type TemplateResult } from 'lit';
-import { eventOptions, property, query, state } from 'lit/decorators.js';
+import { eventOptions, property, query } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
+import { addAriaTarget } from '#internals/controllers/aria-projection.js';
 import {
   addKeybindings,
   arrowDown,
@@ -68,24 +69,17 @@ export abstract class IgcDateTimeInputBaseComponent<
   protected override readonly _input?: HTMLInputElement;
 
   /**
-   * Externally supplied label elements forwarded by a composite host (e.g. `igc-date-picker`)
-   * so that the host's associated labels reach the inner native input. When set, these take
-   * precedence over the component's own `ElementInternals` labels.
-   *
-   * @hidden @internal
+   * Receives ARIA semantics projected by a composite host
+   * (e.g. `igc-date-picker`) onto the inner native input.
+   * See {@link addAriaTarget}.
    */
-  @state()
-  public _labelElements: ReadonlyArray<Element> | null = null;
-
-  /**
-   * Resolves the label elements applied to the native input as `aria-labelledby` targets,
-   * preferring forwarded labels over the component's own `ElementInternals` labels.
-   *
-   * @hidden @internal
-   */
-  protected get _resolvedLabelElements(): ReadonlyArray<Element> | null {
-    return this._labelElements ?? this._internals.labels;
-  }
+  protected readonly _ariaTarget = addAriaTarget(this, {
+    labels: () => this._internals.labels,
+    description: () =>
+      this._slots.hasAssignedElements('helper-text')
+        ? this.renderRoot.querySelector('#helper-text')
+        : null,
+  });
 
   protected override get __validators() {
     return dateTimeInputValidators;
@@ -586,7 +580,6 @@ export abstract class IgcDateTimeInputBaseComponent<
 
   protected _renderInput(): TemplateResult {
     const hasNegativeTabIndex = this.getAttribute('tabindex') === '-1';
-    const hasHelperText = this._slots.hasAssignedElements('helper-text');
 
     return renderMaskedNativeInput({
       id: this._inputId,
@@ -597,8 +590,7 @@ export abstract class IgcDateTimeInputBaseComponent<
       readOnly: this.readOnly,
       disabled: this.disabled,
       tabindex: hasNegativeTabIndex ? -1 : undefined,
-      ariaDescribedBy: hasHelperText ? 'helper-text' : undefined,
-      ariaLabelledByElements: this._resolvedLabelElements,
+      aria: this._ariaTarget.resolveBindings(),
       onInput: this._handleInput,
       onBeforeInput: this._handleBeforeInput,
       onFocus: this._handleFocus,

--- a/src/components/file-input/file-input.spec.ts
+++ b/src/components/file-input/file-input.spec.ts
@@ -2,7 +2,10 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import type { TemplateResult } from 'lit';
 import { spy } from 'sinon';
 import { defineComponents } from '#internals/definitions/defineComponents.js';
-import { createFormAssociatedTestBed } from '#internals/testing/form-testbed.spec.js';
+import {
+  createFormAssociatedTestBed,
+  runExternalLabelAssociationTests,
+} from '#internals/testing/form-testbed.spec.js';
 import { simulateFileUpload } from '#internals/testing/simulate.spec.js';
 import {
   runValidationContainerTests,
@@ -19,6 +22,15 @@ describe('File Input component', () => {
 
   before(() => {
     defineComponents(IgcFileInputComponent);
+  });
+
+  runExternalLabelAssociationTests({
+    tagName: IgcFileInputComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcFileInputComponent).renderRoot.querySelector('input')!,
+    // Chromium does not move focus into an `<input type="file">` on label
+    // activation the way it does for text editors.
+    assertFocus: false,
   });
 
   let element: IgcFileInputComponent;

--- a/src/components/file-input/file-input.ts
+++ b/src/components/file-input/file-input.ts
@@ -4,6 +4,7 @@ import {
 } from 'igniteui-i18n-core';
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { ariaBindings } from '#internals/controllers/aria-projection.js';
 import { addSlotController, setSlots } from '#internals/controllers/slot.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import { addI18nController } from '#internals/i18n/i18n-controller.js';
@@ -270,10 +271,10 @@ export default class IgcFileInputComponent extends EventEmitterMixin<
 
   protected override _renderInput() {
     const hasNegativeTabIndex = this.getAttribute('tabindex') === '-1';
-    const hasHelperText = this._slots.hasAssignedElements('helper-text');
 
     return html`
       <input
+        ${ariaBindings(this._ariaTarget.resolveBindings())}
         id=${this._inputId}
         part=${partMap(this._resolvePartNames('input'))}
         type="file"
@@ -283,7 +284,6 @@ export default class IgcFileInputComponent extends EventEmitterMixin<
         ?multiple=${this.multiple}
         tabindex=${bindIf(hasNegativeTabIndex, -1)}
         accept=${bindIf(this.accept, this.accept)}
-        aria-describedby=${bindIf(hasHelperText, 'helper-text')}
         @click=${this._handleClick}
         @change=${this._handleChange}
         @cancel=${this._handleCancel}

--- a/src/components/input/input-base.ts
+++ b/src/components/input/input-base.ts
@@ -1,6 +1,7 @@
 import { LitElement, nothing, type TemplateResult } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
+import { addAriaTarget } from '#internals/controllers/aria-projection.js';
 import type { SlotController } from '#internals/controllers/slot.js';
 import { blazorDeepImport } from '#internals/decorators/blazorDeepImport.js';
 import { shadowOptions } from '#internals/decorators/shadow-options.js';
@@ -13,18 +14,6 @@ import {
   resolveInputPartNames,
 } from '#internals/templates/input-shell.js';
 import type { ThemingController } from '#theming/theming-controller.js';
-
-/**
- * ARIA semantics a composite host can project onto the native input.
- *
- * @hidden @internal
- */
-export type InputAriaProperties = {
-  role?: string;
-  hasPopup?: string;
-  expanded?: string;
-  controls?: ReadonlyArray<Element> | null;
-};
 
 export interface IgcInputComponentEventMap {
   /* alternateName: inputOcurred */
@@ -57,35 +46,16 @@ export abstract class IgcInputBaseComponent extends FormAssociatedRequiredMixin(
   protected readonly _input?: HTMLInputElement;
 
   /**
-   * Externally supplied label elements forwarded by a composite host (e.g. `igc-select`)
-   * so that the host's associated labels reach the inner native input. When set, these take
-   * precedence over the component's own `ElementInternals` labels.
-   *
-   * @hidden @internal
+   * Receives ARIA semantics projected by a composite host (e.g. `igc-select`)
+   * onto the inner native input. See {@link addAriaTarget}.
    */
-  @state()
-  public _labelElements: ReadonlyArray<Element> | null = null;
-
-  /**
-   * Resolves the label elements applied to the native input as `aria-labelledby` targets,
-   * preferring forwarded labels over the component's own `ElementInternals` labels.
-   *
-   * @hidden @internal
-   */
-  protected get _resolvedLabelElements(): ReadonlyArray<Element> | null {
-    return this._labelElements ?? this._internals.labels;
-  }
-
-  /**
-   * ARIA semantics forwarded by a composite host (e.g. `igc-select`) onto the
-   * inner native input, which is the element assistive technology lands on and
-   * reports once the host delegates focus to it. `controls` takes elements
-   * rather than an id, as the target sits outside the input's shadow root.
-   *
-   * @hidden @internal
-   */
-  @state()
-  public _ariaProperties: InputAriaProperties = {};
+  protected readonly _ariaTarget = addAriaTarget(this, {
+    labels: () => this._internals.labels,
+    description: () =>
+      this._slots.hasAssignedElements('helper-text')
+        ? this.renderRoot.querySelector('#helper-text')
+        : null,
+  });
 
   /* blazorSuppress */
   /** The value of the control. */

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -2,6 +2,7 @@ import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
+import { ariaBindings } from '#internals/controllers/aria-projection.js';
 import { addSlotController, setSlots } from '#internals/controllers/slot.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import { createFormValueState } from '#internals/mixins/forms/form-value.js';
@@ -291,10 +292,10 @@ export default class IgcInputComponent extends IgcInputBaseComponent {
 
   protected _renderInput() {
     const hasNegativeTabIndex = this.getAttribute('tabindex') === '-1';
-    const hasHelperText = this._slots.hasAssignedElements('helper-text');
 
     return html`
       <input
+        ${ariaBindings(this._ariaTarget.resolveBindings())}
         id=${this._inputId}
         part=${partMap(this._resolvePartNames('input'))}
         name=${ifDefined(this.name)}
@@ -314,12 +315,6 @@ export default class IgcInputComponent extends IgcInputBaseComponent {
         minlength=${ifDefined(this.minLength)}
         maxlength=${bindIf(!this.validateOnly, this.maxLength)}
         step=${ifDefined(this.step)}
-        .ariaLabelledByElements=${this._resolvedLabelElements}
-        .ariaControlsElements=${this._ariaProperties.controls ?? null}
-        role=${ifDefined(this._ariaProperties.role)}
-        aria-haspopup=${ifDefined(this._ariaProperties.hasPopup)}
-        aria-expanded=${ifDefined(this._ariaProperties.expanded)}
-        aria-describedby=${bindIf(hasHelperText, 'helper-text')}
         @keydown=${this._handleEnterKeydown}
         @change=${this._handleChange}
         @input=${this._handleInput}

--- a/src/components/input/themes/shared/input.bootstrap.scss
+++ b/src/components/input/themes/shared/input.bootstrap.scss
@@ -156,7 +156,7 @@ $theme: $bootstrap;
     }
 }
 
-:host(:not([aria-haspopup='dialog'],[role='combobox'])[readonly]) {
+:host(:not([data-haspopup='dialog'],[data-role='combobox'])[readonly]) {
     [part='prefix'],
     [part='suffix'],
     [part~='container'] {
@@ -165,14 +165,14 @@ $theme: $bootstrap;
 }
 
 :host(:not([disabled],[readonly]):state(ig-invalid)),
-:host(:not([disabled])[role='combobox']:state(ig-invalid)) {
+:host(:not([disabled])[data-role='combobox']:state(ig-invalid)) {
     [part~='input'] {
         border-color: var-get($theme, 'error-secondary-color');
     }
 }
 
 :host(:not([disabled],[readonly]):state(ig-invalid):focus-within),
-:host(:not([disabled])[role='combobox']:state(ig-invalid):focus-within) {
+:host(:not([disabled])[data-role='combobox']:state(ig-invalid):focus-within) {
     [part~='input'] {
         box-shadow: 0 0 0 rem(4px) var-get($theme, 'error-shadow-color');
     }
@@ -217,8 +217,8 @@ $theme: $bootstrap;
     }
 }
 
-:host(:not(:disabled, [role='combobox'])),
-:host(:not([disabled], [role='combobox'])) {
+:host(:not(:disabled, [data-role='combobox'])),
+:host(:not([disabled], [data-role='combobox'])) {
     ::slotted([slot='suffix']) {
         border-inline-end: rem(1px) solid var(--border-color);
     }
@@ -228,8 +228,8 @@ $theme: $bootstrap;
     }
 }
 
-:host(:disabled:not([role='combobox'])),
-:host([disabled]:not([role='combobox'])) {
+:host(:disabled:not([data-role='combobox'])),
+:host([disabled]:not([data-role='combobox'])) {
     ::slotted([slot='suffix']) {
         border-inline-end: rem(1px) solid var(--disabled-border-color);
     }

--- a/src/components/input/themes/shared/input.common.scss
+++ b/src/components/input/themes/shared/input.common.scss
@@ -106,7 +106,7 @@ input::-webkit-datetime-edit {
 }
 /* stylelint-enable */
 
-:host(:not([role='combobox'])[readonly]) {
+:host(:not([data-role='combobox'])[readonly]) {
     [part='prefix'],
     [part='suffix'] {
         color: var-get($theme, 'disabled-text-color');
@@ -140,7 +140,7 @@ input::-webkit-datetime-edit {
     padding-inline: var(--affix-padding);
 }
 
-:host(:not([role='combobox'])) {
+:host(:not([data-role='combobox'])) {
     ::slotted([slot='suffix']),
     ::slotted([slot='prefix']) {
         padding-inline: var(--affix-padding);

--- a/src/components/input/themes/shared/input.fluent.scss
+++ b/src/components/input/themes/shared/input.fluent.scss
@@ -110,7 +110,7 @@ $theme: $fluent;
     }
 }
 
-:host([aria-expanded][readonly]:not(:focus-within):hover) {
+:host([data-role='combobox'][readonly]:not(:focus-within):hover) {
     [part^='container'] {
         &::before {
             // The color: here is the actual box-shadow color. If we don't provide color-value to the shadow it
@@ -123,7 +123,7 @@ $theme: $fluent;
     }
 }
 
-:host([aria-haspopup]:not([readonly], [disabled], :focus-within):hover) {
+:host([data-haspopup='dialog']:not([readonly], [disabled], :focus-within):hover) {
     [part^='container'] {
         &::before {
             color: var-get($theme, 'hover-border-color');
@@ -132,7 +132,7 @@ $theme: $fluent;
     }
 }
 
-:host(:not([aria-haspopup],[aria-expanded])[readonly]) {
+:host(:not([data-haspopup='dialog'],[data-role='combobox'])[readonly]) {
     [part='prefix'],
     [part='suffix'] {
         background: transparent;
@@ -193,8 +193,8 @@ $theme: $fluent;
 
 :host(:not([disabled],[readonly]):state(ig-invalid)),
 :host(:not([disabled],[readonly]):state(ig-invalid):hover),
-:host(:not([disabled])[role='combobox']:state(ig-invalid)),
-:host(:not([disabled])[role='combobox']:state(ig-invalid):hover) {
+:host(:not([disabled])[data-role='combobox']:state(ig-invalid)),
+:host(:not([disabled])[data-role='combobox']:state(ig-invalid):hover) {
     [part~='container'] {
         &::before {
             box-shadow: inset 0 0 0 var(--input-border-size) var-get($theme, 'error-secondary-color');
@@ -203,7 +203,7 @@ $theme: $fluent;
 }
 
 :host(:not([disabled],[readonly]):state(ig-invalid):focus-within),
-:host(:not([disabled])[role='combobox']:state(ig-invalid):focus-within) {
+:host(:not([disabled])[data-role='combobox']:state(ig-invalid):focus-within) {
     [part~='container'] {
         &::before {
             box-shadow: inset 0 0 0 calc(var(--input-border-size) + #{rem(1px)}) var-get($theme, 'error-secondary-color');

--- a/src/components/input/themes/shared/input.indigo.scss
+++ b/src/components/input/themes/shared/input.indigo.scss
@@ -115,7 +115,7 @@ $transition-duration: .25s;
 }
 
 :host(:not([disabled],[readonly]):hover),
-:host(:not([disabled])[readonly][role='combobox']:hover) {
+:host(:not([disabled])[readonly][data-role='combobox']:hover) {
     [part^='container'] {
         background: var-get($theme, 'box-background-hover');
         border-color: var-get($theme, 'hover-bottom-line-color');
@@ -123,7 +123,7 @@ $transition-duration: .25s;
 }
 
 :host(:not([disabled],[readonly]):focus-within),
-:host(:not([disabled])[readonly][role='combobox']:focus-within) {
+:host(:not([disabled])[readonly][data-role='combobox']:focus-within) {
     [part^='container'] {
         background: var-get($theme, 'box-background-focus');
         caret-color: var-get($theme, 'focused-bottom-line-color');
@@ -149,7 +149,7 @@ $transition-duration: .25s;
     }
 }
 
-:host(:not([aria-haspopup='dialog'],[role='combobox'],[disabled])[readonly]) {
+:host(:not([data-haspopup='dialog'],[data-role='combobox'],[disabled])[readonly]) {
     [part^='container'] {
         border-color: var-get($theme, 'disabled-text-color');
     }
@@ -157,7 +157,7 @@ $transition-duration: .25s;
 
 :host(:not([disabled],[readonly]):state(ig-invalid)),
 :host(:not([disabled],[readonly]):state(ig-invalid):hover),
-:host(:not([disabled])[role='combobox']:state(ig-invalid)) {
+:host(:not([disabled])[data-role='combobox']:state(ig-invalid)) {
     [part^='container'] {
         caret-color: initial;
         border-color: var-get($theme, 'error-secondary-color');

--- a/src/components/input/themes/shared/input.material.scss
+++ b/src/components/input/themes/shared/input.material.scss
@@ -243,8 +243,8 @@ $fs: rem(16px) !default;
     :not(
         [outlined],
         [type='search'],
-        [aria-haspopup='dialog'],
-        [role='combobox']
+        [data-haspopup='dialog'],
+        [data-role='combobox']
     )[readonly]
 ) {
     [part~='container'] {
@@ -255,8 +255,8 @@ $fs: rem(16px) !default;
 :host(:not(
     [outlined],
     [type='search'],
-    [aria-haspopup='dialog'],
-    [role='combobox']
+    [data-haspopup='dialog'],
+    [data-role='combobox']
 )[readonly]:hover) {
     [part~='container'] {
         background: var-get($theme, 'box-background-focus');
@@ -283,8 +283,8 @@ $fs: rem(16px) !default;
 :host(
     :not(
             [outlined],
-            [aria-haspopup='dialog'],
-            [role='combobox']
+            [data-haspopup='dialog'],
+            [data-role='combobox']
         )[readonly]:focus-within
 ) {
     [part~='container'] {
@@ -302,8 +302,8 @@ $fs: rem(16px) !default;
 :host(
     :not(
             [outlined],
-            [aria-haspopup='dialog'],
-            [role='combobox']
+            [data-haspopup='dialog'],
+            [data-role='combobox']
         )[readonly]:focus-within
 ) {
     [part='label'] {
@@ -315,9 +315,9 @@ $fs: rem(16px) !default;
 
 :host(:not([outlined], [disabled], [readonly]):state(ig-invalid)),
 :host(:not([outlined], [disabled], [readonly]):state(ig-invalid):focus-within),
-:host(:not([disabled], [outlined])[role='combobox']:state(ig-invalid)),
+:host(:not([disabled], [outlined])[data-role='combobox']:state(ig-invalid)),
 :host(
-    :not([disabled], [outlined])[role='combobox']:state(ig-invalid):focus-within
+    :not([disabled], [outlined])[data-role='combobox']:state(ig-invalid):focus-within
 ) {
     [part~='container'] {
         border-color: var-get($theme, 'error-secondary-color');
@@ -494,7 +494,7 @@ $fs: rem(16px) !default;
 }
 
 :host(
-    :not([aria-haspopup='dialog'], [role='combobox'])[outlined][readonly]:hover
+    :not([data-haspopup='dialog'], [data-role='combobox'])[outlined][readonly]:hover
 ) {
     [part='notch'],
     [part='start'],
@@ -509,8 +509,8 @@ $fs: rem(16px) !default;
 }
 
 :host(:not(
-    [aria-haspopup='dialog'],
-    [role='combobox']
+    [data-haspopup='dialog'],
+    [data-role='combobox']
 )[outlined][readonly]:focus-within) {
     [part='notch'],
     [part='start'],
@@ -627,8 +627,8 @@ $fs: rem(16px) !default;
 :host(
     :not(
             [type='search'],
-            [aria-haspopup='dialog'],
-            [role='combobox']
+            [data-haspopup='dialog'],
+            [data-role='combobox']
         )[outlined]:focus-within
 ) {
     [part='notch'] {
@@ -662,9 +662,9 @@ $fs: rem(16px) !default;
 :host(
     :not([type='search'], [readonly])[outlined]:state(ig-invalid):focus-within
 ),
-:host(:not([disabled])[role='combobox'][outlined]:state(ig-invalid)),
+:host(:not([disabled])[data-role='combobox'][outlined]:state(ig-invalid)),
 :host(
-    :not([disabled])[role='combobox'][outlined]:state(ig-invalid):focus-within
+    :not([disabled])[data-role='combobox'][outlined]:state(ig-invalid):focus-within
 ) {
     [part='start'],
     [part='notch'],
@@ -680,7 +680,7 @@ $fs: rem(16px) !default;
 }
 
 :host(
-    :not([disabled])[role='combobox'][outlined]:state(ig-invalid):focus-within
+    :not([disabled])[data-role='combobox'][outlined]:state(ig-invalid):focus-within
 ) {
     :not([part~='filled']) {
         input:not(:placeholder-shown) + [part='notch'] {
@@ -690,15 +690,15 @@ $fs: rem(16px) !default;
 }
 
 :host(:not([type='search'])[outlined]:state(ig-invalid):focus-within),
-:host([role='combobox'][outlined]:state(ig-invalid):focus-within) {
+:host([data-role='combobox'][outlined]:state(ig-invalid):focus-within) {
     [part='notch'] {
         border-top: $idle-border-width solid transparent;
     }
 }
 
-:host(:not([disabled], [readonly])[role='combobox'][outlined]:focus-within),
+:host(:not([disabled], [readonly])[data-role='combobox'][outlined]:focus-within),
 :host(
-    :not([disabled], [readonly])[role='combobox'][outlined]:state(
+    :not([disabled], [readonly])[data-role='combobox'][outlined]:state(
             ig-invalid
         ):focus-within
 ) {
@@ -714,7 +714,7 @@ $fs: rem(16px) !default;
 }
 
 :host(:not([disabled], [readonly]):state(ig-invalid)),
-:host(:not([disabled])[role='combobox']:state(ig-invalid)) {
+:host(:not([disabled])[data-role='combobox']:state(ig-invalid)) {
     [part='label'] {
         color: var-get($theme, 'error-secondary-color');
     }

--- a/src/components/mask-input/mask-input.ts
+++ b/src/components/mask-input/mask-input.ts
@@ -275,7 +275,6 @@ export default class IgcMaskInputComponent extends MaskBehaviorMixin(
 
   protected override _renderInput() {
     const hasNegativeTabIndex = this.getAttribute('tabindex') === '-1';
-    const hasHelperText = this._slots.hasAssignedElements('helper-text');
 
     return renderMaskedNativeInput({
       id: this._inputId,
@@ -288,8 +287,7 @@ export default class IgcMaskInputComponent extends MaskBehaviorMixin(
       autofocus: this.autofocus,
       inputMode: this.inputMode,
       tabindex: hasNegativeTabIndex ? -1 : undefined,
-      ariaDescribedBy: hasHelperText ? 'helper-text' : undefined,
-      ariaLabelledByElements: this._resolvedLabelElements,
+      aria: this._ariaTarget.resolveBindings(),
       onInput: this._handleInput,
       onBeforeInput: this._handleBeforeInput,
       onFocus: this._handleFocus,

--- a/src/components/select/select-header.ts
+++ b/src/components/select/select-header.ts
@@ -27,16 +27,11 @@ export default class IgcSelectHeaderComponent extends LitElement {
 
     // A `listbox` may only own `option` and `group` nodes, so this purely
     // visual separator is taken out of the accessibility tree.
-    addInternalsController(this, { initialARIA: { role: 'presentation' } });
+    addInternalsController(this, {
+      initialARIA: { role: 'presentation' },
+      reflectRole: true,
+    });
     addThemingController(this, all);
-  }
-
-  /** @internal */
-  public override connectedCallback(): void {
-    // R.K. Workaround for Axe accessibility unit tests.
-    // I guess it does not support ElementInternals ARIAMixin state yet
-    super.connectedCallback();
-    this.role = 'presentation';
   }
 
   protected override render() {

--- a/src/components/select/select.spec.ts
+++ b/src/components/select/select.spec.ts
@@ -6,6 +6,7 @@ import {
   nextFrame,
 } from '@open-wc/testing';
 import { spy, useFakeTimers } from 'sinon';
+import { internalsOf } from '#internals/controllers/internals.js';
 import {
   altKey,
   arrowDown,
@@ -20,9 +21,13 @@ import {
 import { defineComponents } from '#internals/definitions/defineComponents.js';
 import {
   createFormAssociatedTestBed,
+  runAriaProjectionTests,
   runExternalLabelAssociationTests,
 } from '#internals/testing/form-testbed.spec.js';
-import { isFocused } from '#internals/testing/helpers.spec.js';
+import {
+  axeReflectedRelationsOptions,
+  isFocused,
+} from '#internals/testing/helpers.spec.js';
 import {
   simulateClick,
   simulateKeyboard,
@@ -224,10 +229,9 @@ describe('Select', () => {
       });
 
       it('is accessible', async () => {
-        // `aria-controls` is published through element reflection, which blanks
-        // the content attribute axe reads - see "projects the combobox
-        // semantics onto the native input", which asserts the real relation.
-        const axeOptions = { ignoredRules: ['aria-required-attr'] };
+        // See "projects the combobox semantics onto the native input", which
+        // asserts the real `aria-controls` relation by identity readback.
+        const axeOptions = axeReflectedRelationsOptions;
 
         // Closed state
         await expect(select).dom.to.be.accessible(axeOptions);
@@ -802,12 +806,10 @@ describe('Select', () => {
 
       const [first, second] = select.groups;
 
-      expect((first as any)._internals.getARIA('ariaLabel')).to.equal(
+      expect(internalsOf(first)?.getARIA('ariaLabel')).to.equal(
         'Pre development'
       );
-      expect((second as any)._internals.getARIA('ariaLabel')).to.equal(
-        'Development'
-      );
+      expect(internalsOf(second)?.getARIA('ariaLabel')).to.equal('Development');
     });
   });
 
@@ -1835,5 +1837,23 @@ describe('Select', () => {
       (host as IgcSelectComponent).renderRoot
         .querySelector<IgcInputComponent>(IgcInputComponent.tagName)!
         .renderRoot.querySelector('input')!,
+  });
+
+  runAriaProjectionTests({
+    tagName: IgcSelectComponent.tagName,
+    getNativeInput: (host) =>
+      (host as IgcSelectComponent).renderRoot
+        .querySelector<IgcInputComponent>(IgcInputComponent.tagName)!
+        .renderRoot.querySelector('input')!,
+    expected: { role: 'combobox', hasPopup: 'listbox' },
+    getControls: (host) => [
+      (host as IgcSelectComponent).renderRoot.querySelector('#dropdown')!,
+    ],
+    getDescription: (host) => [
+      (host as IgcSelectComponent).renderRoot.querySelector(
+        '#select-helper-text'
+      )!,
+    ],
+    openProperty: 'open',
   });
 });

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -1,6 +1,7 @@
-import { html, type PropertyValues, type TemplateResult } from 'lit';
+import { html, type TemplateResult } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { addAriaProjector } from '#internals/controllers/aria-projection.js';
 import {
   addKeybindings,
   altKey,
@@ -191,6 +192,9 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
   @query('#dropdown')
   protected _list!: HTMLDivElement | null;
 
+  @query('#select-helper-text')
+  protected _helperText!: IgcValidationContainerComponent | null;
+
   protected get _activeItems(): IgcSelectItemComponent[] {
     return Array.from(
       getActiveItems<IgcSelectItemComponent>(
@@ -307,6 +311,21 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
 
     addThemingController(this, all);
 
+    // Projects the host's labels and combobox semantics onto the native
+    // input inside `igc-input` (see ProjectedARIA for why the host cannot
+    // publish these itself).
+    addAriaProjector(this, {
+      target: () => this._input,
+      state: () => ({
+        role: 'combobox',
+        hasPopup: 'listbox',
+        expanded: `${this.open}`,
+        controls: this._list ? [this._list] : null,
+        describedBy: this._helperText ? [this._helperText] : null,
+        labelledBy: this._internals.labels,
+      }),
+    });
+
     addKeybindings(this, {
       skip: () => this.disabled,
       bindingDefaults: { preventDefault: true, repeat: true },
@@ -394,11 +413,6 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
     }
 
     this._validate();
-  }
-
-  protected override updated(changedProperties: PropertyValues): void {
-    super.updated(changedProperties);
-    this._forwardToInput();
   }
 
   //#endregion
@@ -663,36 +677,6 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
       .replace(/\s+/gu, ' ');
   }
 
-  /**
-   * Projects the host's labels and the combobox semantics onto the native input
-   * inside `igc-input`. Neither can be bound on the `igc-input` element itself:
-   * it delegates focus, so the native input is what assistive technology lands
-   * on and reports, and neither an external `<label for>` nor the `#dropdown`
-   * IDREF can reach across into its shadow root.
-   */
-  private _forwardToInput(): void {
-    const input = this._input;
-
-    if (!input) {
-      return;
-    }
-
-    input._labelElements = this._internals.labels;
-
-    // Only the expanded state ever changes; reassigning unconditionally would
-    // schedule a redundant input render on every update of the select.
-    const expanded = `${this.open}`;
-
-    if (input._ariaProperties.expanded !== expanded) {
-      input._ariaProperties = {
-        role: 'combobox',
-        hasPopup: 'listbox',
-        expanded,
-        controls: this._list ? [this._list] : null,
-      };
-    }
-  }
-
   //#endregion
 
   //#region Public API
@@ -800,7 +784,6 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
         id="input"
         slot="anchor"
         readonly
-        aria-describedby="select-helper-text"
         exportparts="container: input, input: native-input, label, prefix, suffix"
         value=${ifDefined(this._displayValue)}
         placeholder=${ifDefined(this.placeholder)}

--- a/src/components/select/themes/select.base.scss
+++ b/src/components/select/themes/select.base.scss
@@ -17,12 +17,12 @@
     }
 }
 
-[role='combobox'] {
+[data-role='combobox'] {
     outline-style: none;
 }
 
 :host([disabled]) {
-    [role='combobox'] {
+    [data-role='combobox'] {
         pointer-events: none;
     }
 }

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -14,6 +14,7 @@ import { cache } from 'lit/directives/cache.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 
 import { styleMap } from 'lit/directives/style-map.js';
+import { addInternalsController } from '#internals/controllers/internals.js';
 import {
   addKeybindings,
   arrowLeft,
@@ -172,6 +173,11 @@ export default class IgcTabsComponent extends EventEmitterMixin<
   constructor() {
     super();
 
+    addInternalsController(this, {
+      initialARIA: { role: 'tablist', ariaOrientation: 'horizontal' },
+      reflectRole: true,
+    });
+
     addThemingController(this, all);
 
     addKeybindings(this, {
@@ -208,13 +214,6 @@ export default class IgcTabsComponent extends EventEmitterMixin<
     this._syncSelection(selectedTab);
 
     this._resizeController.observe(this._headerRef.value!);
-  }
-
-  /** @internal */
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    this.role = 'tablist';
-    this.ariaOrientation = 'horizontal';
   }
 
   protected override update(props: PropertyValues<this>): void {

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -10,6 +10,10 @@ import { cache } from 'lit/directives/cache.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import {
+  addAriaTarget,
+  ariaBindings,
+} from '#internals/controllers/aria-projection.js';
 import { createResizeObserverController } from '#internals/controllers/resize-observer.js';
 import {
   addSlotController,
@@ -111,6 +115,18 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   private readonly _slots = addSlotController(this, {
     slots: Slots,
     onChange: this._handleSlotChange,
+  });
+
+  /**
+   * Receives ARIA semantics projected by a composite host onto the inner
+   * native textarea. See {@link addAriaTarget}.
+   */
+  private readonly _ariaTarget = addAriaTarget(this, {
+    labels: () => this._internals.labels,
+    description: () =>
+      this._slots.hasAssignedElements('helper-text')
+        ? this.renderRoot.querySelector('#helper-text')
+        : null,
   });
 
   @query('textarea')
@@ -458,13 +474,10 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   }
 
   protected _renderInput() {
-    const describedBy = this._slots.hasAssignedElements('helper-text')
-      ? 'helper-text'
-      : nothing;
-
     return html`
       <slot style="display: none"></slot>
       <textarea
+        ${ariaBindings(this._ariaTarget.resolveBindings())}
         id=${this.id || this._inputId}
         part="input"
         style=${styleMap({
@@ -485,8 +498,6 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
         ?disabled=${this.disabled}
         ?required=${this.required}
         ?readonly=${this.readOnly}
-        aria-describedby=${describedBy}
-        .ariaLabelledByElements=${this._internals.labels}
       ></textarea>
     `;
   }

--- a/src/internals/controllers/aria-projection.ts
+++ b/src/internals/controllers/aria-projection.ts
@@ -1,0 +1,340 @@
+import {
+  type LitElement,
+  noChange,
+  type ReactiveController,
+  type ReactiveControllerHost,
+} from 'lit';
+import {
+  Directive,
+  type DirectiveParameters,
+  directive,
+  type ElementPart,
+  type PartInfo,
+  PartType,
+} from 'lit/directive.js';
+
+type ControllerHost = ReactiveControllerHost & LitElement;
+
+/**
+ * ARIA semantics a composite host projects onto the native editor of an
+ * input-shaped component.
+ *
+ * The host cannot publish these itself: it delegates focus, so the native
+ * editor inside the input component's shadow root is what assistive technology
+ * lands on and reports. All relations travel as element references — an IDREF
+ * cannot cross a shadow boundary, while ARIA element reflection resolves into
+ * ancestor tree scopes.
+ */
+export type ProjectedARIA = {
+  role?: string;
+  hasPopup?: string;
+  expanded?: string;
+  disabled?: string;
+  label?: string;
+  controls?: ReadonlyArray<Element> | null;
+  describedBy?: ReadonlyArray<Element> | null;
+  labelledBy?: ReadonlyArray<Element> | null;
+  activeDescendant?: Element | null;
+};
+
+/** Configuration for the {@link AriaTargetController}. */
+type AriaTargetConfig = {
+  /** Resolves the component's own `ElementInternals` labels. */
+  labels: () => ReadonlyArray<Element> | null;
+  /**
+   * Resolves the component's own description element (its helper-text
+   * container), or `null` when it currently renders no description content.
+   */
+  description: () => Element | null;
+};
+
+/**
+ * Binding values for a native editor element, resolved from the projected
+ * state merged with the editor's own ARIA. Applied onto the editor with the
+ * {@link ariaBindings} directive: scalars bind as attributes, relations bind
+ * through the ARIA element-reflection properties.
+ */
+export type ResolvedARIABindings = {
+  role?: string;
+  hasPopup?: string;
+  expanded?: string;
+  disabled?: string;
+  label?: string;
+  /**
+   * Same-root IDREF for the editor's own description, applied while no
+   * description is projected. Unlike element reflection, a content attribute
+   * stays visible to tooling that only reads attributes (e.g. axe).
+   */
+  describedByRef?: string;
+  labelledBy: ReadonlyArray<Element> | null;
+  controls: ReadonlyArray<Element> | null;
+  describedBy: ReadonlyArray<Element> | null;
+  activeDescendant: Element | null;
+};
+
+/**
+ * Internal registry resolving an input-shaped component to its ARIA target
+ * controller, so composite hosts can project state without the component
+ * exposing a public member for it.
+ */
+const targets = new WeakMap<Element, AriaTargetController>();
+
+function elementsEqual(
+  a: ReadonlyArray<Element> | null | undefined,
+  b: ReadonlyArray<Element> | null | undefined
+): boolean {
+  if (a == null || b == null) {
+    return a == null && b == null;
+  }
+
+  return a.length === b.length && a.every((element, i) => element === b[i]);
+}
+
+function projectionsEqual(a: ProjectedARIA, b: ProjectedARIA): boolean {
+  return (
+    a.role === b.role &&
+    a.hasPopup === b.hasPopup &&
+    a.expanded === b.expanded &&
+    a.disabled === b.disabled &&
+    a.label === b.label &&
+    (a.activeDescendant ?? null) === (b.activeDescendant ?? null) &&
+    elementsEqual(a.controls, b.controls) &&
+    elementsEqual(a.describedBy, b.describedBy) &&
+    elementsEqual(a.labelledBy, b.labelledBy)
+  );
+}
+
+/**
+ * The receiving end of an ARIA projection, added by every input-shaped
+ * component. Holds the state a composite host currently projects and resolves
+ * it against the component's own ARIA when the native editor is rendered.
+ *
+ * Not a reactive controller — it needs no lifecycle hooks, only a render
+ * scheduled on the host when the projected state changes.
+ */
+class AriaTargetController {
+  private readonly _host: ControllerHost;
+  private readonly _config: AriaTargetConfig;
+  private _projected: ProjectedARIA = {};
+
+  constructor(host: ControllerHost, config: AriaTargetConfig) {
+    this._host = host;
+    this._config = config;
+    targets.set(host, this);
+  }
+
+  /**
+   * Replaces the projected state, scheduling a host render only when it
+   * actually changed so projecting on every host update stays cheap.
+   */
+  public setProjected(state: ProjectedARIA): void {
+    if (!projectionsEqual(this._projected, state)) {
+      this._projected = state;
+      this._reflectStylingHooks();
+      this._host.requestUpdate();
+    }
+  }
+
+  /**
+   * Mirrors the projected `role`/`hasPopup` as `data-role`/`data-haspopup`
+   * attributes on the component itself. The input themes style anchors of
+   * composite widgets differently and key off these; the ARIA itself lives on
+   * the native editor inside the shadow root, where `:host()` selectors
+   * cannot observe it.
+   */
+  private _reflectStylingHooks(): void {
+    const host = this._host;
+    const { role, hasPopup } = this._projected;
+
+    role
+      ? host.setAttribute('data-role', role)
+      : host.removeAttribute('data-role');
+    hasPopup
+      ? host.setAttribute('data-haspopup', hasPopup)
+      : host.removeAttribute('data-haspopup');
+  }
+
+  /**
+   * Resolves the binding values for the native editor element by merging the
+   * projected state with the editor's own ARIA.
+   *
+   * Projected labels take precedence over the component's own. The editor's
+   * description stays a same-root IDREF ({@link ResolvedARIABindings.describedByRef})
+   * while nothing is projected; once a host projects a description, the whole
+   * relation switches to element references — attribute and reflection cannot
+   * coexist — with the editor's own description element joining the projected
+   * ones.
+   */
+  public resolveBindings(): ResolvedARIABindings {
+    const projected = this._projected;
+    const description = this._config.description();
+
+    return {
+      role: projected.role,
+      hasPopup: projected.hasPopup,
+      expanded: projected.expanded,
+      disabled: projected.disabled,
+      label: projected.label,
+      labelledBy: projected.labelledBy ?? this._config.labels(),
+      controls: projected.controls ?? null,
+      describedBy: projected.describedBy
+        ? description
+          ? [description, ...projected.describedBy]
+          : projected.describedBy
+        : null,
+      describedByRef: projected.describedBy
+        ? undefined
+        : description?.id || undefined,
+      activeDescendant: projected.activeDescendant ?? null,
+    };
+  }
+}
+
+const scalarBindings = [
+  ['role', 'role'],
+  ['hasPopup', 'aria-haspopup'],
+  ['expanded', 'aria-expanded'],
+  ['disabled', 'aria-disabled'],
+  ['label', 'aria-label'],
+  ['describedByRef', 'aria-describedby'],
+] as const;
+
+/**
+ * Applies {@link ResolvedARIABindings} onto the native editor element —
+ * relations on every render, scalar attributes only when they changed.
+ */
+class AriaBindingsDirective extends Directive {
+  private _previous?: ResolvedARIABindings;
+
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+
+    if (partInfo.type !== PartType.ELEMENT) {
+      throw new Error(
+        '`ariaBindings()` can only be used as an element expression.'
+      );
+    }
+  }
+
+  public override render(_: ResolvedARIABindings): unknown {
+    return noChange;
+  }
+
+  public override update(
+    part: ElementPart,
+    [bindings]: DirectiveParameters<this>
+  ): unknown {
+    const element = part.element;
+    const previous = this._previous;
+    this._previous = bindings;
+
+    // Relations are re-asserted on every render: element references assigned
+    // while the editor is detached (its first render commits inside the
+    // template fragment) are dropped by the browser, so memoizing them here
+    // would leave the associations permanently missing.
+    // Assigning them first also means the scalar pass below always observes
+    // the final state, since a reflection property detaches the corresponding
+    // content attribute.
+    element.ariaLabelledByElements = bindings.labelledBy;
+    element.ariaControlsElements = bindings.controls;
+    element.ariaDescribedByElements = bindings.describedBy;
+    element.ariaActiveDescendantElement = bindings.activeDescendant;
+
+    for (const [key, attribute] of scalarBindings) {
+      const value = bindings[key];
+
+      if (!previous || previous[key] !== value) {
+        value != null
+          ? element.setAttribute(attribute, value)
+          : element.removeAttribute(attribute);
+      }
+    }
+
+    return noChange;
+  }
+}
+
+/**
+ * Binds resolved ARIA state onto a native editor element as a single element
+ * expression, e.g. `<input ${ariaBindings(aria)} />`.
+ */
+export const ariaBindings = directive(AriaBindingsDirective);
+
+/** Configuration for the {@link AriaProjectorController}. */
+type AriaProjectorConfig = {
+  /** Resolves the input-shaped component the ARIA state is projected onto. */
+  target: () => Element | null | undefined;
+  /** Computes the ARIA state to project. Invoked after every host update. */
+  state: () => ProjectedARIA;
+};
+
+/**
+ * The sending end of an ARIA projection, added by composite hosts
+ * (e.g. `igc-select`). After every host update it pushes the computed ARIA
+ * state onto the target component's {@link AriaTargetController}.
+ */
+class AriaProjectorController implements ReactiveController {
+  private readonly _host: ControllerHost;
+  private readonly _config: AriaProjectorConfig;
+  private _retryScheduled = false;
+
+  constructor(host: ControllerHost, config: AriaProjectorConfig) {
+    this._host = host;
+    this._config = config;
+    host.addController(this);
+  }
+
+  /** @internal */
+  public hostUpdated(): void {
+    const element = this._config.target();
+
+    if (!element) {
+      return;
+    }
+
+    const target = targets.get(element);
+
+    if (target) {
+      target.setProjected(this._config.state());
+      return;
+    }
+
+    // The target exists but has no controller yet - it is not upgraded on the
+    // host's first render when definitions register late. Re-project once its
+    // definition resolves.
+    if (!this._retryScheduled) {
+      this._retryScheduled = true;
+
+      customElements.whenDefined(element.localName).then(() => {
+        this._retryScheduled = false;
+        this._host.requestUpdate();
+      });
+    }
+  }
+}
+
+/**
+ * Creates and adds an {@link AriaTargetController} to an input-shaped
+ * component, making its native editor a valid target for
+ * {@link addAriaProjector} — the editor is what assistive technology lands on
+ * and reports once the component's host delegates focus to it.
+ */
+export function addAriaTarget(
+  host: ControllerHost,
+  config: AriaTargetConfig
+): AriaTargetController {
+  return new AriaTargetController(host, config);
+}
+
+/**
+ * Creates and adds an {@link AriaProjectorController} to a composite host,
+ * projecting ARIA semantics onto the native editor of the target component.
+ */
+export function addAriaProjector(
+  host: ControllerHost,
+  config: AriaProjectorConfig
+): AriaProjectorController {
+  return new AriaProjectorController(host, config);
+}
+
+export type { AriaProjectorController, AriaTargetController };

--- a/src/internals/controllers/internals.spec.ts
+++ b/src/internals/controllers/internals.spec.ts
@@ -1,0 +1,97 @@
+import {
+  defineCE,
+  expect,
+  fixture,
+  html,
+  unsafeStatic,
+} from '@open-wc/testing';
+import { LitElement } from 'lit';
+import {
+  addInternalsController,
+  type ElementInternalsController,
+} from './internals.js';
+
+describe('ElementInternals controller', () => {
+  describe('reflectRole', () => {
+    let tag: string;
+    let tagName: ReturnType<typeof unsafeStatic>;
+
+    before(() => {
+      tag = defineCE(
+        class extends LitElement {
+          public internals = addInternalsController(this, {
+            initialARIA: { role: 'option' },
+            reflectRole: true,
+          });
+        }
+      );
+      tagName = unsafeStatic(tag);
+    });
+
+    it('mirrors the internals role as a content attribute on connect', async () => {
+      const instance = await fixture<LitElement>(
+        html`<${tagName}></${tagName}>`
+      );
+
+      expect(instance.getAttribute('role')).to.equal('option');
+    });
+
+    it('yields to an author-supplied role attribute present before connect', async () => {
+      const instance = await fixture<LitElement>(
+        html`<${tagName} role="presentation"></${tagName}>`
+      );
+
+      expect(instance.getAttribute('role')).to.equal('presentation');
+    });
+
+    it('updates its own attribute when the internals role changes', async () => {
+      const instance = await fixture<
+        LitElement & { internals: ElementInternalsController }
+      >(html`<${tagName}></${tagName}>`);
+
+      instance.internals.setARIA({ role: 'listitem' });
+
+      expect(instance.getAttribute('role')).to.equal('listitem');
+    });
+
+    it('keeps an author override through an internals role change', async () => {
+      const instance = await fixture<
+        LitElement & { internals: ElementInternalsController }
+      >(html`<${tagName}></${tagName}>`);
+
+      instance.setAttribute('role', 'presentation');
+      instance.internals.setARIA({ role: 'listitem' });
+
+      expect(instance.getAttribute('role')).to.equal('presentation');
+    });
+
+    it('keeps an author override through a DOM reconnection', async () => {
+      const container = await fixture<HTMLDivElement>(
+        html`<div><${tagName}></${tagName}></div>`
+      );
+      const instance = container.querySelector<LitElement>(tag)!;
+
+      expect(instance.getAttribute('role')).to.equal('option');
+
+      instance.setAttribute('role', 'presentation');
+
+      // Re-parenting an upgraded element re-runs `hostConnected` and with it
+      // the role reflection.
+      instance.remove();
+      container.append(instance);
+
+      expect(instance.getAttribute('role')).to.equal('presentation');
+    });
+
+    it('restores its attribute after the author removes it, on the next reflection', async () => {
+      const instance = await fixture<
+        LitElement & { internals: ElementInternalsController }
+      >(html`<${tagName}></${tagName}>`);
+
+      instance.removeAttribute('role');
+      instance.internals.setARIA({ role: 'option' });
+
+      expect(instance.getAttribute('role')).to.equal('option');
+    });
+  });
+});

--- a/src/internals/controllers/internals.ts
+++ b/src/internals/controllers/internals.ts
@@ -38,8 +38,8 @@ class ElementInternalsController implements ReactiveController {
   private readonly _internals: ElementInternals;
   private readonly _reflectRole: boolean;
 
-  /** Whether the current `role` content attribute was written by this controller. */
-  private _roleReflected = false;
+  /** The last `role` content attribute value written by this controller. */
+  private _reflectedRole: string | null = null;
 
   /**
    * Gets the closest ancestor `<form>` element or `null`.
@@ -136,10 +136,13 @@ class ElementInternalsController implements ReactiveController {
     }
 
     const role = this._internals.role;
+    const current = host.getAttribute('role');
 
-    if (role && (this._roleReflected || !host.hasAttribute('role'))) {
+    // Write only when the attribute is absent or still holds the value this
+    // controller wrote — an attribute changed by the author is theirs to keep.
+    if (role && (current === null || current === this._reflectedRole)) {
       host.setAttribute('role', role);
-      this._roleReflected = true;
+      this._reflectedRole = role;
     }
   }
 

--- a/src/internals/controllers/internals.ts
+++ b/src/internals/controllers/internals.ts
@@ -8,16 +8,38 @@ import type { FormValueType } from '../mixins/forms/types.js';
 /** Configuration for the ElementInternalsController. */
 type ElementInternalsConfig<T extends keyof ARIAMixin = keyof ARIAMixin> = {
   /** Initial ARIA attributes to set on the element internals. */
-  initialARIA: Partial<Record<T, ARIAMixin[T]>>;
+  initialARIA?: Partial<Record<T, ARIAMixin[T]>>;
+  /**
+   * Whether to also mirror the internals `role` to a `role` content attribute
+   * on the host element.
+   *
+   * Workaround for axe, which reads content attributes only and does not see
+   * `ElementInternals` ARIA. An author-supplied `role` attribute always wins —
+   * the controller only writes the attribute when it is absent or was written
+   * by the controller itself.
+   */
+  reflectRole?: boolean;
 };
+
+/**
+ * Internal registry resolving a host element to its internals controller.
+ *
+ * `attachInternals()` throws when called twice on the same element, so a host
+ * maps to at most one controller.
+ */
+const registry = new WeakMap<Element, ElementInternalsController>();
 
 /**
  * A Lit ReactiveController to manage `ElementInternals` for a host element.
  * Provides methods to interact with custom element states and ARIA attributes..
  */
-class ElementInternalsController {
+class ElementInternalsController implements ReactiveController {
   private readonly _host: ReactiveControllerHost & LitElement;
   private readonly _internals: ElementInternals;
+  private readonly _reflectRole: boolean;
+
+  /** Whether the current `role` content attribute was written by this controller. */
+  private _roleReflected = false;
 
   /**
    * Gets the closest ancestor `<form>` element or `null`.
@@ -84,12 +106,41 @@ class ElementInternalsController {
   ) {
     this._host = host;
     this._internals = this._host.attachInternals();
+    this._reflectRole = config?.reflectRole ?? false;
 
     if (config?.initialARIA) {
       this.setARIA(config.initialARIA);
     }
 
-    host.addController(this as ReactiveController);
+    registry.set(host, this);
+    host.addController(this);
+  }
+
+  /** @internal */
+  public hostConnected(): void {
+    this._reflectRoleAttribute();
+  }
+
+  /**
+   * Mirrors the internals `role` onto a content attribute on the host, when
+   * {@link ElementInternalsConfig.reflectRole} is enabled.
+   *
+   * Deferred until the host is connected — custom elements must not gain
+   * attributes during construction.
+   */
+  private _reflectRoleAttribute(): void {
+    const host = this._host;
+
+    if (!(this._reflectRole && host.isConnected)) {
+      return;
+    }
+
+    const role = this._internals.role;
+
+    if (role && (this._roleReflected || !host.hasAttribute('role'))) {
+      host.setAttribute('role', role);
+      this._roleReflected = true;
+    }
   }
 
   /** Sets ARIA attributes on the element's internals. */
@@ -97,6 +148,10 @@ class ElementInternalsController {
     state: Partial<Record<T, ARIAMixin[T]>>
   ): void {
     Object.assign(this._internals, state);
+
+    if ('role' in state) {
+      this._reflectRoleAttribute();
+    }
   }
 
   /**
@@ -175,6 +230,19 @@ export function addInternalsController(
   config?: ElementInternalsConfig
 ): ElementInternalsController {
   return new ElementInternalsController(host, config);
+}
+
+/**
+ * Resolves the {@link ElementInternalsController} of the given element, if it has one.
+ *
+ * Internal cross-component/spec lookup. Not part of the public API — lives under
+ * `#internals` and must not be re-exported from the package entry point. Prefer this
+ * over exposing `public` `@hidden @internal` members on component classes.
+ */
+export function internalsOf(
+  element: Element
+): ElementInternalsController | undefined {
+  return registry.get(element);
 }
 
 export type { ElementInternalsController };

--- a/src/internals/mixins/option.ts
+++ b/src/internals/mixins/option.ts
@@ -6,6 +6,7 @@ import { addInternalsController } from '../controllers/internals.js';
 export abstract class IgcBaseOptionLikeComponent extends LitElement {
   protected readonly _internals = addInternalsController(this, {
     initialARIA: { role: 'option' },
+    reflectRole: true,
   });
 
   protected _active = false;
@@ -75,14 +76,6 @@ export abstract class IgcBaseOptionLikeComponent extends LitElement {
 
   public get value(): string {
     return this._value ? this._value : this._contentSlotText;
-  }
-
-  /** @internal */
-  public override connectedCallback(): void {
-    // R.K. Workaround for Axe accessibility unit tests.
-    // I guess it does not support ElementInternals ARIAMixin state yet
-    super.connectedCallback();
-    this.role = 'option';
   }
 
   protected override render() {

--- a/src/internals/templates/masked-input.ts
+++ b/src/internals/templates/masked-input.ts
@@ -1,6 +1,10 @@
 import { html, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
+import {
+  ariaBindings,
+  type ResolvedARIABindings,
+} from '../controllers/aria-projection.js';
 import { partMap } from '../part-map.js';
 import { bindIf } from '../utils/lit.js';
 
@@ -21,10 +25,11 @@ export interface MaskedInputOptions {
   inputMode?: string;
   /** When provided, sets the `tabindex` attribute. */
   tabindex?: number;
-  /** When provided, sets the `aria-describedby` attribute. */
-  ariaDescribedBy?: string;
-  /** When provided, sets the `aria-labelledby` attribute using the provided elements. */
-  ariaLabelledByElements?: ReadonlyArray<Element> | null;
+  /**
+   * Resolved ARIA bindings for the native input — the projected host state
+   * merged with the editor's own (see `AriaTargetController.resolveBindings`).
+   */
+  aria: ResolvedARIABindings;
 
   // Required mask handlers
   onInput: (event: InputEvent) => void;
@@ -66,8 +71,7 @@ export function renderMaskedNativeInput(
       ?autofocus=${opts.autofocus}
       inputmode=${ifDefined(opts.inputMode)}
       tabindex=${bindIf(opts.tabindex != null, opts.tabindex)}
-      aria-describedby=${bindIf(!!opts.ariaDescribedBy, opts.ariaDescribedBy)}
-      .ariaLabelledByElements=${opts.ariaLabelledByElements ?? null}
+      ${ariaBindings(opts.aria)}
       @input=${opts.onInput}
       @beforeinput=${opts.onBeforeInput}
       @focus=${opts.onFocus}

--- a/src/internals/testing/form-testbed.spec.ts
+++ b/src/internals/testing/form-testbed.spec.ts
@@ -219,6 +219,12 @@ export interface ExternalLabelAssociationConfig {
   getNativeInput: (host: HTMLElement) => HTMLInputElement | HTMLTextAreaElement;
   /** Optional additional attributes to set on the rendered host element. */
   hostAttributes?: string;
+  /**
+   * Whether clicking the label is asserted to move focus onto the native
+   * control. Defaults to `true`; opt out for controls the browser does not
+   * label-focus like text editors (e.g. `<input type="file">`).
+   */
+  assertFocus?: boolean;
 }
 
 /**
@@ -234,7 +240,12 @@ export interface ExternalLabelAssociationConfig {
 export function runExternalLabelAssociationTests(
   config: ExternalLabelAssociationConfig
 ): void {
-  const { tagName, getNativeInput, hostAttributes = '' } = config;
+  const {
+    tagName,
+    getNativeInput,
+    hostAttributes = '',
+    assertFocus = true,
+  } = config;
 
   describe('External label association', () => {
     async function createLabelledFixture(nested: boolean) {
@@ -253,32 +264,140 @@ export function runExternalLabelAssociationTests(
       return { label, host };
     }
 
-    it('links an external label through an IDREF (`for` attribute)', async () => {
-      const { label, host } = await createLabelledFixture(false);
+    async function assertLabelAssociation(nested: boolean) {
+      const { label, host } = await createLabelledFixture(nested);
       const native = getNativeInput(host);
 
-      expect(native.ariaLabelledByElements).to.have.lengthOf(1);
-      expect(native.ariaLabelledByElements?.[0]).to.equal(label);
+      expect(native.ariaLabelledByElements).to.eql([label]);
 
       simulateClick(label);
       await elementUpdated(host);
 
       expect(document.activeElement).to.equal(host);
-      expect(isFocused(native)).to.be.true;
-    });
 
-    it('links an external label by nesting the component inside it', async () => {
-      const { label, host } = await createLabelledFixture(true);
+      if (assertFocus) {
+        expect(isFocused(native)).to.be.true;
+      }
+    }
+
+    it('links an external label through an IDREF (`for` attribute)', () =>
+      assertLabelAssociation(false));
+
+    it('links an external label by nesting the component inside it', () =>
+      assertLabelAssociation(true));
+  });
+}
+
+export interface AriaProjectionTestConfig {
+  /** The host custom element tag name (e.g. `igc-select`). */
+  tagName: string;
+  /** Optional additional attributes to set on the rendered host element. */
+  hostAttributes?: string;
+  /**
+   * Locates the AT-exposed native editor (`<input>`/`<textarea>`) that
+   * receives the projected ARIA state within the given host element.
+   */
+  getNativeInput: (host: HTMLElement) => HTMLInputElement | HTMLTextAreaElement;
+  /** The scalar ARIA state expected on the native editor. */
+  expected: {
+    role?: string;
+    hasPopup?: string;
+  };
+  /** Locates the expected `aria-controls` targets within the host. */
+  getControls?: (host: HTMLElement) => Element[];
+  /** Locates the expected `aria-describedby` targets within the host. */
+  getDescription?: (host: HTMLElement) => Element[];
+  /** A boolean property toggling the popup, asserted against `aria-expanded`. */
+  openProperty?: string;
+}
+
+/**
+ * Shared test suite asserting that a composite host projects its ARIA
+ * semantics onto the native editor of its inner input component — the element
+ * assistive technology lands on and reports when the host delegates focus.
+ *
+ * Relations are asserted by element-identity readback
+ * (e.g. `input.ariaControlsElements[0] === list`), never by content attribute:
+ * they are published through ARIA element reflection, since an IDREF cannot
+ * cross the shadow boundary between the editor and the host, and reflection
+ * blanks the content attribute by spec.
+ */
+export function runAriaProjectionTests(config: AriaProjectionTestConfig): void {
+  const {
+    tagName,
+    hostAttributes = '',
+    getNativeInput,
+    expected,
+    getControls,
+    getDescription,
+    openProperty,
+  } = config;
+
+  describe('ARIA projection', () => {
+    async function createProjectionFixture() {
+      const container = await fixture<HTMLElement>(html`<div></div>`);
+      container.innerHTML = `<${tagName} ${hostAttributes}></${tagName}>`;
+
+      const host = container.querySelector<HTMLElement>(tagName)!;
+
+      await elementUpdated(host);
+      await nextFrame();
+
+      return host;
+    }
+
+    it('projects the host semantics onto the native editor', async () => {
+      const host = await createProjectionFixture();
       const native = getNativeInput(host);
 
-      expect(native.ariaLabelledByElements).to.have.lengthOf(1);
-      expect(native.ariaLabelledByElements?.[0]).to.equal(label);
+      // The input component wrapping the native editor. It carries the
+      // projected `role`/`hasPopup` as `data-role`/`data-haspopup` styling
+      // hooks for the input themes.
+      const anchor = (native.getRootNode() as ShadowRoot).host;
 
-      simulateClick(label);
-      await elementUpdated(host);
+      if (expected.role) {
+        expect(native.role).to.equal(expected.role);
+        expect(anchor.getAttribute('data-role')).to.equal(expected.role);
+      }
 
-      expect(document.activeElement).to.equal(host);
-      expect(isFocused(native)).to.be.true;
+      if (expected.hasPopup) {
+        expect(native.getAttribute('aria-haspopup')).to.equal(
+          expected.hasPopup
+        );
+        expect(anchor.getAttribute('data-haspopup')).to.equal(
+          expected.hasPopup
+        );
+      }
+
+      if (getControls) {
+        expect(native.ariaControlsElements).to.eql(getControls(host));
+      }
+
+      if (getDescription) {
+        const description = getDescription(host);
+        for (const element of description) {
+          expect(native.ariaDescribedByElements).to.contain(element);
+        }
+      }
     });
+
+    if (openProperty) {
+      it('reflects the open state of the host onto the native editor', async () => {
+        const host = await createProjectionFixture();
+        const native = getNativeInput(host);
+
+        expect(native.getAttribute('aria-expanded')).to.equal('false');
+
+        (host as unknown as Record<string, boolean>)[openProperty] = true;
+        await elementUpdated(host);
+
+        expect(native.getAttribute('aria-expanded')).to.equal('true');
+
+        (host as unknown as Record<string, boolean>)[openProperty] = false;
+        await elementUpdated(host);
+
+        expect(native.getAttribute('aria-expanded')).to.equal('false');
+      });
+    }
   });
 }

--- a/src/internals/testing/helpers.spec.ts
+++ b/src/internals/testing/helpers.spec.ts
@@ -89,3 +89,16 @@ export function suppressResizeObserverLoopError(): void {
     return errorHandler ? errorHandler(message, ...args) : false;
   };
 }
+
+/**
+ * Axe options for components that publish required ARIA relations
+ * (e.g. `aria-controls` on a `combobox`) through ARIA element reflection.
+ *
+ * Reflection blanks the content attribute axe reads, so axe reports the
+ * relation as missing and trips `aria-required-attr`. Specs using this must
+ * assert the real relation by identity readback instead
+ * (e.g. `input.ariaControlsElements[0] === list`).
+ */
+export const axeReflectedRelationsOptions = {
+  ignoredRules: ['aria-required-attr'],
+};


### PR DESCRIPTION
## Description

Shadow DOM breaks two things ARIA depends on: the identity of the focused element (delegated focus lands on the native editor inside the input's shadow root, not the host holding the semantics) and IDREF resolution (a reference cannot cross a shadow boundary). Select, combo and the date pickers each worked around this ad hoc, and select's combobox semantics were published on an element assistive technology never reports on.

Replace the per-component workarounds with shared infrastructure:

- ARIA projection controller pair (`addAriaProjector`/`addAriaTarget`): composite hosts declaratively project role, popup state and relations onto the native editor of their inner input component. Relations travel as ARIA element references, which resolve across shadow boundaries, and the resolved bindings are applied with a single `ariaBindings()` element-expression directive. References are re-asserted every render — the browser drops them when assigned to a detached element (lit's first render commits inside the template fragment).
- External label forwarding is folded into the same channel, replacing three copy-pasted implementations; textarea previously did not forward host labels at all.
- `internalsOf()` registry lookup so internal code reaches a component's internals controller without `@hidden @internal` public members; `_ariaProperties`, `_labelElements` and `_labelTarget` are deleted.
- `reflectRole` option on the internals controller centralizes the "axe only reads content attributes" workaround, removing the seven manual `this.role` assignments.
- Both date pickers now project `describedBy` onto their editors, fixing a dead helper-text association. Combo's wrapper-level attributes move onto the native input (`aria-owns` dropped, `aria-haspopup="listbox"` added) and its clear icon gets `role="button"` (axe `aria-prohibited-attr`).
- The input themes keyed styling off the removed host ARIA attributes; the projected role/haspopup are mirrored as `data-role`/ `data-haspopup` styling hooks and the selectors renamed 1:1.
- Shared `runAriaProjectionTests`/`runExternalLabelAssociationTests` suites and the `axeReflectedRelationsOptions` suppression for the known `aria-required-attr` false positive on reflected relations.

The coding guidelines and the LLM skills document the new contract.

## Type of Change

- [x] Refactoring (code improvements without functional changes)


## Checklist

<!-- Remove items that don't apply -->

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
