### PR TITLE
fix(chat): adopt document styles injected after the initial adoption (#2328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Time only date strings are resolved against the current local date rather than the UTC one, which shifted the parsed date by a day near midnight in some time zones.
   - Stale `week-start` resolution until a subsequent update fixed the view. Now `week-start` is correctly resolved and rendered on initial render.
   - Clamp keyboard navigation logic to a no-op when navigating over a large amount of disabled dates which could hang the browser.
+- #### Chat
+  - With `adoptRootStyles` enabled, stylesheets that entered the document after the initial adoption were ignored, so custom renderers whose styles are injected while the view is being created - Angular component styles, for instance - rendered unstyled content. The document stylesheets are now tracked while the option is on, and any addition or removal is reflected in the shadow roots that adopted them, including stylesheet links that finish loading later. [#2328](https://github.com/IgniteUI/igniteui-webcomponents/issues/2328)
+  - Adopting the document styles no longer discards the theme styles of the message and input parts, which were dropped from their shadow roots because the adoption rebuilt the stylesheet list from the component's static styles alone.
 - #### Form associated components
   - Validation messages no longer disappear right after the first failed form submission. The submit-driven invalid state used to hold only for the update the submission itself scheduled, so any re-render that followed - a `slotchange` from the validation slots the submission had just projected, for instance - silently dropped the projected messages while the invalid styling stayed on.
   - Invalid styling now follows the validity state, so a control that turns valid again (a cleared `required`, a widened `min`/`max`, a disabled control) drops the styles it picked up from an earlier interaction or submission.

--- a/src/components/chat/chat.spec.ts
+++ b/src/components/chat/chat.spec.ts
@@ -1079,16 +1079,20 @@ describe('Chat', () => {
       );
     }
 
+    const lateStyles = `
+      .custom-background {
+        color: rgb(0, 0, 255);
+      }
+    `;
+
     /** Mimics a custom renderer injecting global styles at a later point. */
-    function appendLateStyles() {
+    function appendLateStyles(cssText = lateStyles) {
       const styles = document.createElement('style');
       styles.setAttribute('id', 'adopt-styles-test-late');
-      styles.innerHTML = `
-        .custom-background {
-          color: rgb(0, 0, 255);
-        }
-      `;
+      styles.innerHTML = cssText;
       document.head.append(styles);
+
+      return styles;
     }
 
     beforeEach(async () => {
@@ -1110,6 +1114,7 @@ describe('Chat', () => {
     afterEach(() => {
       document.head.querySelector('#adopt-styles-test')?.remove();
       document.head.querySelector('#adopt-styles-test-late')?.remove();
+      document.head.querySelector('#adopt-styles-test-meta')?.remove();
     });
 
     it('correctly applies `adoptRootStyles` when set', async () => {
@@ -1191,6 +1196,43 @@ describe('Chat', () => {
       expect(getCustomStyles().color).to.not.equal('rgb(0, 0, 255)');
 
       appendLateStyles();
+      await nextFrame();
+
+      expect(getCustomStyles().color).to.equal('rgb(0, 0, 255)');
+    });
+
+    it('adopts a stylesheet which is appended empty and populated afterwards', async () => {
+      await createAdoptedStylesChat({ adoptRootStyles: true });
+      await elementUpdated(chat);
+
+      const styles = appendLateStyles('');
+      await nextFrame();
+
+      expect(getCustomStyles().color).to.not.equal('rgb(0, 0, 255)');
+
+      styles.textContent = lateStyles;
+      await nextFrame();
+
+      expect(getCustomStyles().color).to.equal('rgb(0, 0, 255)');
+    });
+
+    it('adopts a stylesheet populated through the CSSOM on the next synchronization', async () => {
+      await createAdoptedStylesChat({ adoptRootStyles: true });
+      await elementUpdated(chat);
+
+      const styles = appendLateStyles('');
+      await nextFrame();
+
+      // Inserting a rule through the CSSOM mutates no DOM and keeps the same
+      // stylesheet object, so it is only observable through a later change.
+      styles.sheet!.insertRule('.custom-background { color: rgb(0, 0, 255); }');
+      await nextFrame();
+
+      document.head.append(
+        Object.assign(document.createElement('meta'), {
+          id: 'adopt-styles-test-meta',
+        })
+      );
       await nextFrame();
 
       expect(getCustomStyles().color).to.equal('rgb(0, 0, 255)');

--- a/src/components/chat/chat.spec.ts
+++ b/src/components/chat/chat.spec.ts
@@ -1,4 +1,4 @@
-import { elementUpdated, expect, fixture } from '@open-wc/testing';
+import { elementUpdated, expect, fixture, nextFrame } from '@open-wc/testing';
 import { html, nothing } from 'lit';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { enterKey, tabKey } from '#internals/controllers/key-bindings.js';
@@ -1058,15 +1058,37 @@ describe('Chat', () => {
       `);
     }
 
-    function verifyCustomStyles(state: boolean) {
+    function getCustomStyles() {
       const { messages } = getChatDOM(chat);
-      const { backgroundColor } = getComputedStyle(
+
+      return getComputedStyle(
         getChatMessageDOM(firstOf(messages)).content.querySelector(
           '.custom-background'
         )!
       );
+    }
 
-      expect(backgroundColor === 'rgb(255, 0, 0)').to.equal(state);
+    function getMessageStyleSheets() {
+      const { messages } = getChatDOM(chat);
+      return firstOf(messages).shadowRoot!.adoptedStyleSheets;
+    }
+
+    function verifyCustomStyles(state: boolean) {
+      expect(getCustomStyles().backgroundColor === 'rgb(255, 0, 0)').to.equal(
+        state
+      );
+    }
+
+    /** Mimics a custom renderer injecting global styles at a later point. */
+    function appendLateStyles() {
+      const styles = document.createElement('style');
+      styles.setAttribute('id', 'adopt-styles-test-late');
+      styles.innerHTML = `
+        .custom-background {
+          color: rgb(0, 0, 255);
+        }
+      `;
+      document.head.append(styles);
     }
 
     beforeEach(async () => {
@@ -1087,6 +1109,7 @@ describe('Chat', () => {
 
     afterEach(() => {
       document.head.querySelector('#adopt-styles-test')?.remove();
+      document.head.querySelector('#adopt-styles-test-late')?.remove();
     });
 
     it('correctly applies `adoptRootStyles` when set', async () => {
@@ -1157,6 +1180,64 @@ describe('Chat', () => {
       // Toggle to true again
       chat.options = { ...chat.options, adoptRootStyles: true };
       await elementUpdated(chat);
+      verifyCustomStyles(true);
+    });
+
+    it('adopts stylesheets added to the document after the initial adoption', async () => {
+      await createAdoptedStylesChat({ adoptRootStyles: true });
+      await elementUpdated(chat);
+
+      verifyCustomStyles(true);
+      expect(getCustomStyles().color).to.not.equal('rgb(0, 0, 255)');
+
+      appendLateStyles();
+      await nextFrame();
+
+      expect(getCustomStyles().color).to.equal('rgb(0, 0, 255)');
+    });
+
+    it('removes adopted styles when their stylesheet is removed from the document', async () => {
+      await createAdoptedStylesChat({ adoptRootStyles: true });
+      await elementUpdated(chat);
+      verifyCustomStyles(true);
+
+      document.head.querySelector('#adopt-styles-test')!.remove();
+      await nextFrame();
+
+      verifyCustomStyles(false);
+    });
+
+    it('does not drop the component styles when adopting document styles', async () => {
+      await createAdoptedStylesChat({ adoptRootStyles: false });
+      await elementUpdated(chat);
+
+      const componentStyles = Array.from(getMessageStyleSheets());
+
+      await createAdoptedStylesChat({ adoptRootStyles: true });
+      await elementUpdated(chat);
+
+      const adopted = getMessageStyleSheets();
+
+      for (const sheet of componentStyles) {
+        expect(adopted.includes(sheet), 'component stylesheet was dropped').to
+          .be.true;
+      }
+      verifyCustomStyles(true);
+    });
+
+    it('re-adopts document styles when the host is reconnected', async () => {
+      await createAdoptedStylesChat({ adoptRootStyles: true });
+      await elementUpdated(chat);
+      verifyCustomStyles(true);
+
+      const parent = chat.parentElement!;
+
+      chat.remove();
+      await nextFrame();
+
+      parent.append(chat);
+      await elementUpdated(chat);
+
       verifyCustomStyles(true);
     });
   });

--- a/src/internals/controllers/adopt-styles.ts
+++ b/src/internals/controllers/adopt-styles.ts
@@ -41,7 +41,8 @@ function getCloneableRules(sheet: CSSStyleSheet): CSSRule[] {
  * The document is observed for as long as at least one controller is adopting styles,
  * so that stylesheets appearing after the initial adoption - such as the ones injected
  * at runtime by framework renderers - are picked up and pushed to the shadow roots
- * which have already adopted.
+ * which have already adopted. A stylesheet mutated in place, without entering or
+ * leaving the document, is not observable and needs an explicit {@link invalidate}.
  */
 class DocumentStyleSheets {
   //#region Instances
@@ -76,6 +77,19 @@ class DocumentStyleSheets {
   private _sheets: CSSStyleSheet[] = [];
   private _isStale = true;
 
+  /**
+   * The node under which stylesheets are expected to appear.
+   *
+   * Style injection targets the head by convention, so observing it keeps the browser
+   * from recording a mutation for every DOM change in the page. The fallbacks cover
+   * documents without a head, such as ones created through `DOMImplementation`.
+   */
+  private get _observedRoot(): Node {
+    return (
+      this._document.head ?? this._document.documentElement ?? this._document
+    );
+  }
+
   //#endregion
 
   //#region Public properties
@@ -103,7 +117,7 @@ class DocumentStyleSheets {
     this._consumers.add(consumer);
 
     if (this._consumers.size === 1) {
-      this._observer.observe(this._document, observerConfig);
+      this._observer.observe(this._observedRoot, observerConfig);
       this._document.addEventListener('load', this, { capture: true });
     }
   }
@@ -130,10 +144,15 @@ class DocumentStyleSheets {
    * Stylesheet links have no CSSOM representation at the time they are appended to
    * the document, so they are picked up when they finish loading.
    *
+   * The listener is capturing and document wide - it sees the load event of every
+   * resource - hence the check for an element which has just produced a stylesheet.
+   *
    * @internal
    */
   public handleEvent(event: Event): void {
-    if ((event.target as Node | null)?.nodeName === 'LINK') {
+    const target = event.target as Partial<HTMLLinkElement> | null;
+
+    if (target?.sheet) {
       this._synchronize();
     }
   }

--- a/src/internals/controllers/adopt-styles.ts
+++ b/src/internals/controllers/adopt-styles.ts
@@ -1,9 +1,367 @@
+import {
+  adoptStyles,
+  type LitElement,
+  type ReactiveController,
+  type ReactiveControllerHost,
+} from 'lit';
+
+const observerConfig: MutationObserverInit = { childList: true, subtree: true };
+
+/** Shallow identity comparison of two stylesheet collections. */
+function isSameCollection(
+  a: readonly CSSStyleSheet[],
+  b: readonly CSSStyleSheet[]
+): boolean {
+  return a.length === b.length && a.every((sheet, index) => sheet === b[index]);
+}
+
 /**
- * Reactive controller for adopting document-level styles into Shadow DOM.
+ * Returns the rules of a stylesheet which can be re-inserted in a constructable one.
  *
- * This controller enables web components to access and apply styles from the
- * document's stylesheets within their Shadow DOM, effectively bridging the
- * style encapsulation boundary when needed.
+ * Cross-origin stylesheets are not readable and yield no rules, as do `@import` rules,
+ * which cannot be inserted in a constructable stylesheet.
+ */
+function getCloneableRules(sheet: CSSStyleSheet): CSSRule[] {
+  try {
+    return Array.from(sheet.cssRules).filter(
+      (rule) => !(rule instanceof CSSImportRule)
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Tracks the stylesheets of a document and mirrors them as constructable stylesheets
+ * which can be adopted by shadow roots.
+ *
+ * A single instance per document is shared by all the {@link AdoptedStylesController}
+ * instances whose hosts belong to it.
+ *
+ * The document is observed for as long as at least one controller is adopting styles,
+ * so that stylesheets appearing after the initial adoption - such as the ones injected
+ * at runtime by framework renderers - are picked up and pushed to the shadow roots
+ * which have already adopted.
+ */
+class DocumentStyleSheets {
+  //#region Instances
+
+  private static readonly _instances = new WeakMap<
+    Document,
+    DocumentStyleSheets
+  >();
+
+  /** Returns the tracker of the given document, creating it if necessary. */
+  public static for(document: Document): DocumentStyleSheets {
+    let instance = DocumentStyleSheets._instances.get(document);
+
+    if (!instance) {
+      instance = new DocumentStyleSheets(document);
+      DocumentStyleSheets._instances.set(document, instance);
+    }
+
+    return instance;
+  }
+
+  //#endregion
+
+  //#region Internal state
+
+  private readonly _document: Document;
+  private readonly _observer: MutationObserver;
+  private readonly _consumers = new Set<AdoptedStylesController>();
+
+  private _clones = new WeakMap<CSSStyleSheet, CSSStyleSheet>();
+  private _sources: readonly CSSStyleSheet[] = [];
+  private _sheets: CSSStyleSheet[] = [];
+  private _isStale = true;
+
+  //#endregion
+
+  //#region Public properties
+
+  /** The clones of the document stylesheets. */
+  public get sheets(): CSSStyleSheet[] {
+    if (this._isStale) {
+      this._collect(Array.from(this._document.styleSheets));
+    }
+
+    return this._sheets;
+  }
+
+  //#endregion
+
+  constructor(document: Document) {
+    this._document = document;
+    this._observer = new MutationObserver(() => this._synchronize());
+  }
+
+  //#region Public API
+
+  /** Registers a consumer, starting the document observation if it is the first one. */
+  public subscribe(consumer: AdoptedStylesController): void {
+    this._consumers.add(consumer);
+
+    if (this._consumers.size === 1) {
+      this._observer.observe(this._document, observerConfig);
+      this._document.addEventListener('load', this, { capture: true });
+    }
+  }
+
+  /** Unregisters a consumer, stopping the document observation if it was the last one. */
+  public unsubscribe(consumer: AdoptedStylesController): void {
+    if (this._consumers.delete(consumer) && this._consumers.size === 0) {
+      this._observer.disconnect();
+      this._document.removeEventListener('load', this, { capture: true });
+    }
+  }
+
+  /** Drops the cloned stylesheets, forcing a re-clone on the next access. */
+  public invalidate(): void {
+    this._clones = new WeakMap();
+    this._isStale = true;
+  }
+
+  //#endregion
+
+  //#region Event handling
+
+  /**
+   * Stylesheet links have no CSSOM representation at the time they are appended to
+   * the document, so they are picked up when they finish loading.
+   *
+   * @internal
+   */
+  public handleEvent(event: Event): void {
+    if ((event.target as Node | null)?.nodeName === 'LINK') {
+      this._synchronize();
+    }
+  }
+
+  //#endregion
+
+  //#region Internal methods
+
+  /** Re-clones the document stylesheets and notifies the consumers if they have changed. */
+  private _synchronize(): void {
+    const sources = Array.from(this._document.styleSheets);
+
+    if (!this._isStale && isSameCollection(sources, this._sources)) {
+      return;
+    }
+
+    this._collect(sources);
+
+    for (const consumer of this._consumers) {
+      consumer.updateAdoptedStyles();
+    }
+  }
+
+  private _collect(sources: readonly CSSStyleSheet[]): void {
+    const sheets: CSSStyleSheet[] = [];
+
+    for (const source of sources) {
+      const clone = this._clone(source);
+
+      if (clone) {
+        sheets.push(clone);
+      }
+    }
+
+    this._sources = sources;
+    this._sheets = sheets;
+    this._isStale = false;
+  }
+
+  /**
+   * Clones the given stylesheet into a constructable one, keeping the rules in their
+   * original order. Rules which cannot be inserted, such as ones with invalid syntax,
+   * are skipped.
+   *
+   * Empty results are not cached, so that stylesheets populated at a later point are
+   * eventually picked up.
+   *
+   * @returns The cloned stylesheet or null when there is nothing to clone.
+   */
+  private _clone(sheet: CSSStyleSheet): CSSStyleSheet | null {
+    const cached = this._clones.get(sheet);
+
+    if (cached) {
+      return cached;
+    }
+
+    const rules = getCloneableRules(sheet);
+
+    if (rules.length === 0) {
+      return null;
+    }
+
+    const clone = new CSSStyleSheet();
+
+    for (const rule of rules) {
+      try {
+        clone.insertRule(rule.cssText, clone.cssRules.length);
+      } catch {
+        // Skip rules that cannot be cloned
+      }
+    }
+
+    if (clone.cssRules.length === 0) {
+      return null;
+    }
+
+    this._clones.set(sheet, clone);
+    return clone;
+  }
+
+  //#endregion
+}
+
+/**
+ * Reactive controller which adopts the document stylesheets into the shadow root of
+ * its host, effectively bridging the style encapsulation boundary when needed.
+ *
+ * The document is tracked for as long as the styles are adopted, so stylesheets added
+ * to or removed from it afterwards are reflected in the shadow root as well. Only the
+ * stylesheets the controller itself adopted are ever removed - the styles of the
+ * component and of its theme are left intact.
+ */
+class AdoptedStylesController implements ReactiveController {
+  //#region Internal state
+
+  private readonly _host: ReactiveControllerHost & LitElement;
+
+  private _adoptedSheets: readonly CSSStyleSheet[] = [];
+  private _shouldAdopt = false;
+  private _hasAdoptedStyles = false;
+
+  private get _documentStyles(): DocumentStyleSheets {
+    return DocumentStyleSheets.for(this._host.ownerDocument);
+  }
+
+  //#endregion
+
+  //#region Public properties
+
+  /** Whether the document styles are adopted in the host's shadow root. */
+  public get hasAdoptedStyles(): boolean {
+    return this._hasAdoptedStyles;
+  }
+
+  //#endregion
+
+  constructor(host: ReactiveControllerHost & LitElement) {
+    this._host = host;
+    host.addController(this);
+  }
+
+  //#region ReactiveController implementation
+
+  /**
+   * Restores the styles cleared on the previous disconnect.
+   * @internal
+   */
+  public hostConnected(): void {
+    this.updateAdoptedStyles();
+  }
+
+  /**
+   * Clears the adopted styles to prevent memory leaks.
+   * @internal
+   */
+  public hostDisconnected(): void {
+    this._clearAdoptedStyles();
+  }
+
+  //#endregion
+
+  //#region Public API
+
+  /**
+   * Adopts or clears the document styles based on the passed condition.
+   *
+   * @example
+   * ```typescript
+   * this._adoptedStyles.shouldAdoptStyles(this.options?.adoptRootStyles);
+   * ```
+   */
+  public shouldAdoptStyles(condition: boolean): void {
+    this._shouldAdopt = condition;
+    condition ? this._adoptRootStyles() : this._clearAdoptedStyles();
+  }
+
+  /**
+   * Invalidates the cloned stylesheets of the given document, so that the next adoption
+   * re-clones them. Additions and removals are picked up on their own - this is meant for
+   * changes the document cannot be observed for, such as a theme rewriting a stylesheet
+   * in place.
+   *
+   * @param doc - The document whose cache to invalidate. Defaults to the global document.
+   */
+  public invalidateCache(doc?: Document): void {
+    DocumentStyleSheets.for(doc ?? document).invalidate();
+  }
+
+  /**
+   * Re-adopts the document styles. Invoked when the tracked stylesheets change.
+   * @internal
+   */
+  public updateAdoptedStyles(): void {
+    if (this._shouldAdopt) {
+      this._adoptRootStyles();
+    }
+  }
+
+  //#endregion
+
+  //#region Internal methods
+
+  private _adoptRootStyles(): void {
+    const shadowRoot = this._host.shadowRoot;
+
+    if (!shadowRoot) {
+      return;
+    }
+
+    const documentStyles = this._documentStyles;
+    const sheets = documentStyles.sheets;
+
+    adoptStyles(shadowRoot, [...this._getHostSheets(shadowRoot), ...sheets]);
+
+    this._adoptedSheets = sheets;
+    this._hasAdoptedStyles = true;
+
+    documentStyles.subscribe(this);
+  }
+
+  private _clearAdoptedStyles(): void {
+    if (!this._hasAdoptedStyles) {
+      return;
+    }
+
+    const shadowRoot = this._host.shadowRoot;
+
+    if (shadowRoot) {
+      adoptStyles(shadowRoot, this._getHostSheets(shadowRoot));
+    }
+
+    this._adoptedSheets = [];
+    this._hasAdoptedStyles = false;
+    this._documentStyles.unsubscribe(this);
+  }
+
+  /** Returns the stylesheets of the shadow root which are not managed by this controller. */
+  private _getHostSheets(shadowRoot: ShadowRoot): CSSStyleSheet[] {
+    return shadowRoot.adoptedStyleSheets.filter(
+      (sheet) => !this._adoptedSheets.includes(sheet)
+    );
+  }
+
+  //#endregion
+}
+
+/**
+ * Creates and attaches an {@link AdoptedStylesController} to a Lit component.
  *
  * @example
  * ```typescript
@@ -15,197 +373,6 @@
  *       this._adoptedStyles.shouldAdoptStyles(this.shouldAdopt);
  *     }
  *     super.update(props);
- *   }
- * }
- * ```
- */
-
-import {
-  adoptStyles,
-  type LitElement,
-  type ReactiveController,
-  type ReactiveControllerHost,
-} from 'lit';
-
-/**
- * Controller that manages the adoption of document-level styles into a
- * component's Shadow DOM.
- *
- * This controller provides:
- * - Automatic caching of cloned stylesheets per document
- * - Efficient adoption and removal of document styles
- * - Cache invalidation for theme changes
- * - Automatic cleanup on component disconnection
- */
-class AdoptedStylesController implements ReactiveController {
-  private static _cachedSheets = new WeakMap<Document, CSSStyleSheet[]>();
-
-  private static _invalidateCache(doc: Document): void {
-    AdoptedStylesController._cachedSheets.delete(doc);
-  }
-
-  private readonly _host: ReactiveControllerHost & LitElement;
-  private _hasAdoptedStyles = false;
-
-  /**
-   * Indicates whether document styles have been adopted into the host's Shadow DOM.
-   */
-  public get hasAdoptedStyles(): boolean {
-    return this._hasAdoptedStyles;
-  }
-
-  constructor(host: ReactiveControllerHost & LitElement) {
-    this._host = host;
-    host.addController(this);
-  }
-
-  /**
-   * Conditionally adopts or clears document styles based on the provided condition.
-   *
-   * @param condition - If true, adopts document styles; if false, clears adopted styles
-   *
-   * @example
-   * ```typescript
-   * this._adoptedStyles.shouldAdoptStyles(this.options?.adoptRootStyles);
-   * ```
-   */
-  public shouldAdoptStyles(condition: boolean): void {
-    condition ? this._adoptRootStyles() : this._clearAdoptedStyles();
-  }
-
-  /**
-   * Invalidates the stylesheet cache for the specified document.
-   *
-   * This should be called when the document's stylesheets change (e.g., theme changes)
-   * to ensure the next adoption uses the updated styles.
-   *
-   * @param doc - The document whose cache to invalidate. Defaults to the global document.
-   *
-   * @example
-   * ```typescript
-   * // Invalidate cache on theme change
-   * this._adoptedStyles.invalidateCache(this.ownerDocument);
-   * ```
-   */
-  public invalidateCache(doc?: Document): void {
-    AdoptedStylesController._invalidateCache(doc ?? document);
-  }
-
-  /**
-   * Lifecycle callback invoked when the host component is disconnected.
-   * Automatically clears adopted styles to prevent memory leaks.
-   * @internal
-   */
-  public hostDisconnected(): void {
-    this._clearAdoptedStyles();
-  }
-
-  /**
-   * Adopts document-level styles into the host's Shadow DOM.
-   *
-   * This method:
-   * 1. Checks the cache for previously cloned stylesheets
-   * 2. Clones document stylesheets if not cached
-   * 3. Applies both component styles and cloned document styles to the Shadow Root
-   */
-  private _adoptRootStyles(): void {
-    const ownerDocument = this._host.ownerDocument;
-
-    if (!AdoptedStylesController._cachedSheets.has(ownerDocument)) {
-      AdoptedStylesController._cachedSheets.set(
-        ownerDocument,
-        this._cloneDocumentStyleSheets(ownerDocument)
-      );
-    }
-
-    const ctor = this._host.constructor as typeof LitElement;
-    adoptStyles(this._host.shadowRoot!, [
-      ...ctor.elementStyles,
-      ...AdoptedStylesController._cachedSheets.get(ownerDocument)!,
-    ]);
-    this._hasAdoptedStyles = true;
-  }
-
-  /**
-   * Removes previously adopted document styles from the Shadow DOM.
-   *
-   * Only removes stylesheets that were added by this controller, preserving
-   * the component's original styles.
-   */
-  private _clearAdoptedStyles(): void {
-    const shadowRoot = this._host.shadowRoot;
-    if (shadowRoot) {
-      shadowRoot.adoptedStyleSheets = shadowRoot.adoptedStyleSheets.filter(
-        (sheet) =>
-          !AdoptedStylesController._cachedSheets
-            .get(this._host.ownerDocument)
-            ?.includes(sheet)
-      );
-    }
-    this._hasAdoptedStyles = false;
-  }
-
-  /**
-   * Clones all accessible stylesheets from the document into constructable stylesheets.
-   *
-   * This method:
-   * - Iterates through all document stylesheets
-   * - Skips cross-origin stylesheets (CORS restrictions)
-   * - Skips @import rules (cannot be cloned into constructable stylesheets)
-   * - Creates new CSSStyleSheet instances with cloned rules
-   *
-   * @param ownerDocument - The document whose stylesheets should be cloned
-   * @returns An array of cloned CSSStyleSheet objects
-   */
-  private _cloneDocumentStyleSheets(ownerDocument: Document): CSSStyleSheet[] {
-    const sheets: CSSStyleSheet[] = [];
-
-    for (const sheet of ownerDocument.styleSheets) {
-      try {
-        const constructed = new CSSStyleSheet();
-        let hasRules = false;
-
-        for (const rule of sheet.cssRules) {
-          // Skip @import rules as they cannot be inserted into constructable stylesheets
-          if (rule instanceof CSSImportRule) {
-            continue;
-          }
-
-          try {
-            // insert last to keep rules/override order:
-            constructed.insertRule(rule.cssText, constructed.cssRules.length);
-            hasRules = true;
-          } catch {
-            // Skip rules that cannot be cloned (e.g., invalid syntax)
-          }
-        }
-
-        if (hasRules) {
-          sheets.push(constructed);
-        }
-      } catch {
-        // Skip stylesheets that cannot be accessed (e.g., cross-origin)
-      }
-    }
-
-    return sheets;
-  }
-}
-
-/**
- * Creates and attaches an AdoptedStylesController to a Lit component.
- *
- * @param host - The Lit component that will host the controller
- * @returns The created AdoptedStylesController instance
- *
- * @example
- * ```typescript
- * class MyComponent extends LitElement {
- *   private readonly _adoptedStyles = addAdoptedStylesController(this);
- *
- *   connectedCallback() {
- *     super.connectedCallback();
- *     this._adoptedStyles.shouldAdoptStyles(true);
  *   }
  * }
  * ```

--- a/src/internals/controllers/adopt-styles.ts
+++ b/src/internals/controllers/adopt-styles.ts
@@ -41,8 +41,8 @@ function getCloneableRules(sheet: CSSStyleSheet): CSSRule[] {
  * The document is observed for as long as at least one controller is adopting styles,
  * so that stylesheets appearing after the initial adoption - such as the ones injected
  * at runtime by framework renderers - are picked up and pushed to the shadow roots
- * which have already adopted. A stylesheet mutated in place, without entering or
- * leaving the document, is not observable and needs an explicit {@link invalidate}.
+ * which have already adopted. A stylesheet which has already been cloned is not read
+ * again - one rewritten in place needs an explicit {@link invalidate}.
  */
 class DocumentStyleSheets {
   //#region Instances
@@ -73,7 +73,6 @@ class DocumentStyleSheets {
   private readonly _consumers = new Set<AdoptedStylesController>();
 
   private _clones = new WeakMap<CSSStyleSheet, CSSStyleSheet>();
-  private _sources: readonly CSSStyleSheet[] = [];
   private _sheets: CSSStyleSheet[] = [];
   private _isStale = true;
 
@@ -97,7 +96,7 @@ class DocumentStyleSheets {
   /** The clones of the document stylesheets. */
   public get sheets(): CSSStyleSheet[] {
     if (this._isStale) {
-      this._collect(Array.from(this._document.styleSheets));
+      this._collect();
     }
 
     return this._sheets;
@@ -163,23 +162,27 @@ class DocumentStyleSheets {
 
   /** Re-clones the document stylesheets and notifies the consumers if they have changed. */
   private _synchronize(): void {
-    const sources = Array.from(this._document.styleSheets);
-
-    if (!this._isStale && isSameCollection(sources, this._sources)) {
-      return;
-    }
-
-    this._collect(sources);
-
-    for (const consumer of this._consumers) {
-      consumer.updateAdoptedStyles();
+    if (this._collect()) {
+      for (const consumer of this._consumers) {
+        consumer.updateAdoptedStyles();
+      }
     }
   }
 
-  private _collect(sources: readonly CSSStyleSheet[]): void {
+  /**
+   * Mirrors the stylesheets currently in the document.
+   *
+   * Change is decided on the clones rather than on the document collection, so that a
+   * stylesheet which yielded nothing before - an empty one, for instance - is re-read on
+   * every pass, while a change to the document which produces the same clones, such as
+   * an unreadable stylesheet being added, leaves the consumers alone.
+   *
+   * @returns Whether the mirrored collection has changed.
+   */
+  private _collect(): boolean {
     const sheets: CSSStyleSheet[] = [];
 
-    for (const source of sources) {
+    for (const source of this._document.styleSheets) {
       const clone = this._clone(source);
 
       if (clone) {
@@ -187,9 +190,14 @@ class DocumentStyleSheets {
       }
     }
 
-    this._sources = sources;
-    this._sheets = sheets;
     this._isStale = false;
+
+    if (isSameCollection(sheets, this._sheets)) {
+      return false;
+    }
+
+    this._sheets = sheets;
+    return true;
   }
 
   /**
@@ -197,8 +205,8 @@ class DocumentStyleSheets {
    * original order. Rules which cannot be inserted, such as ones with invalid syntax,
    * are skipped.
    *
-   * Empty results are not cached, so that stylesheets populated at a later point are
-   * eventually picked up.
+   * Nothing is cached for a stylesheet which yields no rules, so one that is appended
+   * empty and populated afterwards is picked up by a later pass.
    *
    * @returns The cloned stylesheet or null when there is nothing to clone.
    */


### PR DESCRIPTION
## Description

The document stylesheets were cloned once and cached forever, so styles a custom renderer injects while creating its view - Angular component styles, for instance - never reached the shadow root and their content rendered unstyled.

- Track the document while the styles are adopted and reflect additions, removals and links that finish loading later in the adopting shadow roots
- Memoize the clones per source stylesheet so incremental injections don't re-clone the whole document
- Keep the theme styles, which the adoption dropped by rebuilding the stylesheet list from the component's static styles alone
- Re-adopt on reconnect instead of staying cleared until an unrelated property changed

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
