### PR TITLE
fix(forms): overhaul validation lifecycle of the form-associated mixins

### DIFF
--- a/src/components/checkbox/checkbox.spec.ts
+++ b/src/components/checkbox/checkbox.spec.ts
@@ -245,6 +245,19 @@ describe('Checkbox', () => {
       expect(spec.element.checked).to.be.true;
     });
 
+    it('syncs the native input checked state after form reset', async () => {
+      // Regression: the old restore path recorded the wrong reactive property
+      // (`value` instead of `checked`) for the reset update cycle.
+      spec.setProperties({ checked: true });
+      await elementUpdated(spec.element);
+
+      spec.reset();
+      await elementUpdated(spec.element);
+
+      const input = spec.element.renderRoot.querySelector('input')!;
+      expect(input.checked).to.be.false;
+    });
+
     it('is correctly submitted on pressing Enter', () => {
       expect(
         spec.submitWithEnter(spec.element.renderRoot.querySelector('input'))

--- a/src/components/combo/combo.ts
+++ b/src/components/combo/combo.ts
@@ -655,11 +655,6 @@ export default class IgcComboComponent<
 
   // #region Form Associated overrides
 
-  protected override _restoreDefaultValue(): void {
-    super._restoreDefaultValue();
-    this._syncSelectionFromValue();
-  }
-
   protected override _setDefaultValue(current: string | null): void {
     try {
       this.defaultValue = JSON.parse(current || '[]');

--- a/src/components/date-picker/date-picker-form.spec.ts
+++ b/src/components/date-picker/date-picker-form.spec.ts
@@ -82,6 +82,34 @@ describe('igc-datepicker form integration', () => {
       spec.assertSubmitHasValue(today.native.toISOString());
     });
 
+    it('should clear the invalid styles of the inner editor on form reset', async () => {
+      // Regression: the inner editor is not associated with the outer form
+      // and runs its own constraint validation against the forwarded
+      // `required`, so a focus + blur before a reset left it touched and
+      // permanently styled as invalid.
+      spec.setProperties({ required: true });
+
+      const inner = spec.element.renderRoot.querySelector(
+        IgcDateTimeInputComponent.tagName
+      )!;
+      const native = inner.renderRoot.querySelector('input')!;
+
+      native.focus();
+      native.blur();
+      await elementUpdated(spec.element);
+      await elementUpdated(inner);
+
+      expect(spec.element.matches(':state(ig-invalid)')).to.be.true;
+      expect(inner.matches(':state(ig-invalid)')).to.be.true;
+
+      spec.reset();
+      await elementUpdated(spec.element);
+      await elementUpdated(inner);
+
+      expect(spec.element.matches(':state(ig-invalid)')).to.be.false;
+      expect(inner.matches(':state(ig-invalid)')).to.be.false;
+    });
+
     it('should submit on pressing Enter when value is valid', () => {
       spec.setProperties({ value: today.native });
       expect(

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -356,6 +356,22 @@ export default class IgcDatePickerComponent extends EventEmitterMixin<
 
   //#endregion
 
+  //#region Form associated overrides
+
+  protected override formResetCallback(): void {
+    super.formResetCallback();
+
+    // The inner editor is not associated with the outer form (shadow
+    // boundary), so the browser never resets it. Since it runs its own
+    // constraint validation against the forwarded `required`/`min`/`max`,
+    // a touched editor would otherwise keep its invalid styles after the
+    // form reset.
+    // biome-ignore lint/complexity/useLiteralKeys: Reset the internal validation state of the editor
+    this._input?.['formResetCallback']();
+  }
+
+  //#endregion
+
   //#region Public methods
 
   /** Increments the passed in date part */

--- a/src/components/date-range-picker/date-range-picker-single.form.spec.ts
+++ b/src/components/date-range-picker/date-range-picker-single.form.spec.ts
@@ -58,6 +58,22 @@ describe('Date Range Picker Single Input - Form integration', () => {
       spec.assertSubmitHasKeyValue('rangePicker', null);
     });
 
+    it('should report the required message for a partial out-of-bounds range', async () => {
+      // Regression: a partial range below `min` fails both the required and
+      // the min validators - the reported message must match the
+      // `valueMissing` flag instead of coming from the min validator.
+      spec.setProperties({
+        required: true,
+        min: today.native,
+        value: { start: today.add('day', -5).native, end: null },
+      });
+      await elementUpdated(spec.element);
+
+      expect(spec.element.validity.valueMissing).to.be.true;
+      expect(spec.element.validity.rangeUnderflow).to.be.false;
+      expect(spec.element.validationMessage).to.equal('This field is required');
+    });
+
     it('is correctly reset on form reset', async () => {
       const initial = spec.element.value;
 

--- a/src/components/file-input/file-input.spec.ts
+++ b/src/components/file-input/file-input.spec.ts
@@ -247,6 +247,16 @@ describe('Form Integration', () => {
     expect(spec.element.value).to.be.empty;
   });
 
+  it('ignores the value attribute as a default on form reset', () => {
+    // Regression: the value attribute string used to be stored as the
+    // FileList default and iterated into per-character FormData entries
+    // after a form reset.
+    spec.element.setAttribute('value', 'abc');
+    spec.reset();
+
+    expect(spec.formData.getAll(spec.element.name)).to.eql([]);
+  });
+
   it('reflects disabled ancestor state', () => {
     spec.setAncestorDisabledState(true);
     expect(spec.element.disabled).to.be.true;

--- a/src/components/file-input/file-input.ts
+++ b/src/components/file-input/file-input.ts
@@ -205,11 +205,25 @@ export default class IgcFileInputComponent extends EventEmitterMixin<
 
   //#region Internal methods
 
+  /**
+   * A file input cannot have a default file list, so the `value` attribute
+   * never contributes a default - otherwise its string would be stored as the
+   * FileList default and submitted character-by-character after a form reset.
+   */
+  protected override _setDefaultValue(): void {
+    this._formValue.defaultValue = null;
+  }
+
+  /**
+   * Restores directly instead of through the `value` setter: the setter is
+   * deliberately inert (read-only semantics) and never updates the form state.
+   */
   protected override _restoreDefaultValue(): void {
     if (this._input) {
       this._input.value = '';
     }
-    super._restoreDefaultValue();
+    this._formValue.setValueAndFormState(this._formValue.defaultValue);
+    this.requestUpdate();
   }
 
   //#endregion

--- a/src/components/mask-input/mask-input.spec.ts
+++ b/src/components/mask-input/mask-input.spec.ts
@@ -1062,6 +1062,28 @@ describe('Masked input', () => {
       spec.assertSubmitHasValue(spec.element.value);
     });
 
+    it('refreshes the rendered masked value after form reset', async () => {
+      // Regression: the old restore path never requested an update, leaving
+      // the rendered masked value stale after a reset while valid.
+      const bed = createFormAssociatedTestBed<IgcMaskInputComponent>(
+        html`<igc-mask-input
+          name="masked"
+          mask="(CC) (CC)"
+          value="1234"
+        ></igc-mask-input>`
+      );
+      await bed.setup(IgcMaskInputComponent.tagName);
+      const input = bed.element.renderRoot.querySelector('input')!;
+
+      bed.setProperties({ value: '9999' });
+      await elementUpdated(bed.element);
+      expect(input.value).to.equal('(99) (99)');
+
+      bed.reset();
+      await elementUpdated(bed.element);
+      expect(input.value).to.equal('(12) (34)');
+    });
+
     it('reflects disabled ancestor state', () => {
       spec.setAncestorDisabledState(true);
       expect(spec.element.disabled).to.be.true;

--- a/src/components/mask-input/mask-input.ts
+++ b/src/components/mask-input/mask-input.ts
@@ -222,14 +222,6 @@ export default class IgcMaskInputComponent extends MaskBehaviorMixin(
 
   //#region Internal methods
 
-  protected override _restoreDefaultValue(): void {
-    const value = this.defaultValue as string;
-
-    this._maskedValue = this._parser.apply(value);
-    this._updateMaskedValue();
-    this._formValue.setValueAndFormState(value);
-  }
-
   /**
    * Commits straight to the form value instead of going through the `value` setter: the
    * setter re-applies the parser, and `apply(parse(x))` left-packs the text - a mask with

--- a/src/components/radio/radio.spec.ts
+++ b/src/components/radio/radio.spec.ts
@@ -283,6 +283,21 @@ describe('Radio Component', () => {
       spec.assertSubmitHasValue(lastOf(radios).value);
     });
 
+    it('should not restore a checked state whose attribute was removed before reset', () => {
+      // Regression: removing the `checked` attribute used to leave
+      // `defaultChecked` as true, re-checking the radio on form reset.
+      const radio = firstOf(radios);
+
+      radio.toggleAttribute('checked', true);
+      expect(radio.checked).to.be.true;
+
+      radio.removeAttribute('checked');
+      expect(radio.checked).to.be.false;
+
+      spec.reset();
+      expect(radio.checked).to.be.false;
+    });
+
     it('is correctly submitted on pressing Enter', () => {
       expect(
         spec.submitWithEnter(spec.element.renderRoot.querySelector('input'))
@@ -360,6 +375,20 @@ describe('Radio Component', () => {
         spec.reset();
 
         expect(spec.element.checked).to.be.true;
+      });
+
+      it('preserves sibling pristine state on form reset', () => {
+        lastOf(radios).checked = true;
+        spec.reset();
+
+        expect(radios.filter((radio) => radio.checked)).to.eql([
+          firstOf(radios),
+        ]);
+
+        // All radios are pristine again after the reset, so reassigning a
+        // default must sync the live checked state.
+        lastOf(radios).defaultChecked = true;
+        expect(lastOf(radios).checked).to.be.true;
       });
     });
   });

--- a/src/components/radio/radio.ts
+++ b/src/components/radio/radio.ts
@@ -22,7 +22,7 @@ import { isEmpty, lastOf } from '#internals/utils/arrays.js';
 import { isLTR } from '#internals/utils/dom.js';
 import { wrap } from '#internals/utils/math.js';
 import { createIdGenerator } from '#internals/utils/strings.js';
-import { isDefined } from '#internals/utils/types.js';
+import { isString } from '#internals/utils/types.js';
 import { addThemingController } from '#theming/theming-controller.js';
 import type { ToggleLabelPosition } from '../types.js';
 import IgcValidationContainerComponent from '../validation-container/validation-container.js';
@@ -215,10 +215,25 @@ export default class IgcRadioComponent extends FormAssociatedCheckboxRequiredMix
   }
 
   protected override _setDefaultValue(current: string | null): void {
-    this._formValue.defaultValue = isDefined(current);
+    // The base mixin passes 'true' when the `checked` attribute is present and
+    // null when it is removed - `isString` mirrors that contract (`isDefined`
+    // would treat null as present and re-check the radio on form reset).
+    this._formValue.defaultValue = isString(current);
     for (const radio of this._siblings) {
       radio.defaultChecked = false;
     }
+  }
+
+  /**
+   * Restores the default state directly instead of through the `checked`
+   * setter: setting `checked` to true unchecks all siblings, which would
+   * corrupt the pristine state of radios the browser has already reset
+   * during the same `form.reset()` pass.
+   */
+  protected override _restoreDefaultValue(): void {
+    const checked = this.checked;
+    this._formValue.setValueAndFormState(this.defaultChecked);
+    this.requestUpdate('checked', checked);
   }
 
   /** Simulates a click on the radio control. */
@@ -271,6 +286,7 @@ export default class IgcRadioComponent extends FormAssociatedCheckboxRequiredMix
   public override setCustomValidity(message: string): void {
     for (const radio of this._radios) {
       radio._validate(message);
+      radio.requestUpdate();
     }
   }
 

--- a/src/components/rating/rating.spec.ts
+++ b/src/components/rating/rating.spec.ts
@@ -528,6 +528,17 @@ describe('Rating component', () => {
       spec.assertSubmitHasValue(spec.element.value.toString());
     });
 
+    it('should clamp an out-of-range default value on form reset', () => {
+      // Regression: reset used to restore the raw default, bypassing the
+      // value setter clamping and reporting aria-valuenow beyond max.
+      spec.setAttributes({ value: 10 });
+      spec.setProperties({ value: 1 });
+      spec.reset();
+
+      expect(spec.element.value).to.equal(5);
+      spec.assertSubmitHasValue('5');
+    });
+
     it('reflects disabled ancestor state', () => {
       spec.setAncestorDisabledState(true);
       expect(spec.element.disabled).to.be.true;

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -551,13 +551,6 @@ export default class IgcSelectComponent extends FormAssociatedRequiredMixin(
 
   //#region Internal API
 
-  protected override _restoreDefaultValue(): void {
-    super._restoreDefaultValue();
-    this._formValue.setValueAndFormState(this._formValue.defaultValue);
-    const item = this._getItem(this._formValue.value!);
-    item ? this._setSelectedItem(item) : this._clearSelectedItem();
-  }
-
   private _activateItem(item: IgcSelectItemComponent | null): void {
     if (this._activeItem && this._activeItem !== item) {
       this._activeItem.active = false;

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -1137,6 +1137,17 @@ describe('Slider component', () => {
       spec.assertSubmitHasValue(spec.element.value.toString());
     });
 
+    it('should clamp an out-of-range default value on form reset', () => {
+      // Regression: reset used to restore the raw default, bypassing the
+      // value setter clamping and rendering an out-of-bounds track.
+      spec.setAttributes({ value: 200 });
+      spec.setProperties({ value: 50 });
+      spec.reset();
+
+      expect(spec.element.value).to.equal(100);
+      spec.assertSubmitHasValue('100');
+    });
+
     it('reflects disabled ancestor state', () => {
       spec.setAncestorDisabledState(true);
       expect(spec.element.disabled).to.be.true;

--- a/src/internals/mixins/form-associated.spec.ts
+++ b/src/internals/mixins/form-associated.spec.ts
@@ -16,9 +16,10 @@ import {
 } from '../validators.js';
 import { FormAssociatedRequiredMixin } from './forms/associated-required.js';
 import { createFormValueState } from './forms/form-value.js';
-import type {
-  FormAssociatedElementInterface,
-  FormRequiredInterface,
+import {
+  type FormAssociatedElementInterface,
+  type FormRequiredInterface,
+  InternalInvalidEvent,
 } from './forms/types.js';
 
 type FormAssociatedTestProps = {
@@ -26,6 +27,7 @@ type FormAssociatedTestProps = {
   required?: boolean;
   minLength?: number;
   maxLength?: number;
+  alwaysFailingValidator?: boolean;
 };
 
 type FormAssociatedTestInstance = LitElement &
@@ -48,8 +50,24 @@ describe('Form associated mixin tests', () => {
           maxLength: { type: Number },
         };
 
+        public alwaysFailingValidator = false;
+
         protected override get __validators(): Validator<this>[] {
-          return [requiredValidator, minLengthValidator, maxLengthValidator];
+          const validators: Validator<this>[] = [
+            requiredValidator,
+            minLengthValidator,
+            maxLengthValidator,
+          ];
+
+          if (this.alwaysFailingValidator) {
+            validators.push({
+              key: 'badInput',
+              message: 'Always failing',
+              isValid: () => false,
+            });
+          }
+
+          return validators;
         }
 
         protected override _formValue = createFormValueState(this, {
@@ -105,6 +123,41 @@ describe('Form associated mixin tests', () => {
     );
   }
 
+  let form: HTMLFormElement;
+  let submitEvents = 0;
+  let internalInvalidEvents = 0;
+
+  async function createFormFixture(props?: FormAssociatedTestProps) {
+    form = await fixture(
+      html`<form>
+        <${tagName}
+          name="test"
+          ?required=${props?.required}
+          value=${ifDefined(props?.value)}>
+        </${tagName}>
+      </form>`
+    );
+    instance = form.querySelector<FormAssociatedTestInstance>(tag)!;
+
+    submitEvents = 0;
+    internalInvalidEvents = 0;
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      submitEvents++;
+    });
+    instance.addEventListener(InternalInvalidEvent, () => {
+      internalInvalidEvents++;
+    });
+  }
+
+  /** Requests a form submission and returns whether it went through. */
+  function requestSubmit(): boolean {
+    const count = submitEvents;
+    form.requestSubmit();
+    return submitEvents > count;
+  }
+
   it('initial valid state when no constraints', async () => {
     await createFixture({ value: '123' });
     expect(instance.checkValidity()).to.be.true;
@@ -147,6 +200,86 @@ describe('Form associated mixin tests', () => {
     expect(instance.checkValidity()).to.be.true;
     expect(hasValidityFlags(instance, 'valid')).to.be.true;
     expect(instance.validationMessage).to.not.equal(message);
+  });
+
+  it('setCustomValidity("") does not swallow the next failed submission', async () => {
+    // Regression: clearing a custom message used to latch the internal
+    // validation flag, so the `invalid` event of the next form submission was
+    // misclassified as internal - no touched state, no internal invalid event,
+    // no invalid styles.
+    await createFormFixture({ required: true });
+
+    instance.setCustomValidity('Custom');
+    instance.setCustomValidity('');
+
+    const submitted = requestSubmit();
+
+    expect(submitted).to.be.false;
+    expect(internalInvalidEvents).to.equal(1);
+    expect(instance.matches(':state(ig-invalid)')).to.be.true;
+  });
+
+  it('form reset clears a developer-set invalid state', async () => {
+    await createFormFixture();
+
+    instance.invalid = true;
+    expect(instance.matches(':state(ig-invalid)')).to.be.true;
+
+    form.reset();
+
+    expect(instance.invalid).to.be.false;
+    expect(instance.matches(':state(ig-invalid)')).to.be.false;
+  });
+
+  it('moving the element in the DOM preserves touched state and invalid styles', async () => {
+    await createFormFixture({ required: true });
+
+    // Simulate a failed submission - the control becomes touched and shows
+    // invalid styles.
+    requestSubmit();
+    expect(instance.matches(':state(ig-invalid)')).to.be.true;
+
+    // Re-parent the control within the form (framework list reorder and the like).
+    const container = document.createElement('div');
+    form.appendChild(container);
+    container.appendChild(instance);
+    await instance.updateComplete;
+
+    expect(instance.matches(':state(ig-invalid)')).to.be.true;
+  });
+
+  it('pressing Enter in an invalid control surfaces validation feedback', async () => {
+    await createFormFixture({ required: true });
+
+    // biome-ignore lint/complexity/useLiteralKeys: Simulating the Enter key protected handler
+    instance['_handleEnterKeydown'](
+      new KeyboardEvent('keydown', { key: 'Enter' })
+    );
+
+    expect(submitEvents).to.equal(0);
+    expect(internalInvalidEvents).to.equal(1);
+    expect(instance.matches(':state(ig-invalid)')).to.be.true;
+
+    instance.value = '123';
+
+    // biome-ignore lint/complexity/useLiteralKeys: Simulating the Enter key protected handler
+    instance['_handleEnterKeydown'](
+      new KeyboardEvent('keydown', { key: 'Enter' })
+    );
+
+    expect(submitEvents).to.equal(1);
+  });
+
+  it('valueMissing reports the required validator message over later failing validators', async () => {
+    // Regression: the message of the last failing validator used to be kept
+    // even when the validity flags were collapsed to `valueMissing`.
+    await createFixture();
+    instance.alwaysFailingValidator = true;
+    instance.required = true;
+
+    expect(instance.checkValidity()).to.be.false;
+    expect(hasValidityFlags(instance, 'valueMissing')).to.be.true;
+    expect(instance.validationMessage).to.equal('This field is required');
   });
 
   it('setCustomValidity() + other constraints', async () => {

--- a/src/internals/mixins/forms/associated-required.ts
+++ b/src/internals/mixins/forms/associated-required.ts
@@ -6,19 +6,16 @@ import {
   FormAssociatedMixin,
 } from './associated.js';
 import type {
+  BaseFormAssociatedElement,
   FormAssociatedCheckboxElementInterface,
   FormAssociatedElementInterface,
   FormRequiredInterface,
 } from './types.js';
 
-/**
- * Mixes the passed class into a form associated custom element with an
- * additional `required` attribute.
- */
-export function FormAssociatedRequiredMixin<T extends Constructor<LitElement>>(
-  base: T
-) {
-  class FormAssociatedRequiredElement extends FormAssociatedMixin(base) {
+function BaseFormAssociatedRequired<
+  T extends Constructor<BaseFormAssociatedElement & LitElement>,
+>(base: T) {
+  class BaseFormAssociatedRequiredElement extends base {
     protected _required = false;
 
     /**
@@ -36,6 +33,20 @@ export function FormAssociatedRequiredMixin<T extends Constructor<LitElement>>(
       return this._required;
     }
   }
+
+  return BaseFormAssociatedRequiredElement;
+}
+
+/**
+ * Mixes the passed class into a form associated custom element with an
+ * additional `required` attribute.
+ */
+export function FormAssociatedRequiredMixin<T extends Constructor<LitElement>>(
+  base: T
+) {
+  class FormAssociatedRequiredElement extends BaseFormAssociatedRequired(
+    FormAssociatedMixin(base)
+  ) {}
 
   return FormAssociatedRequiredElement as unknown as Constructor<
     FormRequiredInterface & FormAssociatedElementInterface
@@ -50,28 +61,11 @@ export function FormAssociatedRequiredMixin<T extends Constructor<LitElement>>(
 export function FormAssociatedCheckboxRequiredMixin<
   T extends Constructor<LitElement>,
 >(base: T) {
-  class FormAssociatedRequiredElement extends FormAssociatedCheckboxMixin(
-    base
-  ) {
-    protected _required = false;
+  class FormAssociatedCheckboxRequiredElement extends BaseFormAssociatedRequired(
+    FormAssociatedCheckboxMixin(base)
+  ) {}
 
-    /**
-     * When set, makes the component a required field for validation.
-     * @attr
-     * @default false
-     */
-    @property({ type: Boolean, reflect: true })
-    public set required(value: boolean) {
-      this._required = Boolean(value);
-      this._validate();
-    }
-
-    public get required(): boolean {
-      return this._required;
-    }
-  }
-
-  return FormAssociatedRequiredElement as unknown as Constructor<
+  return FormAssociatedCheckboxRequiredElement as unknown as Constructor<
     FormRequiredInterface & FormAssociatedCheckboxElementInterface
   > &
     T;

--- a/src/internals/mixins/forms/associated.ts
+++ b/src/internals/mixins/forms/associated.ts
@@ -104,6 +104,11 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
 
     /**
      * Sets the control into invalid state (visual state only).
+     *
+     * @remarks
+     * The property is not reflected back to the attribute. Reading it returns
+     * the effective visual state, so a touched control failing validation
+     * reads `true` even after assigning `false`.
      * @attr
      * @default false
      */
@@ -114,7 +119,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     }
 
     public get invalid(): boolean {
-      return this._isExternalInvalid || this._shouldApplyStyles;
+      return this._shouldApplyStyles;
     }
 
     /** Returns the HTMLFormElement associated with this element. */
@@ -154,8 +159,12 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     /** @internal */
     public override connectedCallback(): void {
       super.connectedCallback();
-      this._pristine = true;
-      this._touched = false;
+
+      if (!this.hasUpdated) {
+        this._pristine = true;
+        this._touched = false;
+      }
+
       this._validate();
     }
 
@@ -164,15 +173,11 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     //#region Enter key submission handling
 
     protected _handleEnterKeydown(event: KeyboardEvent): void {
-      if (event.key !== enterKey) return;
-      if (event.repeat) return;
-
-      const canSubmit =
-        this.form && (this.form.noValidate || this.checkValidity());
-
-      if (canSubmit) {
-        this.form?.requestSubmit();
+      if (event.key !== enterKey || event.repeat) {
+        return;
       }
+
+      this.form?.requestSubmit();
     }
 
     //#endregion
@@ -217,9 +222,8 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
       validity: ValidityStateFlags;
       message: string;
     } {
-      const validity: ValidityStateFlags = {};
+      let validity: ValidityStateFlags = {};
       let message = '';
-      let validationFailed = false;
 
       for (const validator of this.__validators) {
         const isValid = validator.isValid(this);
@@ -227,14 +231,16 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
         validity[validator.key] = !isValid;
 
         if (!isValid) {
-          validationFailed = true;
           message = isFunction(validator.message)
             ? validator.message(this)
             : validator.message;
+
+          if (validator.key === 'valueMissing') {
+            validity = { valueMissing: true };
+            break;
+          }
         }
       }
-
-      this._invalid = validationFailed;
 
       return { validity, message };
     }
@@ -244,16 +250,9 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
      */
     protected _validate(userMessage?: string): void {
       if (isServer) return;
-      let { validity, message } = this.__runValidators();
+      const { validity, message: validatorMessage } = this.__runValidators();
       const hasCustomError = this.validity.customError;
-
-      // valueMissing has precedence over the other validators aside from customError
-      if (validity.valueMissing) {
-        validity = {
-          valueMissing: true,
-          customError: hasCustomError,
-        };
-      }
+      let message = validatorMessage;
 
       if (hasCustomError && userMessage === undefined) {
         // Internal validation cycle after the user has called setCustomValidity()
@@ -282,9 +281,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
     }
 
     protected _setTouchedState(): void {
-      if (!this._touched) {
-        this._touched = true;
-      }
+      this._touched = true;
     }
 
     protected _setDefaultValue(current: string | null): void {
@@ -301,8 +298,9 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
       this._pristine = false;
       this._internals.setFormValue(value, state);
       this._validate();
-      this._setInvalidStyles();
     }
+
+    //#endregion
 
     //#region Form associated callback hooks
 
@@ -319,6 +317,7 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
       this._pristine = true;
       this._touched = false;
       this._invalid = false;
+      this._isExternalInvalid = false;
       this._setInvalidStyles();
       emitFormResetEvent(this);
     }
@@ -355,8 +354,6 @@ function BaseFormAssociated<T extends Constructor<LitElement>>(base: T) {
      */
     public setCustomValidity(message: string): void {
       this._validate(message);
-      this._isInternalValidation = message === '';
-      this._setInvalidStyles();
       this.requestUpdate();
     }
 
@@ -387,6 +384,20 @@ export function FormAssociatedMixin<T extends Constructor<LitElement>>(
 
     public get defaultValue(): unknown {
       return this._formValue.defaultValue;
+    }
+
+    /**
+     * Restores the default value through the public `value` setter so any
+     * clamping/normalization the component applies (slider bounds, rating max)
+     * also applies on form reset, and the correct reactive property is
+     * recorded for the update cycle.
+     */
+    protected override _restoreDefaultValue(): void {
+      if ('value' in this) {
+        this.value = this.defaultValue;
+      } else {
+        super._restoreDefaultValue();
+      }
     }
 
     public override attributeChangedCallback(
@@ -426,6 +437,18 @@ export function FormAssociatedCheckboxMixin<T extends Constructor<LitElement>>(
 
     public get defaultChecked(): boolean {
       return this._formValue.defaultValue as boolean;
+    }
+
+    /**
+     * Restores the default checked state through the public `checked` setter
+     * so the correct reactive property is recorded for the update cycle.
+     */
+    protected override _restoreDefaultValue(): void {
+      if ('checked' in this) {
+        this.checked = this.defaultChecked;
+      } else {
+        super._restoreDefaultValue();
+      }
     }
 
     public override attributeChangedCallback(

--- a/src/internals/mixins/forms/types.ts
+++ b/src/internals/mixins/forms/types.ts
@@ -7,7 +7,7 @@ export type FormValueType = string | File | FormData | null;
 export type IgcFormControl = LitElement &
   (FormAssociatedElementInterface | FormAssociatedCheckboxElementInterface);
 
-declare class BaseFormAssociatedElement {
+export declare class BaseFormAssociatedElement {
   public static readonly formAssociated: boolean;
 
   //#region Properties


### PR DESCRIPTION
## Description

- Keep setCustomValidity('') from swallowing the next failed submission
- Submit on Enter through form.requestSubmit() for native-like feedback
- Preserve pristine/touched state when a control is moved in the DOM
- Report the required validator's message when valueMissing is set
- Clear developer-set invalid state on form reset
- Restore defaults through the public value/checked setters so component clamping applies and the correct reactive property is recorded
- Ignore the value attribute as a file-input default and keep removed checked attributes from re-checking radios on reset
- Reset the date picker's inner editor validation state on form reset
- Deduplicate the required mixins and drop dead/redundant code

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
