### PR TITLE
fix(testing): keep failed assertions on spies and DOM nodes reportable

### DIFF
--- a/src/internals/testing/assertion-errors.spec.ts
+++ b/src/internals/testing/assertion-errors.spec.ts
@@ -1,0 +1,84 @@
+import type { chai as ChaiInstance } from '@open-wc/testing';
+// @ts-expect-error - `chai` is exported at runtime, but is missing from the typings of
+// the side-effect free entry point. The default one must not be used here: it registers
+// a fixture cleanup hook only if mocha has already defined its globals, and this module
+// runs before the test framework.
+import { chai as untypedChai } from '@open-wc/testing/pure';
+
+const chai = untypedChai as typeof ChaiInstance;
+
+/**
+ * Web test runner ships the results of a browser session to the Node process
+ * through `structuredClone`, `actual` and `expected` of a failed assertion
+ * included. Chai defaults `actual` to the assertion subject, so asserting on a
+ * value that cannot be cloned - a sinon spy, a DOM node - makes the transport
+ * throw a `DataCloneError` *after* the test has already failed. The session
+ * result is never delivered: instead of a diff, the test file fails with a
+ * `testsFinishTimeout` after two minutes and takes the collected browser logs
+ * down with it.
+ *
+ * Substituting the inspected form of such values keeps the failure reportable.
+ * Loaded through the `testRunnerHtml` option of the runner config so that it
+ * applies to every test file.
+ */
+
+const MAX_INSPECT_LENGTH = 512;
+
+function isCloneable(value: unknown): boolean {
+  try {
+    structuredClone(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function inspect(value: unknown): string {
+  try {
+    return chai.util.inspect(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
+function toCloneable(value: unknown): unknown {
+  if (isCloneable(value)) {
+    return value;
+  }
+
+  const inspected = inspect(value);
+
+  return inspected.length > MAX_INSPECT_LENGTH
+    ? `${inspected.slice(0, MAX_INSPECT_LENGTH)}...`
+    : inspected;
+}
+
+type AssertionError = { actual?: unknown; expected?: unknown };
+
+function makeReportable(error: unknown): unknown {
+  if (error && typeof error === 'object') {
+    const assertionError = error as AssertionError;
+
+    if ('actual' in assertionError) {
+      assertionError.actual = toCloneable(assertionError.actual);
+    }
+
+    if ('expected' in assertionError) {
+      assertionError.expected = toCloneable(assertionError.expected);
+    }
+  }
+
+  return error;
+}
+
+const assert = chai.Assertion.prototype.assert;
+
+chai.Assertion.prototype.assert = function (
+  ...args: Parameters<typeof assert>
+): void {
+  try {
+    assert.apply(this, args);
+  } catch (error) {
+    throw makeReportable(error);
+  }
+};

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -26,9 +26,27 @@ function filterBenignBrowserLogs() {
   };
 }
 
+/**
+ * Loads `assertion-errors.spec.ts` ahead of the test framework so that every
+ * test file gets the chai patch that keeps failed assertions on non-cloneable
+ * subjects (sinon spies, DOM nodes) reportable. See the module itself for the
+ * details.
+ */
+function testRunnerHtml(testFramework) {
+  return `<!DOCTYPE html>
+<html>
+  <body>
+    <script type="module" src="/src/internals/testing/assertion-errors.spec.ts"></script>
+    <script type="module" src="${testFramework}"></script>
+  </body>
+</html>`;
+}
+
 export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   files: ['src/**/*.spec.ts'],
   browsers: [playwrightLauncher({ product: 'chromium', headless: true })],
+
+  testRunnerHtml,
 
   /** Compile JS for older browsers. Requires @web/dev-server-esbuild plugin */
   // esbuildTarget: 'auto',


### PR DESCRIPTION
## Description

Web test runner ships the browser session result through structuredClone with the `actual` and `expected` of a failed assertion included raw, and chai defaults `actual` to the assertion subject. Asserting on a value that cannot be cloned - a sinon spy, a DOM node - made the transport throw a DataCloneError after the test had already failed, so the result was never delivered: every `expect(spy).calledWith()` mismatch surfaced as a two minute testsFinishTimeout instead of a diff and took the collected browser logs with it.

- Substitute the inspected form of a non-cloneable `actual`/`expected` on a failed chai assertion, leaving the message - which already carries sinon-chai's own diff - untouched
- Load the patch through the testRunnerHtml option, ahead of the test framework, so it applies to every spec file without touching the assertions themselves
- Take chai from the side-effect free entry point of @open-wc/testing: the default one registers its fixture cleanup hook only if mocha has already defined its globals, which a module running before the framework would silently disable

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
