### PR TITLE
fix(splitter): overhaul size resolution and collapse state

### DIFF
--- a/src/components/splitter/splitter.spec.ts
+++ b/src/components/splitter/splitter.spec.ts
@@ -3059,7 +3059,7 @@ describe('Splitter', () => {
 
   describe('Size and constraint values', () => {
     it('should reject values without an explicit unit', async () => {
-      for (const invalid of ['200', 'abc', 'calc(100% - 10px)', '']) {
+      for (const invalid of ['200', '1.5', 'abc', 'calc(100% - 10px)', '']) {
         splitter.startSize = invalid;
         splitter.startMinSize = invalid;
         await elementUpdated(splitter);
@@ -3067,6 +3067,29 @@ describe('Splitter', () => {
         expect(splitter.startSize, invalid).to.equal('auto');
         expect(splitter.startMinSize, invalid).to.be.undefined;
       }
+    });
+
+    it('should accept a unitless zero, the one length that needs no unit', async () => {
+      for (const zero of ['0', '0.0', '+0']) {
+        splitter.startSize = zero;
+        splitter.startMinSize = zero;
+        await elementUpdated(splitter);
+
+        expect(splitter.startSize, zero).to.equal(zero);
+        expect(splitter.startMinSize, zero).to.equal(zero);
+      }
+    });
+
+    it('should render a zero-sized pane for a unitless zero size', async () => {
+      splitter.startSize = '0';
+      await elementUpdated(splitter);
+
+      const startPane = getSplitterPart(splitter, START_PART);
+      expect(getComputedStyle(startPane).flex).to.equal('0 1 0px');
+
+      const sizes = getPanesSizes(splitter, 'width');
+      expect(sizes.startSize).to.equal(0);
+      expect(sizes.endSize).to.equal(getTotalSize(splitter, 'width'));
     });
 
     it('should resolve font-relative constraints against their computed pixel size', async () => {

--- a/src/components/splitter/splitter.spec.ts
+++ b/src/components/splitter/splitter.spec.ts
@@ -19,11 +19,12 @@ import { defineComponents } from '#internals/definitions/defineComponents.js';
 import { finishAnimationsFor } from '#internals/testing/helpers.spec.js';
 import {
   simulateKeyboard,
+  simulateLostPointerCapture,
   simulatePointerDown,
   simulatePointerMove,
   simulatePointerUp,
 } from '#internals/testing/simulate.spec.js';
-import { roundPrecise } from '#internals/utils/math.js';
+import { asPercent, roundPrecise } from '#internals/utils/math.js';
 import IgcTreeComponent from '../tree/tree.js';
 import IgcTreeItemComponent from '../tree/tree-item.js';
 import type { SplitterOrientation } from '../types.js';
@@ -64,6 +65,26 @@ describe('Splitter', () => {
 
       const bar = getSplitterPart(splitter, BAR_PART);
       expect(bar.getAttribute('role')).to.equal('separator');
+
+      // The name states what the separator does; the collapsed/expanded state
+      // is a description, so the name does not change as panes collapse.
+      const label = splitter.shadowRoot!.querySelector('#splitter-label')!;
+      const state = splitter.shadowRoot!.querySelector('#splitter-state')!;
+
+      expect(bar.getAttribute('aria-labelledby')).to.equal('splitter-label');
+      expect(bar.getAttribute('aria-describedby')).to.equal('splitter-state');
+      expect(label.textContent?.trim()).to.equal('Resize panes');
+      expect(state.textContent).to.contain('Start pane expanded');
+
+      expect(bar.getAttribute('aria-valuetext')).to.equal(
+        `${bar.getAttribute('aria-valuenow')}%`
+      );
+
+      splitter.toggle('start');
+      await elementUpdated(splitter);
+
+      expect(label.textContent?.trim()).to.equal('Resize panes');
+      expect(state.textContent).to.contain('Start pane collapsed');
     });
 
     it('should render both panes with equal sizes if no explicit sizes set', async () => {
@@ -403,6 +424,18 @@ describe('Splitter', () => {
       expect(splitter.startMinSize).to.be.undefined;
       expect(splitter.startMaxSize).to.be.undefined;
 
+      // The DOM must not keep asserting sizes the component no longer holds
+      for (const attribute of [
+        'start-size',
+        'start-min-size',
+        'start-max-size',
+        'end-size',
+        'end-min-size',
+        'end-max-size',
+      ]) {
+        expect(splitter.hasAttribute(attribute), attribute).to.be.false;
+      }
+
       expect(style.minHeight).to.equal('0px');
       expect(style.maxHeight).to.equal('100%');
       expect(style.minWidth).to.equal('0px');
@@ -724,10 +757,10 @@ describe('Splitter', () => {
       splitter.startSize = '200px';
       splitter.endSize = '30%';
       await elementUpdated(splitter);
-      const totalSize = getTotalSize(splitter, 'width');
+      const containerSize = getContainerSize(splitter, 'width');
 
       const { startSize: initialStart } = getPanesSizes(splitter, 'width');
-      const expectedStartPercent = `${roundPrecise((initialStart / totalSize) * 100, 2)}%`;
+      const expectedStartPercent = `${roundPrecise((initialStart / containerSize) * 100, 2)}%`;
 
       splitter.toggle('start');
       await elementUpdated(splitter);
@@ -741,7 +774,7 @@ describe('Splitter', () => {
       expect(splitter.startSize).to.equal(expectedStartPercent);
 
       const { endSize: currentEnd } = getPanesSizes(splitter, 'width');
-      const expectedEndPercent = `${roundPrecise((currentEnd / totalSize) * 100, 2)}%`;
+      const expectedEndPercent = `${roundPrecise((currentEnd / containerSize) * 100, 2)}%`;
 
       splitter.toggle('end');
       await elementUpdated(splitter);
@@ -837,13 +870,13 @@ describe('Splitter', () => {
 
     it('should emit igcLayoutChanged when a collapse/expand button is clicked', async () => {
       const eventSpy = spy(splitter, 'emitEvent');
-      const totalSize = getTotalSize(splitter, 'width');
+      const containerSize = getContainerSize(splitter, 'width');
       let parts = getButtonParts(splitter);
 
       let { startSize: preCollapseStart, endSize: preCollapseEnd } =
         getPanesSizes(splitter, 'width');
-      let expectedStartPercent = `${roundPrecise((preCollapseStart / totalSize) * 100, 2)}%`;
-      let expectedEndPercent = `${roundPrecise((preCollapseEnd / totalSize) * 100, 2)}%`;
+      let expectedStartPercent = `${roundPrecise((preCollapseStart / containerSize) * 100, 2)}%`;
+      let expectedEndPercent = `${roundPrecise((preCollapseEnd / containerSize) * 100, 2)}%`;
 
       simulatePointerDown(parts.startCollapseBtn, { bubbles: true });
       await elementUpdated(splitter);
@@ -883,8 +916,8 @@ describe('Splitter', () => {
         splitter,
         'width'
       ));
-      expectedStartPercent = `${roundPrecise((preCollapseStart / totalSize) * 100, 2)}%`;
-      expectedEndPercent = `${roundPrecise((preCollapseEnd / totalSize) * 100, 2)}%`;
+      expectedStartPercent = `${roundPrecise((preCollapseStart / containerSize) * 100, 2)}%`;
+      expectedEndPercent = `${roundPrecise((preCollapseEnd / containerSize) * 100, 2)}%`;
 
       simulatePointerDown(parts.endCollapseBtn, { bubbles: true });
       await elementUpdated(splitter);
@@ -1069,7 +1102,6 @@ describe('Splitter', () => {
       await elementUpdated(splitter);
 
       const bar = getSplitterPart(splitter, BAR_PART);
-      const barSize = bar.getBoundingClientRect().width;
       bar.focus();
       await elementUpdated(splitter);
 
@@ -1093,8 +1125,9 @@ describe('Splitter', () => {
       }
 
       currentSizes = getPanesSizes(splitter, 'width');
-      // should stop at maxSize (400px)
-      expect(currentSizes.startSize).to.be.closeTo(400 - barSize, 2);
+      // should stop exactly at maxSize (400px) - the pane sizes now sum to the
+      // available space, so flex-shrink no longer eats into the constraint
+      expect(currentSizes.startSize).to.be.closeTo(400, 2);
 
       splitter.orientation = 'vertical';
       await elementUpdated(splitter);
@@ -1259,6 +1292,7 @@ describe('Splitter', () => {
       splitter.startMaxSize = '80%';
       await elementUpdated(splitter);
 
+      const containerSize = getContainerSize(splitter, 'width');
       const totalAvailable = getTotalSize(splitter, 'width');
       const bar = getSplitterPart(splitter, BAR_PART);
       bar.focus();
@@ -1267,17 +1301,27 @@ describe('Splitter', () => {
       simulateKeyboard(bar, homeKey);
       await elementUpdated(splitter);
 
-      expect(splitter.startSize).to.equal('100px');
-      expect(splitter.endSize).to.equal(`${totalAvailable - 100}px`);
+      // Home/End go through the same pipeline as a drag, so the resulting unit
+      // follows the pane it is applied to - both were `auto`, hence percentages.
+      const minPercent = roundPrecise(asPercent(100, containerSize), 2);
+      expect(splitter.startSize).to.equal(`${minPercent}%`);
+      expect(splitter.endSize).to.equal(
+        `${roundPrecise(asPercent(totalAvailable - 100, containerSize), 2)}%`
+      );
 
-      const minPercent = Math.round((100 / totalAvailable) * 100);
-      expect(bar.getAttribute('aria-valuenow')).to.equal(minPercent.toString());
+      expect(bar.getAttribute('aria-valuenow')).to.equal(
+        Math.round(minPercent).toString()
+      );
 
       simulateKeyboard(bar, endKey);
       await elementUpdated(splitter);
 
+      // 80% of the container is the max; the end pane keeps what is left of
+      // the space the panes actually share.
       expect(splitter.startSize).to.equal('80%');
-      expect(splitter.endSize).to.equal('20%');
+      expect(splitter.endSize).to.equal(
+        `${roundPrecise(asPercent(totalAvailable - 0.8 * containerSize, containerSize), 2)}%`
+      );
 
       expect(bar.getAttribute('aria-valuenow')).to.equal('80');
       expect(bar.getAttribute('aria-valuemax')).to.equal('80');
@@ -1288,7 +1332,9 @@ describe('Splitter', () => {
       await elementUpdated(splitter);
       await finishAnimationsFor(splitter.shadowRoot!);
 
+      const containerSize = getContainerSize(splitter, 'height');
       const totalAvailable = getTotalSize(splitter, 'height');
+      const allOfIt = `${roundPrecise(asPercent(totalAvailable, containerSize), 2)}%`;
       const bar = getSplitterPart(splitter, BAR_PART);
       bar.focus();
       await elementUpdated(splitter);
@@ -1296,13 +1342,13 @@ describe('Splitter', () => {
       simulateKeyboard(bar, homeKey);
       await elementUpdated(splitter);
 
-      expect(splitter.startSize).to.equal('0px');
-      expect(splitter.endSize).to.equal(`${totalAvailable}px`);
+      expect(splitter.startSize).to.equal('0%');
+      expect(splitter.endSize).to.equal(allOfIt);
 
       simulateKeyboard(bar, endKey);
       await elementUpdated(splitter);
 
-      expect(splitter.startSize).to.equal('100%');
+      expect(splitter.startSize).to.equal(allOfIt);
       expect(splitter.endSize).to.equal('0%');
     });
 
@@ -1468,11 +1514,11 @@ describe('Splitter', () => {
       bar.focus();
       await elementUpdated(splitter);
 
-      const totalSize = getTotalSize(splitter, 'width');
+      const containerSize = getContainerSize(splitter, 'width');
       const { startSize: preCollapseStart, endSize: preCollapseEnd } =
         getPanesSizes(splitter, 'width');
-      const expectedStartPercent = `${roundPrecise((preCollapseStart / totalSize) * 100, 2)}%`;
-      const expectedEndPercent = `${roundPrecise((preCollapseEnd / totalSize) * 100, 2)}%`;
+      const expectedStartPercent = `${roundPrecise((preCollapseStart / containerSize) * 100, 2)}%`;
+      const expectedEndPercent = `${roundPrecise((preCollapseEnd / containerSize) * 100, 2)}%`;
 
       simulateKeyboard(bar, [ctrlKey, arrowLeft]);
       await elementUpdated(splitter);
@@ -1947,21 +1993,20 @@ describe('Splitter', () => {
       expect(style[targetMaxProp]).to.equal('50%');
 
       const isX = orientation === 'horizontal';
-      const totalAvailable = getTotalSize(
-        mixedConstraintSplitter,
-        isX ? 'width' : 'height'
+      const axis = isX ? 'width' : 'height';
+      const totalAvailable = getTotalSize(mixedConstraintSplitter, axis);
+      // `max-width: 50%` resolves against the container in CSS, and the drag
+      // math now uses that same basis.
+      const expectedStartMax = Math.round(
+        (getContainerSize(mixedConstraintSplitter, axis) * 50) / 100
       );
-      const expectedEndMax = Math.round((totalAvailable * 50) / 100);
 
       let delta = 1000;
       await resize(mixedConstraintSplitter, isX ? delta : 0, isX ? 0 : delta);
 
-      const sizes = getPanesSizes(
-        mixedConstraintSplitter,
-        isX ? 'width' : 'height'
-      );
-      expect(sizes.startSize).to.be.closeTo(totalAvailable - expectedEndMax, 2);
-      expect(sizes.endSize).to.be.closeTo(expectedEndMax, 2);
+      const sizes = getPanesSizes(mixedConstraintSplitter, axis);
+      expect(sizes.startSize).to.be.closeTo(expectedStartMax, 2);
+      expect(sizes.endSize).to.be.closeTo(totalAvailable - expectedStartMax, 2);
 
       delta = -1000;
       await resize(mixedConstraintSplitter, isX ? delta : 0, isX ? 0 : delta);
@@ -2904,6 +2949,310 @@ describe('Splitter', () => {
     });
   });
 
+  describe('Collapsed state integrity', () => {
+    it('should reflect the collapsed attributes for every collapse path', async () => {
+      splitter.toggle('start');
+      await elementUpdated(splitter);
+
+      expect(splitter.startCollapsed).to.be.true;
+      expect(splitter.hasAttribute('start-collapsed')).to.be.true;
+      expect(splitter.hasAttribute('end-collapsed')).to.be.false;
+
+      // Expander button
+      simulatePointerDown(getButtonParts(splitter).startExpander, {
+        bubbles: true,
+      });
+      await elementUpdated(splitter);
+
+      expect(splitter.startCollapsed).to.be.false;
+      expect(splitter.hasAttribute('start-collapsed')).to.be.false;
+
+      // Keyboard
+      const bar = getSplitterPart(splitter, BAR_PART);
+      bar.focus();
+      simulateKeyboard(bar, [ctrlKey, arrowRight]);
+      await elementUpdated(splitter);
+
+      expect(splitter.endCollapsed).to.be.true;
+      expect(splitter.hasAttribute('end-collapsed')).to.be.true;
+    });
+
+    it('should not leave a stale attribute when switching the collapsed pane', async () => {
+      splitter.endCollapsed = true;
+      await elementUpdated(splitter);
+
+      splitter.startCollapsed = true;
+      await elementUpdated(splitter);
+
+      expect(splitter.endCollapsed).to.be.false;
+      expect(splitter.hasAttribute('end-collapsed')).to.be.false;
+      expect(splitter.hasAttribute('start-collapsed')).to.be.true;
+
+      // ...and the same through `toggle()`
+      splitter.toggle('end');
+      await elementUpdated(splitter);
+
+      expect(splitter.hasAttribute('start-collapsed')).to.be.false;
+      expect(splitter.hasAttribute('end-collapsed')).to.be.true;
+    });
+
+    it('should keep min/max constraints across a collapse/expand round trip', async () => {
+      splitter.startMinSize = '100px';
+      splitter.startMaxSize = '300px';
+      splitter.endMinSize = '50px';
+      await elementUpdated(splitter);
+
+      splitter.toggle('start');
+      await elementUpdated(splitter);
+
+      splitter.toggle('start');
+      await elementUpdated(splitter);
+
+      expect(splitter.startMinSize).to.equal('100px');
+      expect(splitter.startMaxSize).to.equal('300px');
+      expect(splitter.endMinSize).to.equal('50px');
+
+      const style = getComputedStyle(getSplitterPart(splitter, START_PART));
+      expect(style.minWidth).to.equal('100px');
+      expect(style.maxWidth).to.equal('300px');
+    });
+
+    it('should honour a size authored while a pane is collapsed', async () => {
+      splitter.startSize = '100px';
+      await elementUpdated(splitter);
+
+      splitter.toggle('start');
+      await elementUpdated(splitter);
+
+      splitter.startSize = '300px';
+      await elementUpdated(splitter);
+
+      splitter.toggle('start');
+      await elementUpdated(splitter);
+
+      expect(splitter.startSize).to.equal('300px');
+
+      // The stale snapshot is dropped wholesale - keeping the end pane's share
+      // would over-subscribe the container and shrink both panes.
+      const sizes = getPanesSizes(splitter, 'width');
+      expect(sizes.startSize).to.equal(300);
+      expect(sizes.startSize + sizes.endSize).to.equal(
+        getTotalSize(splitter, 'width')
+      );
+    });
+
+    it('should not drift the divider across repeated collapse/expand cycles', async () => {
+      const initial = getPanesSizes(splitter, 'width');
+
+      for (let i = 0; i < 5; i++) {
+        splitter.toggle('start');
+        await elementUpdated(splitter);
+        splitter.toggle('start');
+        await elementUpdated(splitter);
+      }
+
+      const current = getPanesSizes(splitter, 'width');
+      expect(current.startSize).to.be.closeTo(initial.startSize, 1);
+      expect(current.endSize).to.be.closeTo(initial.endSize, 1);
+    });
+  });
+
+  describe('Size and constraint values', () => {
+    it('should reject values without an explicit unit', async () => {
+      for (const invalid of ['200', 'abc', 'calc(100% - 10px)', '']) {
+        splitter.startSize = invalid;
+        splitter.startMinSize = invalid;
+        await elementUpdated(splitter);
+
+        expect(splitter.startSize, invalid).to.equal('auto');
+        expect(splitter.startMinSize, invalid).to.be.undefined;
+      }
+    });
+
+    it('should resolve font-relative constraints against their computed pixel size', async () => {
+      splitter.style.width = '1000px';
+      // The probe inherits the container context, so 5rem is 5 x the root size
+      const rootFontSize = Number.parseFloat(
+        getComputedStyle(document.documentElement).fontSize
+      );
+      splitter.startMinSize = '5rem';
+      splitter.startSize = '400px';
+      await elementUpdated(splitter);
+
+      const expectedMinPx = 5 * rootFontSize;
+      const containerSize = getContainerSize(splitter, 'width');
+      const bar = getSplitterPart(splitter, BAR_PART);
+
+      expect(bar.getAttribute('aria-valuemin')).to.equal(
+        Math.round(asPercent(expectedMinPx, containerSize)).toString()
+      );
+
+      // Dragging far past the constraint stops on it, not on `5px`
+      await resize(splitter, -1000, 0);
+
+      expect(getPanesSizes(splitter, 'width').startSize).to.be.closeTo(
+        expectedMinPx,
+        1
+      );
+    });
+
+    it('should clamp percentage constraints where CSS resolves them', async () => {
+      splitter.startMinSize = '20%';
+      await elementUpdated(splitter);
+
+      const startPane = getSplitterPart(splitter, START_PART);
+      const containerSize = getContainerSize(splitter, 'width');
+
+      // CSS resolves `min-width: 20%` against the container...
+      expect(getComputedStyle(startPane).minWidth).to.equal('20%');
+
+      // ...and so does the drag math, so the two agree on the pixel value
+      await resize(splitter, -1000, 0);
+
+      expect(getPanesSizes(splitter, 'width').startSize).to.be.closeTo(
+        0.2 * containerSize,
+        1
+      );
+    });
+  });
+
+  describe('Gesture cancellation', () => {
+    it('should revert the panes and report a no-op when the gesture is cancelled', async () => {
+      const previousSizes = getPanesSizes(splitter, 'width');
+      const eventSpy = spy(splitter, 'emitEvent');
+      const bar = getSplitterPart(splitter, BAR_PART);
+      const barRect = bar.getBoundingClientRect();
+
+      simulatePointerDown(bar, {
+        clientX: barRect.left,
+        clientY: barRect.top,
+        pointerId: 1,
+      });
+      await elementUpdated(splitter);
+
+      simulatePointerMove(
+        bar,
+        { clientX: barRect.left, clientY: barRect.top, pointerId: 1 },
+        { x: 100, y: 0 }
+      );
+      await elementUpdated(splitter);
+
+      expect(getPanesSizes(splitter, 'width').startSize).to.equal(
+        previousSizes.startSize + 100
+      );
+
+      bar.dispatchEvent(
+        new PointerEvent('pointercancel', {
+          bubbles: true,
+          composed: true,
+          pointerId: 1,
+        })
+      );
+      await elementUpdated(splitter);
+      await nextFrame();
+
+      expect(getPanesSizes(splitter, 'width')).to.deep.equal(previousSizes);
+
+      const endCalls = getResizeDetails(eventSpy, 'igcResizeEnd');
+      expect(endCalls).to.have.lengthOf(1);
+      expect(endCalls[0]).to.deep.equal({
+        startPanelSize: previousSizes.startSize,
+        endPanelSize: previousSizes.endSize,
+        delta: 0,
+      });
+      expect(eventSpy.calledWith('igcLayoutChanged')).to.be.true;
+    });
+
+    it('should finalize a drag exactly once when pointer capture is lost after pointerup', async () => {
+      const eventSpy = spy(splitter, 'emitEvent');
+
+      await resize(splitter, 100, 0);
+
+      const sizesAfterDrag = getPanesSizes(splitter, 'width');
+      const bar = getSplitterPart(splitter, BAR_PART);
+
+      simulateLostPointerCapture(bar, { pointerId: 1 });
+      await elementUpdated(splitter);
+      await nextFrame();
+
+      expect(getResizeDetails(eventSpy, 'igcResizeEnd')).to.have.lengthOf(1);
+      expect(getPanesSizes(splitter, 'width')).to.deep.equal(sizesAfterDrag);
+    });
+
+    it('should not resize after the component is disconnected mid-drag', async () => {
+      const bar = getSplitterPart(splitter, BAR_PART);
+      const barRect = bar.getBoundingClientRect();
+
+      simulatePointerDown(bar, {
+        clientX: barRect.left,
+        clientY: barRect.top,
+        pointerId: 1,
+      });
+      await elementUpdated(splitter);
+
+      const parent = splitter.parentElement!;
+      splitter.remove();
+      parent.append(splitter);
+      await elementUpdated(splitter);
+
+      const sizes = getPanesSizes(splitter, 'width');
+
+      simulatePointerMove(
+        bar,
+        { clientX: barRect.left, clientY: barRect.top, pointerId: 1 },
+        { x: 100, y: 0 }
+      );
+      await elementUpdated(splitter);
+
+      expect(getPanesSizes(splitter, 'width')).to.deep.equal(sizes);
+    });
+  });
+
+  describe('Home/End with opposite pane constraints', () => {
+    it('should leave no gap when the end pane has a max size', async () => {
+      splitter.endMaxSize = '300px';
+      await elementUpdated(splitter);
+
+      const eventSpy = spy(splitter, 'emitEvent');
+      const bar = getSplitterPart(splitter, BAR_PART);
+      bar.focus();
+
+      simulateKeyboard(bar, homeKey);
+      await elementUpdated(splitter);
+      await nextFrame();
+
+      const sizes = getPanesSizes(splitter, 'width');
+      const totalAvailable = getTotalSize(splitter, 'width');
+
+      expect(sizes.startSize + sizes.endSize).to.be.closeTo(totalAvailable, 1);
+      expect(sizes.endSize).to.be.closeTo(300, 1);
+
+      // The reported sizes are the ones that actually got rendered
+      const [endDetail] = getResizeDetails(eventSpy, 'igcResizeEnd');
+      expect(endDetail.startPanelSize).to.be.closeTo(sizes.startSize, 1);
+      expect(endDetail.endPanelSize).to.be.closeTo(sizes.endSize, 1);
+    });
+
+    it('should stop at the end pane min size on End', async () => {
+      splitter.endMinSize = '200px';
+      await elementUpdated(splitter);
+
+      const bar = getSplitterPart(splitter, BAR_PART);
+      bar.focus();
+
+      simulateKeyboard(bar, endKey);
+      await elementUpdated(splitter);
+      await nextFrame();
+
+      const sizes = getPanesSizes(splitter, 'width');
+      expect(sizes.endSize).to.be.closeTo(200, 1);
+      expect(sizes.startSize + sizes.endSize).to.be.closeTo(
+        getTotalSize(splitter, 'width'),
+        1
+      );
+    });
+  });
+
   describe('Edge scenarios', () => {
     it('invalid size values should fallback to "auto"', async () => {
       splitter.startSize = '-100px';
@@ -3380,6 +3729,17 @@ function getPanesSizes(
   };
 }
 
+type ResizeEventName = 'igcResizeStart' | 'igcResizing' | 'igcResizeEnd';
+
+function getResizeDetails(
+  eventSpy: sinon.SinonSpy,
+  name: ResizeEventName
+): IgcSplitterResizeEventArgs[] {
+  return eventSpy
+    .withArgs(name)
+    .args.map((args) => args[1].detail as IgcSplitterResizeEventArgs);
+}
+
 function checkResizeEvents(
   eventSpy: sinon.SinonSpy,
   startArgs?: IgcSplitterResizeEventArgs,
@@ -3419,6 +3779,18 @@ function checkPanesAreWithinBounds(
   expect(startSize + endSize).to.be.at.most(splitterSize);
 }
 
+/**
+ * The basis the browser resolves percentage `flex-basis`/`min-*`/`max-*`
+ * against: the content box of the flex container, bar included.
+ */
+function getContainerSize(
+  splitter: IgcSplitterComponent,
+  dimension: 'width' | 'height'
+) {
+  return splitter.getBoundingClientRect()[dimension];
+}
+
+/** The space left for the panes once the bar has taken its own. */
 function getTotalSize(
   splitter: IgcSplitterComponent,
   dimension: 'width' | 'height'

--- a/src/components/splitter/splitter.ts
+++ b/src/components/splitter/splitter.ts
@@ -48,9 +48,12 @@ const KEYBOARD_RESIZE_STEP = 10;
 
 const PANES = ['start', 'end'] as const satisfies readonly PanePosition[];
 
-/** Unitless values are rejected - they produce an invalid `flex` shorthand. */
+/** A number carrying a percentage sign or one of the CSS length units. */
 const CSS_LENGTH =
   /^[+-]?(\d+\.?\d*|\.\d+)(%|px|em|rem|ch|ex|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pt|pc)$/i;
+
+/** A bare number, with no unit at all. */
+const UNITLESS_NUMBER = /^[+-]?(\d+\.?\d*|\.\d+)$/;
 
 const DEFAULT_RESIZE_STATE: SplitterResizeState = {
   startPane: null,
@@ -174,7 +177,6 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   @state()
   private _collapsedPane: PanePosition | null = null;
 
-  /** Nothing in `render()` reads this, so it stays out of the reactive state. */
   private _resizeState: SplitterResizeState = { ...DEFAULT_RESIZE_STATE };
 
   private _measurement: { container: number; bar: number } | null = null;
@@ -281,9 +283,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The minimum size of the start pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    * @attr start-min-size
    */
   @property({ attribute: 'start-min-size' })
@@ -298,9 +300,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The minimum size of the end pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    * @attr end-min-size
    */
   @property({ attribute: 'end-min-size' })
@@ -315,9 +317,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The maximum size of the start pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    * @attr start-max-size
    */
   @property({ attribute: 'start-max-size' })
@@ -332,9 +334,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The maximum size of the end pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    * @attr end-max-size
    */
   @property({ attribute: 'end-max-size' })
@@ -349,9 +351,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The size of the start pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 falls back to automatic sizing.
    * @attr start-size
    */
   @property({ attribute: 'start-size' })
@@ -366,9 +368,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The size of the end pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 falls back to automatic sizing.
    * @attr end-size
    */
   @property({ attribute: 'end-size' })
@@ -724,7 +726,7 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     fallback?: 'auto'
   ): string | undefined {
     const trimmed = value?.trim();
-    if (!trimmed || trimmed === 'auto' || !CSS_LENGTH.test(trimmed)) {
+    if (!trimmed || trimmed === 'auto') {
       return fallback;
     }
 
@@ -732,7 +734,11 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     if (numericValue < 0) return fallback;
     if (trimmed.includes('%') && numericValue > 100) return fallback;
 
-    return trimmed;
+    // Zero is the one length that needs no unit; any other bare number is
+    // invalid CSS and would silently drop the whole `flex` shorthand.
+    const isUnitlessZero = numericValue === 0 && UNITLESS_NUMBER.test(trimmed);
+
+    return isUnitlessZero || CSS_LENGTH.test(trimmed) ? trimmed : fallback;
   }
 
   private _getFlex(which: PanePosition, forceAuto = false): string {

--- a/src/components/splitter/splitter.ts
+++ b/src/components/splitter/splitter.ts
@@ -19,7 +19,7 @@ import { registerComponent } from '#internals/definitions/register.js';
 import type { Constructor } from '#internals/mixins/constructor.js';
 import { EventEmitterMixin } from '#internals/mixins/event-emitter.js';
 import { partMap } from '#internals/part-map.js';
-import { isLTR } from '#internals/utils/dom.js';
+import { isLTR, resolveCssLength } from '#internals/utils/dom.js';
 import { bindIf } from '#internals/utils/lit.js';
 import {
   asNumber,
@@ -46,10 +46,15 @@ import type {
 
 const KEYBOARD_RESIZE_STEP = 10;
 
+const PANES = ['start', 'end'] as const satisfies readonly PanePosition[];
+
+/** Unitless values are rejected - they produce an invalid `flex` shorthand. */
+const CSS_LENGTH =
+  /^[+-]?(\d+\.?\d*|\.\d+)(%|px|em|rem|ch|ex|cap|ic|lh|rlh|vw|vh|vi|vb|vmin|vmax|cm|mm|q|in|pt|pc)$/i;
+
 const DEFAULT_RESIZE_STATE: SplitterResizeState = {
   startPane: null,
   endPane: null,
-  isDragging: false,
   dragStartPosition: { x: 0, y: 0 },
   dragPointerId: -1,
 };
@@ -132,6 +137,12 @@ const DEFAULT_RESIZE_STATE: SplitterResizeState = {
  * @csspart end-collapse-btn - The button to collapse the end panel.
  * @csspart start-expand-btn - The button to expand the start panel when collapsed.
  * @csspart end-expand-btn - The button to expand the end panel when collapsed.
+ *
+ * @remarks
+ * The bar holds two expander elements, one on either side of the drag handle,
+ * and each carries whichever part name applies to the current collapsed state.
+ * A part name is therefore not tied to a fixed side: with the end pane
+ * collapsed, `end-expand-btn` lands on the *first* of the two.
  */
 export default class IgcSplitterComponent extends EventEmitterMixin<
   IgcSplitterComponentEventMap,
@@ -163,8 +174,13 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   @state()
   private _collapsedPane: PanePosition | null = null;
 
-  @state()
+  /** Nothing in `render()` reads this, so it stays out of the reactive state. */
   private _resizeState: SplitterResizeState = { ...DEFAULT_RESIZE_STATE };
+
+  private _measurement: { container: number; bar: number } | null = null;
+
+  /** Container extent at the last resize notification we acted on. */
+  private _observedSize = -1;
 
   @query('[part~="base"]')
   private readonly _base!: HTMLElement;
@@ -177,6 +193,10 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
 
   private get _separator(): HTMLElement | undefined {
     return this._separatorRef.value;
+  }
+
+  private get _isDragging(): boolean {
+    return this._resizeState.dragPointerId !== -1;
   }
 
   private get _resizeDisallowed(): boolean {
@@ -200,6 +220,10 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
 
   /**
    * The orientation of the splitter, which determines the direction of resizing and collapsing.
+   *
+   * Changing the orientation after the initial render clears the pane sizes and
+   * their min/max constraints, along with the corresponding attributes - a size
+   * authored for one axis rarely makes sense on the other.
    * @attr orientation
    * @default 'horizontal'
    */
@@ -257,8 +281,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The minimum size of the start pane.
    *
-   * Accepts a CSS length, e.g. `100px` or `20%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    * @attr start-min-size
    */
   @property({ attribute: 'start-min-size' })
@@ -273,8 +298,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The minimum size of the end pane.
    *
-   * Accepts a CSS length, e.g. `100px` or `20%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    * @attr end-min-size
    */
   @property({ attribute: 'end-min-size' })
@@ -289,8 +315,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The maximum size of the start pane.
    *
-   * Accepts a CSS length, e.g. `500px` or `80%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    * @attr start-max-size
    */
   @property({ attribute: 'start-max-size' })
@@ -305,8 +332,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The maximum size of the end pane.
    *
-   * Accepts a CSS length, e.g. `500px` or `80%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    * @attr end-max-size
    */
   @property({ attribute: 'end-max-size' })
@@ -321,13 +349,14 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The size of the start pane.
    *
-   * Accepts a CSS length, e.g. `200px` or `50%`. Setting `auto`, a negative
-   * value, or a percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 falls back to automatic sizing.
    * @attr start-size
    */
   @property({ attribute: 'start-size' })
   public set startSize(value: string | undefined) {
-    this._startPaneState.size = this._normalizeValue(value, 'auto');
+    this._setPaneSize('start', value);
   }
 
   public get startSize(): string | undefined {
@@ -337,13 +366,14 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   /**
    * The size of the end pane.
    *
-   * Accepts a CSS length, e.g. `200px` or `50%`. Setting `auto`, a negative
-   * value, or a percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 falls back to automatic sizing.
    * @attr end-size
    */
   @property({ attribute: 'end-size' })
   public set endSize(value: string | undefined) {
-    this._endPaneState.size = this._normalizeValue(value, 'auto');
+    this._setPaneSize('end', value);
   }
 
   public get endSize(): string | undefined {
@@ -392,7 +422,7 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     addSlotController(this, { slots: setSlots('start', 'end') });
 
     createResizeObserverController(this, {
-      callback: () => this.requestUpdate(),
+      callback: () => this._handleContainerResize(),
     });
 
     addKeybindings(this, {
@@ -419,13 +449,10 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   }
 
   protected override update(changed: PropertyValues<this>): void {
+    this._measurement = null;
+
     if (changed.get('orientation') != null) {
-      for (const pane of ['start', 'end'] as PanePosition[]) {
-        const state = this._getPaneState(pane);
-        state.size = 'auto';
-        state.minSize = undefined;
-        state.maxSize = undefined;
-      }
+      this._resetPaneSizes();
     }
 
     if (this.hasUpdated) {
@@ -436,7 +463,14 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   }
 
   protected override updated(): void {
+    // Layout has just been committed; the `update()` measurements are stale.
+    this._measurement = null;
     this._updateBarAria();
+  }
+
+  public override disconnectedCallback(): void {
+    this._endDrag();
+    super.disconnectedCallback();
   }
 
   //#endregion
@@ -444,7 +478,7 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   //#region Resize Event Handlers
 
   private _handleBarPointerDown(e: PointerEvent): void {
-    if (e.button !== 0) {
+    if (e.button !== 0 || this._isDragging) {
       return;
     }
 
@@ -452,7 +486,6 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
 
     this._resizeState = {
       ...this._resizeState,
-      isDragging: true,
       dragPointerId: e.pointerId,
       dragStartPosition: { x: e.clientX, y: e.clientY },
     };
@@ -488,10 +521,24 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     this._endDrag();
   }
 
-  private _endDrag(): void {
-    if (this._resizeState.dragPointerId !== -1) {
-      this._separator?.releasePointerCapture(this._resizeState.dragPointerId);
+  /** A cancelled gesture reverts, but still reports an end for the start it emitted. */
+  private _handleCancelDrag(e: PointerEvent): void {
+    if (e.pointerId !== this._resizeState.dragPointerId) {
+      return;
     }
+
+    this._resizeEnd(0);
+    this._endDrag();
+  }
+
+  private _endDrag(): void {
+    const { dragPointerId } = this._resizeState;
+
+    // `releasePointerCapture` throws for a pointer that is no longer active.
+    if (this._separator?.hasPointerCapture(dragPointerId)) {
+      this._separator.releasePointerCapture(dragPointerId);
+    }
+
     this._resizeState = { ...DEFAULT_RESIZE_STATE };
   }
 
@@ -499,10 +546,13 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
 
   //#region Public Methods
 
-  /** Toggles the collapsed state of the specified pane. */
+  /**
+   * Toggles the collapsed state of the specified pane.
+   *
+   * Does not emit `igcLayoutChanged` - that event reports user-driven changes,
+   * and a programmatic call is already known to the caller.
+   */
   public toggle(position: PanePosition): void {
-    // If the requested pane is already collapsed, expand it (set to null)
-    // Otherwise, collapse the requested pane (this also handles switching from one collapsed pane to another)
     this._applyCollapse(this._collapsedPane === position ? null : position);
   }
 
@@ -515,12 +565,49 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
       this._savePaneSizes();
     }
 
+    const wasStartCollapsed = this._isCollapsed('start');
+    const wasEndCollapsed = this._isCollapsed('end');
+
     this._collapsedPane = target;
+
+    // `toggle()`, the expanders and Ctrl + arrow bypass the decorated accessors,
+    // and one assignment can change both flags. Request both so Lit reflects
+    // them from their getters instead of leaving one stale.
+    this.requestUpdate('startCollapsed', wasStartCollapsed);
+    this.requestUpdate('endCollapsed', wasEndCollapsed);
 
     this._internals.setState('start-collapsed', this._isCollapsed('start'));
     this._internals.setState('end-collapsed', this._isCollapsed('end'));
 
     this._restoreSizesOnExpandCollapse();
+  }
+
+  private _setPaneSize(pane: PanePosition, value: string | undefined): void {
+    this._getPaneState(pane).size = this._normalizeValue(value, 'auto');
+
+    // A size authored while collapsed outranks the pre-collapse snapshot. The
+    // whole snapshot goes - keeping the other pane's share would over-subscribe
+    // the container and leave both panes shrinking to fit.
+    if (this._collapsedPane !== null) {
+      for (const target of PANES) {
+        this._getPaneState(target).savedSize = undefined;
+      }
+    }
+  }
+
+  /** Drops the authored sizes and their attributes, which would otherwise diverge. */
+  private _resetPaneSizes(): void {
+    for (const pane of PANES) {
+      const state = this._getPaneState(pane);
+      state.size = 'auto';
+      state.minSize = undefined;
+      state.maxSize = undefined;
+      state.savedSize = undefined;
+
+      for (const suffix of ['size', 'min-size', 'max-size']) {
+        this.removeAttribute(`${pane}-${suffix}`);
+      }
+    }
   }
 
   private _setCollapsed(pane: PanePosition, value: boolean): void {
@@ -531,16 +618,17 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   }
 
   private _savePaneSizes(): void {
-    // Layout not measurable yet (e.g. collapsed state set before first render) -
-    // preserve the explicit size instead of losing it to the 'auto' reset below.
+    // Not measurable yet (collapsed before the first render) - keep the
+    // explicit size rather than lose it to the 'auto' reset.
     if (this._getTotalSize() === 0) {
       this._startPaneState.savedSize = this._startPaneState.size;
       this._endPaneState.savedSize = this._endPaneState.size;
       return;
     }
     // Higher precision than the ARIA percent so restored layouts don't drift.
-    this._startPaneState.savedSize = `${this._paneRectAsPercent(0, 2)}%`;
-    this._endPaneState.savedSize = `${this._paneRectAsPercent(1, 2)}%`;
+    const [start, end] = this._rectSize();
+    this._startPaneState.savedSize = `${this._asPercentOfContainer(start, 2)}%`;
+    this._endPaneState.savedSize = `${this._asPercentOfContainer(end, 2)}%`;
   }
 
   /* Reset sizes on collapse; restore saved sizes on expand */
@@ -555,31 +643,24 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     }
   }
 
-  /** Measures the actual rendered size of a pane and returns it as a percentage of total size. */
-  private _paneRectAsPercent(paneIndex: 0 | 1, precision = 0): number {
-    const totalSize = this._getTotalSize();
-    if (totalSize === 0) {
-      return 0;
-    }
-    return roundPrecise(
-      asPercent(this._rectSize()[paneIndex], totalSize),
-      precision
-    );
+  /**
+   * The container is what the browser resolves a percentage `flex-basis`
+   * against, so a value measured this way survives a round trip through CSS.
+   */
+  private _asPercentOfContainer(size: number, precision = 0): number {
+    const containerSize = this._getContainerSize();
+    return containerSize === 0
+      ? 0
+      : roundPrecise(asPercent(size, containerSize), precision);
   }
 
-  /** Converts a CSS size string (px or %) to a percentage of total size. */
-  private _sizeToPercent(sizeValue: string): number {
-    const totalSize = this._getTotalSize();
-    if (totalSize === 0) {
-      return 0;
+  /** Resolves a CSS length to pixels, percentages against the container. */
+  private _toPixels(value: string): number {
+    if (value.endsWith('%')) {
+      return (asNumber(value) / 100) * this._getContainerSize();
     }
 
-    if (sizeValue.includes('%')) {
-      return asNumber(sizeValue);
-    }
-
-    const pxValue = asNumber(sizeValue);
-    return roundPrecise(asPercent(pxValue, totalSize), 0);
+    return this._base ? resolveCssLength(this._base, value) : 0;
   }
 
   private _getStartPaneSizePercent(): number {
@@ -591,25 +672,37 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
       return 100;
     }
 
-    return this._paneRectAsPercent(0);
+    return this._asPercentOfContainer(this._rectSize()[0]);
   }
 
   private _getMinMaxAsPercent(type: 'min' | 'max'): number {
     const value = type === 'min' ? this.startMinSize : this.startMaxSize;
-    const defaultValue = type === 'min' ? 0 : 100;
 
-    return value ? this._sizeToPercent(value) : defaultValue;
+    if (!value) {
+      return type === 'min' ? 0 : 100;
+    }
+
+    return this._asPercentOfContainer(this._toPixels(value));
   }
 
   private _isCollapsed(which: PanePosition): boolean {
     return this._collapsedPane === which;
   }
 
+  private _otherPane(pane: PanePosition): PanePosition {
+    return pane === 'start' ? 'end' : 'start';
+  }
+
   private _updateBarAria(): void {
-    if (this._separator) {
-      this._separator.ariaValueNow = this._getStartPaneSizePercent().toString();
-      this._separator.ariaValueMin = this._getMinMaxAsPercent('min').toString();
-      this._separator.ariaValueMax = this._getMinMaxAsPercent('max').toString();
+    const separator = this._separator;
+
+    if (separator) {
+      const value = this._getStartPaneSizePercent();
+
+      separator.ariaValueNow = value.toString();
+      separator.ariaValueText = `${value}%`;
+      separator.ariaValueMin = this._getMinMaxAsPercent('min').toString();
+      separator.ariaValueMax = this._getMinMaxAsPercent('max').toString();
     }
   }
 
@@ -631,7 +724,7 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     fallback?: 'auto'
   ): string | undefined {
     const trimmed = value?.trim();
-    if (!trimmed || trimmed === 'auto') {
+    if (!trimmed || trimmed === 'auto' || !CSS_LENGTH.test(trimmed)) {
       return fallback;
     }
 
@@ -642,8 +735,8 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     return trimmed;
   }
 
-  private _getFlex(which: PanePosition): string {
-    const isAuto = this._isAutoSize(which);
+  private _getFlex(which: PanePosition, forceAuto = false): string {
+    const isAuto = forceAuto || this._isAutoSize(which);
     const size = isAuto ? '0px' : this._getPaneState(which).size;
     return `${isAuto ? 1 : 0} 1 ${size}`;
   }
@@ -661,9 +754,19 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
       direction
     );
 
+    this._runResize(delta);
+  }
+
+  /**
+   * A complete resize for a non-pointer gesture. Sharing `_calcNewSizes` with
+   * the drag path is what keeps both panes' constraints honoured and the
+   * emitted sizes equal to the ones that actually render.
+   */
+  private _runResize(delta: number): void {
     this._resizeStart();
     this._resizing(delta);
     this._resizeEnd(delta);
+    this._endDrag();
   }
 
   @eventOptions({ passive: false })
@@ -682,58 +785,22 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     return delta * rtlMultiplier * (direction ?? 1);
   }
 
+  /** Snaps the start pane to its minimum or maximum size. */
   private _handleMinMaxResize(type: 'min' | 'max'): void {
     if (this._resizeDisallowed) {
       return;
     }
 
-    const totalSize = this._getTotalSize();
-    const boundaryValue =
-      type === 'min' ? this.startMinSize : this.startMaxSize;
-    const isPercentage = boundaryValue
-      ? boundaryValue.includes('%')
-      : type === 'max';
-
     const targetStartSizePx =
-      this._setMinMaxInPx('start', type) ?? (type === 'min' ? 0 : totalSize);
-    const targetEndSizePx = totalSize - targetStartSizePx;
+      this._getConstraintInPx('start', type) ??
+      (type === 'min' ? 0 : this._getTotalSize());
 
-    const [initialStart, initialEnd] = this._rectSize();
-    const delta = targetStartSizePx - initialStart;
-
-    this.emitEvent('igcResizeStart', {
-      detail: { startPanelSize: initialStart, endPanelSize: initialEnd },
-    });
-    this.emitEvent('igcResizing', {
-      detail: {
-        startPanelSize: targetStartSizePx,
-        endPanelSize: targetEndSizePx,
-        delta,
-      },
-    });
-
-    if (isPercentage) {
-      this.startSize = `${roundPrecise(asPercent(targetStartSizePx, totalSize), 2)}%`;
-      this.endSize = `${roundPrecise(asPercent(targetEndSizePx, totalSize), 2)}%`;
-    } else {
-      this.startSize = `${targetStartSizePx}px`;
-      this.endSize = `${targetEndSizePx}px`;
-    }
-
-    this.emitEvent('igcResizeEnd', {
-      detail: {
-        startPanelSize: targetStartSizePx,
-        endPanelSize: targetEndSizePx,
-        delta,
-      },
-    });
-    this._emitLayoutChanged();
+    this._runResize(targetStartSizePx - this._rectSize()[0]);
   }
 
   private _handleExpanderAction(pane: PanePosition): void {
-    const other: PanePosition = pane === 'start' ? 'end' : 'start';
-    const target = this._collapsedPane === other ? other : pane;
-    this._toggleWithEvent(target);
+    const other = this._otherPane(pane);
+    this._toggleWithEvent(this._collapsedPane === other ? other : pane);
   }
 
   private _toggleWithEvent(position: PanePosition): void {
@@ -741,8 +808,8 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     this._emitLayoutChanged();
   }
 
-  // While any pane is collapsed, both sizes are forced to 'auto' for rendering,
-  // so report the pre-collapse sizes instead - what a consumer needs to restore layout.
+  // Both sizes render as 'auto' while collapsed, so report the pre-collapse
+  // ones instead - those are what a consumer needs to restore the layout.
   private _reportedSize(pane: PanePosition): string {
     const state = this._getPaneState(pane);
     return (
@@ -767,29 +834,15 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     if (this.disableCollapse || this.orientation !== validOrientation) {
       return;
     }
-    const effectiveTarget: PanePosition =
-      validOrientation === 'horizontal' && !isLTR(this)
-        ? target === 'start'
-          ? 'end'
-          : 'start'
-        : target;
-    this._handleExpanderAction(effectiveTarget);
+    const isFlipped = validOrientation === 'horizontal' && !isLTR(this);
+    this._handleExpanderAction(isFlipped ? this._otherPane(target) : target);
   }
 
   private _resizeStart(): void {
     const [startSize, endSize] = this._rectSize();
-    const totalSize = this._getTotalSize();
 
-    this._resizeState.startPane = this._createPaneState(
-      'start',
-      startSize,
-      totalSize
-    );
-    this._resizeState.endPane = this._createPaneState(
-      'end',
-      endSize,
-      totalSize
-    );
+    this._resizeState.startPane = this._createPaneState('start', startSize);
+    this._resizeState.endPane = this._createPaneState('end', endSize);
 
     this.emitEvent('igcResizeStart', {
       detail: { startPanelSize: startSize, endPanelSize: endSize },
@@ -798,36 +851,31 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
 
   private _createPaneState(
     pane: PanePosition,
-    size: number,
-    totalSize?: number
+    size: number
   ): PaneResizeSnapshot {
     return {
       initialSize: size,
       isPercentageBased: this._isPercentageSize(pane) || this._isAutoSize(pane),
-      minSizePx: this._setMinMaxInPx(pane, 'min', totalSize),
-      maxSizePx: this._setMinMaxInPx(pane, 'max', totalSize),
+      minSizePx: this._getConstraintInPx(pane, 'min'),
+      maxSizePx: this._getConstraintInPx(pane, 'max'),
     };
   }
 
-  private _setMinMaxInPx(
+  private _getConstraintInPx(
     pane: PanePosition,
-    type: 'min' | 'max',
-    totalSize?: number
+    type: 'min' | 'max'
   ): number | undefined {
-    const paneState = this._getPaneState(pane);
-    const value = type === 'max' ? paneState.maxSize : paneState.minSize;
-    const valueAsNumber = asNumber(value);
+    const { minSize, maxSize } = this._getPaneState(pane);
+    const value = type === 'max' ? maxSize : minSize;
 
-    if (!value) {
-      return undefined;
-    }
-
-    return value.includes('%')
-      ? (valueAsNumber / 100) * (totalSize ?? this._getTotalSize())
-      : valueAsNumber;
+    return value ? this._toPixels(value) : undefined;
   }
 
   private _resizing(delta: number): void {
+    if (!this._resizeState.startPane || !this._resizeState.endPane) {
+      return;
+    }
+
     const [startPaneSize, endPaneSize] = this._calcNewSizes(delta);
 
     this.startSize = `${startPaneSize}px`;
@@ -845,31 +893,29 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   private _computeSize(
     pane: PaneResizeSnapshot,
     paneSize: number,
-    totalSize: number
+    containerSize: number
   ): string {
     return pane.isPercentageBased
-      ? `${asPercent(paneSize, totalSize)}%`
+      ? `${asPercent(paneSize, containerSize)}%`
       : `${roundPrecise(paneSize, 0)}px`;
   }
 
   private _resizeEnd(delta: number): void {
-    if (!this._resizeState.startPane || !this._resizeState.endPane) {
+    const { startPane, endPane } = this._resizeState;
+
+    if (!startPane || !endPane) {
       return;
     }
 
-    const [startPaneSize, endPaneSize] = this._calcNewSizes(delta);
-    const totalSize = this._getTotalSize();
+    // A cancelled gesture reverts to the sizes captured at `_resizeStart`.
+    const [startPaneSize, endPaneSize] =
+      delta === 0
+        ? [startPane.initialSize, endPane.initialSize]
+        : this._calcNewSizes(delta);
+    const containerSize = this._getContainerSize();
 
-    this.startSize = this._computeSize(
-      this._resizeState.startPane,
-      startPaneSize,
-      totalSize
-    );
-    this.endSize = this._computeSize(
-      this._resizeState.endPane,
-      endPaneSize,
-      totalSize
-    );
+    this.startSize = this._computeSize(startPane, startPaneSize, containerSize);
+    this.endSize = this._computeSize(endPane, endPaneSize, containerSize);
 
     this.emitEvent('igcResizeEnd', {
       detail: {
@@ -915,39 +961,59 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
     return [start.initialSize + finalDelta, end.initialSize - finalDelta];
   }
 
-  private _getTotalSize(): number {
-    if (!this._base) {
-      return 0;
-    }
-
+  /**
+   * Reads the container and bar extents once per update pass - both
+   * `_updatePanes` and `_updateBarAria` need them, and the style writes in
+   * between would force a reflow for every repeated read.
+   */
+  private _measure(): { container: number; bar: number } {
     const axis = this._isHorizontal ? 'width' : 'height';
-    const barSize = this._separator
-      ? roundPrecise(this._separator.getBoundingClientRect()[axis])
-      : 0;
 
-    const rect = this._base.getBoundingClientRect();
-    const size = rect[axis];
-    return size - barSize;
+    this._measurement ??= {
+      container: this._base ? this._base.getBoundingClientRect()[axis] : 0,
+      bar: this._separator
+        ? roundPrecise(this._separator.getBoundingClientRect()[axis])
+        : 0,
+    };
+
+    return this._measurement;
+  }
+
+  /** The content box of the flex container - the basis for every percentage. */
+  private _getContainerSize(): number {
+    return this._measure().container;
+  }
+
+  /** The space left for the panes once the bar has taken its own. */
+  private _getTotalSize(): number {
+    const { container, bar } = this._measure();
+    return container === 0 ? 0 : container - bar;
+  }
+
+  private _handleContainerResize(): void {
+    this._measurement = null;
+    const size = this._getContainerSize();
+
+    if (size !== this._observedSize) {
+      this._observedSize = size;
+      this.requestUpdate();
+    }
   }
 
   private _updatePanes(): void {
-    const totalSize = this._getTotalSize();
     const isCollapsed = this._collapsedPane !== null;
 
-    for (const pane of ['start', 'end'] as PanePosition[]) {
-      const state = this._getPaneState(pane);
-      if (isCollapsed) {
-        state.size = 'auto';
-        state.minSize = undefined;
-        state.maxSize = undefined;
-      }
+    // A collapsed pane renders as `auto` with its constraints lifted, while the
+    // authored values stay untouched so they survive the round trip.
+    for (const pane of PANES) {
+      const { minSize, maxSize } = this._getPaneState(pane);
+
       this._setPaneMinMaxSizes(
         pane,
-        isCollapsed ? '0' : state.minSize,
-        isCollapsed ? '100%' : state.maxSize,
-        totalSize
+        isCollapsed ? '0' : minSize,
+        isCollapsed ? '100%' : maxSize
       );
-      this._updatePaneStyles(pane, { flex: this._getFlex(pane) });
+      this._updatePaneStyles(pane, { flex: this._getFlex(pane, isCollapsed) });
     }
   }
 
@@ -958,11 +1024,9 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   private _setPaneMinMaxSizes(
     pane: PanePosition,
     minSize?: string,
-    maxSize?: string,
-    totalSize?: number
+    maxSize?: string
   ): void {
-    const min =
-      this._ensureMinConstraintIsWithinBounds(pane, minSize, totalSize) ?? 0;
+    const min = this._ensureMinConstraintIsWithinBounds(pane, minSize) ?? 0;
     const max = maxSize ?? '100%';
 
     this._updatePaneStyles(
@@ -975,29 +1039,25 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
 
   private _ensureMinConstraintIsWithinBounds(
     pane: PanePosition,
-    minSize?: string,
-    totalSize?: number
+    minSize?: string
   ): string | undefined {
-    const total = totalSize ?? this._getTotalSize();
+    const total = this._getTotalSize();
 
-    if (minSize && total > 0) {
-      const minPx = this._setMinMaxInPx(pane, 'min', total) ?? 0;
-      const other: PanePosition = pane === 'start' ? 'end' : 'start';
-      const otherMinPx = this._getPaneState(other).minSize
-        ? (this._setMinMaxInPx(other, 'min', total) ?? 0)
-        : 0;
-
-      // Ignore constraint if it exceeds total or combined exceeds total to prevent content overflow
-      // Once container grows to accommodate the constraint, it will be applied
-      if (minPx > total || minPx + otherMinPx > total) {
-        return undefined;
-      }
+    if (!minSize || total <= 0) {
+      return minSize;
     }
-    return minSize;
+
+    const minPx = this._getConstraintInPx(pane, 'min') ?? 0;
+    const otherMinPx =
+      this._getConstraintInPx(this._otherPane(pane), 'min') ?? 0;
+
+    // Dropping a constraint the panes cannot both satisfy keeps content from
+    // overflowing. It is reapplied once the container grows to accommodate it.
+    return minPx + otherMinPx > total ? undefined : minSize;
   }
 
   private _handleExpanderClick(pane: PanePosition, event: PointerEvent): void {
-    // Prevent resize action being initiated
+    // Keep the bar from starting a resize
     event.stopPropagation();
     this._handleExpanderAction(pane);
   }
@@ -1007,7 +1067,7 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   //#region Rendering
 
   private _resolvePartNames(expander: PanePosition): Record<string, boolean> {
-    const other: PanePosition = expander === 'start' ? 'end' : 'start';
+    const other = this._otherPane(expander);
     const otherIsCollapsed = this._isCollapsed(other);
 
     return {
@@ -1040,7 +1100,10 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
 
   private _renderAccessibleLabel() {
     return html`
-      <igc-visually-hidden id="splitter-label">
+      <igc-visually-hidden id="splitter-label"
+        >Resize panes</igc-visually-hidden
+      >
+      <igc-visually-hidden id="splitter-state">
         ${
           this._isCollapsed('start')
             ? 'Start pane collapsed'
@@ -1053,7 +1116,6 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
   }
 
   private _renderSeparator() {
-    const isDragging = this._resizeState.isDragging;
     const canResize = !this._resizeDisallowed;
 
     return html`
@@ -1064,15 +1126,16 @@ export default class IgcSplitterComponent extends EventEmitterMixin<
         tabindex=${this.disableCollapse && this.disableResize ? -1 : 0}
         aria-controls="start-pane end-pane"
         aria-labelledby="splitter-label"
+        aria-describedby="splitter-state"
         aria-orientation=${this.orientation}
         style=${styleMap({ '--cursor': this._separatorCursor })}
         @touchstart=${bindIf(canResize, this._preventDefaultForEvent)}
         @contextmenu=${bindIf(canResize, this._preventDefaultForEvent)}
         @pointerdown=${bindIf(canResize, this._handleBarPointerDown)}
-        @pointermove=${bindIf(isDragging, this._handleBarPointerMove)}
-        @pointerup=${bindIf(isDragging, this._handleEndDrag)}
-        @lostpointercapture=${bindIf(isDragging, this._handleEndDrag)}
-        @pointercancel=${bindIf(isDragging, this._endDrag)}
+        @pointermove=${this._handleBarPointerMove}
+        @pointerup=${this._handleEndDrag}
+        @lostpointercapture=${this._handleEndDrag}
+        @pointercancel=${this._handleCancelDrag}
       >
         ${this._renderBarControls()}
       </div>

--- a/src/components/splitter/types.ts
+++ b/src/components/splitter/types.ts
@@ -20,8 +20,8 @@ interface PaneResizeSnapshot {
 interface SplitterResizeState {
   startPane: PaneResizeSnapshot | null;
   endPane: PaneResizeSnapshot | null;
-  isDragging: boolean;
   dragStartPosition: { x: number; y: number };
+  /** The active pointer id, or `-1` when no drag is in progress. */
   dragPointerId: number;
 }
 

--- a/src/internals/utils/dom.spec.ts
+++ b/src/internals/utils/dom.spec.ts
@@ -1,0 +1,56 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { resolveCssLength } from './dom.js';
+
+describe('DOM utilities', () => {
+  describe('resolveCssLength', () => {
+    let element: HTMLDivElement;
+
+    beforeEach(async () => {
+      element = await fixture<HTMLDivElement>(
+        html`<div style="font-size: 20px;"></div>`
+      );
+    });
+
+    it('should pass absolute pixel values through', () => {
+      expect(resolveCssLength(element, '42px')).to.equal(42);
+      expect(resolveCssLength(element, '0px')).to.equal(0);
+      expect(resolveCssLength(element, '12.5px')).to.equal(12.5);
+    });
+
+    it('should resolve font-relative units', () => {
+      const rootFontSize = Number.parseFloat(
+        getComputedStyle(document.documentElement).fontSize
+      );
+
+      expect(resolveCssLength(element, '2em')).to.equal(40);
+      expect(resolveCssLength(element, '5rem')).to.equal(5 * rootFontSize);
+    });
+
+    it('should resolve viewport-relative units', () => {
+      expect(resolveCssLength(element, '10vw')).to.equal(
+        0.1 * window.innerWidth
+      );
+    });
+
+    it('should resolve other absolute units', () => {
+      expect(resolveCssLength(element, '1in')).to.equal(96);
+      expect(resolveCssLength(element, '12pt')).to.equal(16);
+    });
+
+    it('should return 0 for percentages, which are not lengths', () => {
+      expect(resolveCssLength(element, '50%')).to.equal(0);
+    });
+
+    it('should return 0 for values that are not valid lengths', () => {
+      expect(resolveCssLength(element, '200')).to.equal(0);
+      expect(resolveCssLength(element, 'auto')).to.equal(0);
+      expect(resolveCssLength(element, 'nonsense')).to.equal(0);
+      expect(resolveCssLength(element, '')).to.equal(0);
+    });
+
+    it('should not leave the resolution property behind on the element', () => {
+      resolveCssLength(element, '3rem');
+      expect(element.getAttribute('style')).to.equal('font-size: 20px;');
+    });
+  });
+});

--- a/src/internals/utils/dom.spec.ts
+++ b/src/internals/utils/dom.spec.ts
@@ -52,5 +52,24 @@ describe('DOM utilities', () => {
       resolveCssLength(element, '3rem');
       expect(element.getAttribute('style')).to.equal('font-size: 20px;');
     });
+
+    it('should restore a custom property the caller had already set inline', () => {
+      element.style.setProperty('--igc-resolved-length', '7px');
+
+      expect(resolveCssLength(element, '3rem')).to.equal(48);
+      expect(element.style.getPropertyValue('--igc-resolved-length')).to.equal(
+        '7px'
+      );
+    });
+
+    it('should preserve the priority of a restored custom property', () => {
+      element.style.setProperty('--igc-resolved-length', '7px', 'important');
+
+      resolveCssLength(element, '3rem');
+
+      expect(
+        element.style.getPropertyPriority('--igc-resolved-length')
+      ).to.equal('important');
+    });
   });
 });

--- a/src/internals/utils/dom.ts
+++ b/src/internals/utils/dom.ts
@@ -1,4 +1,4 @@
-import { numberInRangeInclusive } from './math.js';
+import { asNumber, numberInRangeInclusive } from './math.js';
 import { merge } from './objects.js';
 import { isDefined } from './types.js';
 
@@ -7,6 +7,54 @@ import { isDefined } from './types.js';
  */
 export function isLTR(element: HTMLElement) {
   return element.matches(':dir(ltr)');
+}
+
+const LENGTH_PROPERTY = '--igc-resolved-length';
+let lengthPropertyRegistered = false;
+
+function registerLengthProperty(): void {
+  if (lengthPropertyRegistered) {
+    return;
+  }
+
+  lengthPropertyRegistered = true;
+
+  try {
+    CSS.registerProperty({
+      name: LENGTH_PROPERTY,
+      syntax: '<length>',
+      inherits: false,
+      initialValue: '0px',
+    });
+  } catch {
+    /* Already registered by another bundle instance. */
+  }
+}
+
+/**
+ * Resolves a CSS length to pixels in the context of `element`.
+ *
+ * A registered custom property computes to an absolute length, which lets the
+ * browser do the conversion for font, viewport and container relative units
+ * instead of them being read as raw numbers. Percentages are not lengths -
+ * resolve those against whatever basis applies to the property at hand.
+ *
+ * Returns 0 for percentages and for values that are not valid lengths.
+ *
+ * @example
+ * ```typescript
+ * resolveCssLength(element, '5rem'); // 80
+ * resolveCssLength(element, '2em'); // 2 x the element font size
+ * ```
+ */
+export function resolveCssLength(element: HTMLElement, value: string): number {
+  registerLengthProperty();
+
+  element.style.setProperty(LENGTH_PROPERTY, value);
+  const resolved = getComputedStyle(element).getPropertyValue(LENGTH_PROPERTY);
+  element.style.removeProperty(LENGTH_PROPERTY);
+
+  return asNumber(resolved);
 }
 
 export type IterNodesOptions<T = Node> = {

--- a/src/internals/utils/dom.ts
+++ b/src/internals/utils/dom.ts
@@ -1,3 +1,4 @@
+import { isServer } from 'lit';
 import { asNumber, numberInRangeInclusive } from './math.js';
 import { merge } from './objects.js';
 import { isDefined } from './types.js';
@@ -10,25 +11,33 @@ export function isLTR(element: HTMLElement) {
 }
 
 const LENGTH_PROPERTY = '--igc-resolved-length';
-let lengthPropertyRegistered = false;
 
-function registerLengthProperty(): void {
-  if (lengthPropertyRegistered) {
-    return;
+const SUPPORTS_REGISTERED_PROPERTIES =
+  !isServer && typeof CSS !== 'undefined' && 'registerProperty' in CSS;
+
+let lengthPropertyUsable: boolean | undefined;
+
+function canResolveLengths(): boolean {
+  if (lengthPropertyUsable === undefined) {
+    lengthPropertyUsable = SUPPORTS_REGISTERED_PROPERTIES;
+
+    if (lengthPropertyUsable) {
+      try {
+        CSS.registerProperty({
+          name: LENGTH_PROPERTY,
+          syntax: '<length>',
+          inherits: false,
+          initialValue: '0px',
+        });
+      } catch {
+        // The descriptor is a constant, so the only realistic rejection is a
+        // duplicate registration from another bundle instance - which leaves
+        // the property just as usable.
+      }
+    }
   }
 
-  lengthPropertyRegistered = true;
-
-  try {
-    CSS.registerProperty({
-      name: LENGTH_PROPERTY,
-      syntax: '<length>',
-      inherits: false,
-      initialValue: '0px',
-    });
-  } catch {
-    /* Already registered by another bundle instance. */
-  }
+  return lengthPropertyUsable;
 }
 
 /**
@@ -39,7 +48,10 @@ function registerLengthProperty(): void {
  * instead of them being read as raw numbers. Percentages are not lengths -
  * resolve those against whatever basis applies to the property at hand.
  *
- * Returns 0 for percentages and for values that are not valid lengths.
+ * Returns 0 for percentages, for values that are not valid lengths, and where
+ * the resolution is unavailable - during server-side rendering, or without
+ * support for registered custom properties. Guessing from the raw token would
+ * read `5rem` as 5 pixels, so callers get an obvious zero instead.
  *
  * @example
  * ```typescript
@@ -48,11 +60,23 @@ function registerLengthProperty(): void {
  * ```
  */
 export function resolveCssLength(element: HTMLElement, value: string): number {
-  registerLengthProperty();
+  if (!canResolveLengths()) {
+    return 0;
+  }
 
-  element.style.setProperty(LENGTH_PROPERTY, value);
+  const { style } = element;
+  const previous = style.getPropertyValue(LENGTH_PROPERTY);
+  const priority = style.getPropertyPriority(LENGTH_PROPERTY);
+
+  style.setProperty(LENGTH_PROPERTY, value);
   const resolved = getComputedStyle(element).getPropertyValue(LENGTH_PROPERTY);
-  element.style.removeProperty(LENGTH_PROPERTY);
+
+  // Restore rather than remove - the caller may be using the property itself.
+  if (previous) {
+    style.setProperty(LENGTH_PROPERTY, previous, priority);
+  } else {
+    style.removeProperty(LENGTH_PROPERTY);
+  }
 
   return asNumber(resolved);
 }

--- a/stories/splitter.stories.ts
+++ b/stories/splitter.stories.ts
@@ -71,37 +71,37 @@ const metadata: Meta<IgcSplitterComponent> = {
     startMinSize: {
       type: 'string',
       description:
-        'The minimum size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
+        'The minimum size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `100px` or `20%`, or a\nunitless `0`. Setting `auto`, any other unitless or unparsable value, a\nnegative value, or a percentage above 100 removes the constraint.',
       control: 'text',
     },
     endMinSize: {
       type: 'string',
       description:
-        'The minimum size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
+        'The minimum size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `100px` or `20%`, or a\nunitless `0`. Setting `auto`, any other unitless or unparsable value, a\nnegative value, or a percentage above 100 removes the constraint.',
       control: 'text',
     },
     startMaxSize: {
       type: 'string',
       description:
-        'The maximum size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
+        'The maximum size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `500px` or `80%`, or a\nunitless `0`. Setting `auto`, any other unitless or unparsable value, a\nnegative value, or a percentage above 100 removes the constraint.',
       control: 'text',
     },
     endMaxSize: {
       type: 'string',
       description:
-        'The maximum size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
+        'The maximum size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `500px` or `80%`, or a\nunitless `0`. Setting `auto`, any other unitless or unparsable value, a\nnegative value, or a percentage above 100 removes the constraint.',
       control: 'text',
     },
     startSize: {
       type: 'string',
       description:
-        'The size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 falls back to automatic sizing.',
+        'The size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `200px` or `50%`, or a\nunitless `0`. Setting `auto`, any other unitless or unparsable value, a\nnegative value, or a percentage above 100 falls back to automatic sizing.',
       control: 'text',
     },
     endSize: {
       type: 'string',
       description:
-        'The size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 falls back to automatic sizing.',
+        'The size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `200px` or `50%`, or a\nunitless `0`. Setting `auto`, any other unitless or unparsable value, a\nnegative value, or a percentage above 100 falls back to automatic sizing.',
       control: 'text',
     },
     startCollapsed: {
@@ -168,49 +168,49 @@ interface IgcSplitterArgs {
   /**
    * The minimum size of the start pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    */
   startMinSize: string;
   /**
    * The minimum size of the end pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    */
   endMinSize: string;
   /**
    * The maximum size of the start pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    */
   startMaxSize: string;
   /**
    * The maximum size of the end pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 removes the constraint.
    */
   endMaxSize: string;
   /**
    * The size of the start pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 falls back to automatic sizing.
    */
   startSize: string;
   /**
    * The size of the end pane.
    *
-   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
-   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
-   * percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`, or a
+   * unitless `0`. Setting `auto`, any other unitless or unparsable value, a
+   * negative value, or a percentage above 100 falls back to automatic sizing.
    */
   endSize: string;
   /**

--- a/stories/splitter.stories.ts
+++ b/stories/splitter.stories.ts
@@ -35,7 +35,7 @@ const metadata: Meta<IgcSplitterComponent> = {
     orientation: {
       type: '"horizontal" | "vertical"',
       description:
-        'The orientation of the splitter, which determines the direction of resizing and collapsing.',
+        'The orientation of the splitter, which determines the direction of resizing and collapsing.\n\nChanging the orientation after the initial render clears the pane sizes and\ntheir min/max constraints, along with the corresponding attributes - a size\nauthored for one axis rarely makes sense on the other.',
       options: ['horizontal', 'vertical'],
       control: { type: 'inline-radio' },
       table: { defaultValue: { summary: 'horizontal' } },
@@ -71,37 +71,37 @@ const metadata: Meta<IgcSplitterComponent> = {
     startMinSize: {
       type: 'string',
       description:
-        'The minimum size of the start pane.\n\nAccepts a CSS length, e.g. `100px` or `20%`. Setting `auto`, a negative\nvalue, or a percentage above 100 removes the constraint.',
+        'The minimum size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
       control: 'text',
     },
     endMinSize: {
       type: 'string',
       description:
-        'The minimum size of the end pane.\n\nAccepts a CSS length, e.g. `100px` or `20%`. Setting `auto`, a negative\nvalue, or a percentage above 100 removes the constraint.',
+        'The minimum size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
       control: 'text',
     },
     startMaxSize: {
       type: 'string',
       description:
-        'The maximum size of the start pane.\n\nAccepts a CSS length, e.g. `500px` or `80%`. Setting `auto`, a negative\nvalue, or a percentage above 100 removes the constraint.',
+        'The maximum size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
       control: 'text',
     },
     endMaxSize: {
       type: 'string',
       description:
-        'The maximum size of the end pane.\n\nAccepts a CSS length, e.g. `500px` or `80%`. Setting `auto`, a negative\nvalue, or a percentage above 100 removes the constraint.',
+        'The maximum size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 removes the constraint.',
       control: 'text',
     },
     startSize: {
       type: 'string',
       description:
-        'The size of the start pane.\n\nAccepts a CSS length, e.g. `200px` or `50%`. Setting `auto`, a negative\nvalue, or a percentage above 100 falls back to automatic sizing.',
+        'The size of the start pane.\n\nAccepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 falls back to automatic sizing.',
       control: 'text',
     },
     endSize: {
       type: 'string',
       description:
-        'The size of the end pane.\n\nAccepts a CSS length, e.g. `200px` or `50%`. Setting `auto`, a negative\nvalue, or a percentage above 100 falls back to automatic sizing.',
+        'The size of the end pane.\n\nAccepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting\n`auto`, a unitless or otherwise unparsable value, a negative value, or a\npercentage above 100 falls back to automatic sizing.',
       control: 'text',
     },
     startCollapsed: {
@@ -133,7 +133,13 @@ const metadata: Meta<IgcSplitterComponent> = {
 export default metadata;
 
 interface IgcSplitterArgs {
-  /** The orientation of the splitter, which determines the direction of resizing and collapsing. */
+  /**
+   * The orientation of the splitter, which determines the direction of resizing and collapsing.
+   *
+   * Changing the orientation after the initial render clears the pane sizes and
+   * their min/max constraints, along with the corresponding attributes - a size
+   * authored for one axis rarely makes sense on the other.
+   */
   orientation: 'horizontal' | 'vertical';
   /**
    * Whether collapsing either pane is disabled. When `true`, this also hides
@@ -162,43 +168,49 @@ interface IgcSplitterArgs {
   /**
    * The minimum size of the start pane.
    *
-   * Accepts a CSS length, e.g. `100px` or `20%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    */
   startMinSize: string;
   /**
    * The minimum size of the end pane.
    *
-   * Accepts a CSS length, e.g. `100px` or `20%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `100px` or `20%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    */
   endMinSize: string;
   /**
    * The maximum size of the start pane.
    *
-   * Accepts a CSS length, e.g. `500px` or `80%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    */
   startMaxSize: string;
   /**
    * The maximum size of the end pane.
    *
-   * Accepts a CSS length, e.g. `500px` or `80%`. Setting `auto`, a negative
-   * value, or a percentage above 100 removes the constraint.
+   * Accepts a CSS length with an explicit unit, e.g. `500px` or `80%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 removes the constraint.
    */
   endMaxSize: string;
   /**
    * The size of the start pane.
    *
-   * Accepts a CSS length, e.g. `200px` or `50%`. Setting `auto`, a negative
-   * value, or a percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 falls back to automatic sizing.
    */
   startSize: string;
   /**
    * The size of the end pane.
    *
-   * Accepts a CSS length, e.g. `200px` or `50%`. Setting `auto`, a negative
-   * value, or a percentage above 100 falls back to automatic sizing.
+   * Accepts a CSS length with an explicit unit, e.g. `200px` or `50%`. Setting
+   * `auto`, a unitless or otherwise unparsable value, a negative value, or a
+   * percentage above 100 falls back to automatic sizing.
    */
   endSize: string;
   /**


### PR DESCRIPTION
## Description

Collapsing overwrote the authored pane state, the size arithmetic read CSS lengths as raw numbers against a basis the browser does not use, and Home/End reimplemented the drag path instead of sharing it.

- Reflect start-collapsed/end-collapsed for the toggle(), expander button and Ctrl + arrow paths, and clear the stale flag when the collapsed pane switches
- Keep the authored min/max sizes across a collapse, and let a size set while collapsed outrank the pre-collapse snapshot
- Resolve percentages against the flex container, as CSS does, fixing the divider drift on collapse/expand and the disagreement between the rendered and enforced constraints
- Resolve em/rem/viewport units through a new resolveCssLength() DOM utility
  instead of reading them as pixels, and reject unitless values other than 0,
  which produce an invalid flex shorthand
- Route Home/End through the shared resize pipeline so both panes' constraints apply and the emitted sizes match what renders; the resulting unit now follows the drag rule
- Clear the size attributes on the orientation reset, and revert on pointercancel with an igcResizeEnd matching the emitted start
- Bind the gesture handlers unconditionally so the first pointermove no longer depends on a re-render landing in time
- Name the separator by purpose, move the collapsed/expanded text to aria-describedby and add aria-valuetext
- Cache the per-pass layout reads and ignore self-inflicted resize notifications

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)


## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
