### PR TITLE
refactor(controllers): fix gesture/fullscreen bugs and cut per-event work

### DIFF
--- a/src/internals/controllers/adopt-styles.ts
+++ b/src/internals/controllers/adopt-styles.ts
@@ -258,7 +258,7 @@ class AdoptedStylesController implements ReactiveController {
 
   private readonly _host: ReactiveControllerHost & LitElement;
 
-  private _adoptedSheets: readonly CSSStyleSheet[] = [];
+  private _adoptedSheets: ReadonlySet<CSSStyleSheet> = new Set();
   private _shouldAdopt = false;
   private _hasAdoptedStyles = false;
 
@@ -355,7 +355,7 @@ class AdoptedStylesController implements ReactiveController {
 
     adoptStyles(shadowRoot, [...this._getHostSheets(shadowRoot), ...sheets]);
 
-    this._adoptedSheets = sheets;
+    this._adoptedSheets = new Set(sheets);
     this._hasAdoptedStyles = true;
 
     documentStyles.subscribe(this);
@@ -372,7 +372,7 @@ class AdoptedStylesController implements ReactiveController {
       adoptStyles(shadowRoot, this._getHostSheets(shadowRoot));
     }
 
-    this._adoptedSheets = [];
+    this._adoptedSheets = new Set();
     this._hasAdoptedStyles = false;
     this._documentStyles.unsubscribe(this);
   }
@@ -380,7 +380,7 @@ class AdoptedStylesController implements ReactiveController {
   /** Returns the stylesheets of the shadow root which are not managed by this controller. */
   private _getHostSheets(shadowRoot: ShadowRoot): CSSStyleSheet[] {
     return shadowRoot.adoptedStyleSheets.filter(
-      (sheet) => !this._adoptedSheets.includes(sheet)
+      (sheet) => !this._adoptedSheets.has(sheet)
     );
   }
 

--- a/src/internals/controllers/async-consumer.ts
+++ b/src/internals/controllers/async-consumer.ts
@@ -31,18 +31,21 @@ export class AsyncContextConsumer<
     return this._consumer?.value;
   }
 
+  // If there is already an instance of a consumer (because of an attach/detach cycle),
+  // skip creating a new instance for this host - checked both before and after the
+  // await, since a reconnect can land in between.
   public async hostConnected(): Promise<void> {
+    if (this._consumer) {
+      return;
+    }
+
     await this._host.updateComplete;
 
-    // If there is already an instance of a consumer (because of an attach/detach cycle),
-    // skip creating a new instance for this host.
-    if (!this._consumer) {
-      this._consumer = new ContextConsumer(this._host, {
-        context: this._options.context,
-        callback: this._options.callback,
-        subscribe: this._options.subscribe,
-      });
-    }
+    this._consumer ??= new ContextConsumer(this._host, {
+      context: this._options.context,
+      callback: this._options.callback,
+      subscribe: this._options.subscribe,
+    });
   }
 }
 
@@ -58,5 +61,5 @@ export function createAsyncContext<
     context,
     callback,
     subscribe: true,
-  }) as AsyncContextConsumer<T, Host>;
+  });
 }

--- a/src/internals/controllers/focus-ring.ts
+++ b/src/internals/controllers/focus-ring.ts
@@ -53,8 +53,12 @@ class KeyboardFocusRingController implements ReactiveController {
 
   /** @internal */
   public handleEvent(event: Event): void {
-    this._isKeyboardFocused = event.type === 'keyup';
-    this._host.requestUpdate();
+    const focused = event.type === 'keyup';
+
+    if (focused !== this._isKeyboardFocused) {
+      this._isKeyboardFocused = focused;
+      this._host.requestUpdate();
+    }
   }
 }
 

--- a/src/internals/controllers/fullscreen.ts
+++ b/src/internals/controllers/fullscreen.ts
@@ -54,10 +54,15 @@ class FullscreenController implements ReactiveController {
 
     this._fullscreen = fullscreen;
 
-    if (this._fullscreen) {
-      this._host.requestFullscreen();
+    if (fullscreen) {
+      // Rejects when the request is not user activated or the element is not
+      // allowed to go fullscreen - roll the state back so the host re-renders.
+      this._host.requestFullscreen().catch(() => {
+        this._fullscreen = false;
+        this._host.requestUpdate();
+      });
     } else if (document.fullscreenElement) {
-      document.exitFullscreen();
+      document.exitFullscreen().catch(() => {});
     }
   }
 

--- a/src/internals/controllers/gestures.ts
+++ b/src/internals/controllers/gestures.ts
@@ -168,9 +168,7 @@ class GesturesController extends EventTarget implements ReactiveController {
   }
 
   private _setTouchActionState(disabled: boolean) {
-    Object.assign(this._element.style, {
-      touchAction: disabled ? 'none' : undefined,
-    });
+    this._element.style.touchAction = disabled ? 'none' : '';
   }
 
   private _resetState() {
@@ -186,8 +184,13 @@ class GesturesController extends EventTarget implements ReactiveController {
   }
 
   private _handlePointerDown(event: PointerEvent) {
+    const state = this._getGestureState(event);
+
     this._setTouchActionState(true);
-    this._pointerState.start = this._getGestureState(event);
+    // Seeded so that a press without any movement resolves to a zero delta
+    // instead of being measured against the zeroed default state.
+    this._pointerState.start = state;
+    this._pointerState.current = state;
     this._setPointerCaptureState(event, true);
   }
 

--- a/src/internals/controllers/id-resolver.ts
+++ b/src/internals/controllers/id-resolver.ts
@@ -13,6 +13,17 @@ function getEmitter(root: Node): IdRefChangeEmitter {
   return emitter;
 }
 
+/** Adds the ids of `nodes` and of any of their descendants to `affected`. */
+function collectIds(nodes: NodeList, affected: Set<string>): void {
+  for (const node of nodes) {
+    if (!isElement(node)) continue;
+    if (node.id) affected.add(node.id);
+    for (const child of node.querySelectorAll('[id]')) {
+      if (child.id) affected.add(child.id);
+    }
+  }
+}
+
 function refObserverCallback(
   mutations: MutationRecord[],
   emitter: IdRefChangeEmitter
@@ -27,20 +38,8 @@ function refObserverCallback(
       if (oldId) affected.add(oldId);
       if (newId) affected.add(newId);
     } else {
-      for (const node of mutation.addedNodes) {
-        if (!isElement(node)) continue;
-        if (node.id) affected.add(node.id);
-        for (const child of node.querySelectorAll('[id]')) {
-          if (child.id) affected.add(child.id);
-        }
-      }
-      for (const node of mutation.removedNodes) {
-        if (!isElement(node)) continue;
-        if (node.id) affected.add(node.id);
-        for (const child of node.querySelectorAll('[id]')) {
-          if (child.id) affected.add(child.id);
-        }
-      }
+      collectIds(mutation.addedNodes, affected);
+      collectIds(mutation.removedNodes, affected);
     }
   }
 

--- a/src/internals/controllers/key-bindings.ts
+++ b/src/internals/controllers/key-bindings.ts
@@ -2,7 +2,7 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import type { Ref } from 'lit/directives/ref.js';
 import { createAbortHandle } from '../abort-handler.js';
 import { asArray, partition } from '../utils/arrays.js';
-import { getElementFromPath } from '../utils/events.js';
+import { isElement } from '../utils/dom.js';
 import { toMerged } from '../utils/objects.js';
 import { isFunction } from '../utils/types.js';
 
@@ -133,19 +133,26 @@ interface KeyBinding {
 
 //#region Internal functions and constants
 
-const MODIFIERS = new Set(['alt', 'control', 'meta', 'shift']);
-const ALL_MODIFIER_VALUES = Array.from(MODIFIERS).sort();
-
 /**
- * Maps internal modifier names to their corresponding `KeyboardEvent` boolean property names.
- * Needed because `ctrlKey` in the DOM is the property for the `'control'` modifier (not `'controlKey'`).
+ * Every modifier, paired with the `KeyboardEvent` boolean property it is read
+ * from - `ctrlKey` is the property for the `'control'` modifier, not `'controlKey'`.
+ *
+ * Kept in alphabetical order: combination keys sort their modifiers, and every
+ * derived collection below inherits that order for free.
  */
-export const MODIFIER_EVENT_KEYS: Record<string, string> = {
-  alt: 'altKey',
-  control: 'ctrlKey',
-  meta: 'metaKey',
-  shift: 'shiftKey',
-};
+const MODIFIER_ENTRIES = [
+  ['alt', 'altKey'],
+  ['control', 'ctrlKey'],
+  ['meta', 'metaKey'],
+  ['shift', 'shiftKey'],
+] as const satisfies ReadonlyArray<readonly [string, keyof KeyboardEvent]>;
+
+const ALL_MODIFIER_VALUES = MODIFIER_ENTRIES.map(([name]) => name);
+const MODIFIERS = new Set<string>(ALL_MODIFIER_VALUES);
+
+/** {@link MODIFIER_ENTRIES} as a lookup of modifier name to event property. */
+export const MODIFIER_EVENT_KEYS: Record<string, string> =
+  Object.fromEntries(MODIFIER_ENTRIES);
 
 function normalizeKeys(keys: string | string[]): string[] {
   return asArray(keys).map((key) => key.toLowerCase());
@@ -159,19 +166,34 @@ function isKeyup(event: Event): boolean {
   return event.type === 'keyup';
 }
 
+/** Sorts `modifiers` alphabetically, by filtering the already sorted source. */
+function sortModifiers(modifiers: string[]): string[] {
+  return ALL_MODIFIER_VALUES.filter((mod) => modifiers.includes(mod));
+}
+
+/** Returns the modifiers active for `event`, already sorted. */
+function getActiveModifiers(event: KeyboardEvent): string[] {
+  const active: string[] = [];
+
+  for (const [name, property] of MODIFIER_ENTRIES) {
+    if (event[property]) {
+      active.push(name);
+    }
+  }
+
+  return active;
+}
+
 /**
  * Creates a normalized combination key string from the provided keys and modifiers.
  *
  * The combination key is a string that uniquely identifies a specific combination of keys and modifiers.
  * It is created by sorting the keys and modifiers alphabetically and joining them with a '+' separator.
+ *
+ * `modifiers` must already be sorted - see {@link sortModifiers} and {@link getActiveModifiers}.
  */
 function createCombinationKey(keys: string[], modifiers: string[]): string {
-  const sortedKeys = keys.toSorted();
-  const sortedModifiers = ALL_MODIFIER_VALUES.filter((mod) =>
-    modifiers.includes(mod)
-  ).sort();
-
-  return sortedModifiers.concat(sortedKeys).join('+');
+  return modifiers.concat(keys.length > 1 ? keys.toSorted() : keys).join('+');
 }
 
 //#endregion
@@ -275,24 +297,25 @@ class KeyBindingController implements ReactiveController {
    * The method checks if the event's key is among the allowed keys, if the event originated from within the controller's scope,
    * and if it matches any of the skip conditions defined in the controller's options.
    */
-  private _shouldSkip(event: KeyboardEvent): boolean {
+  private _shouldSkip(event: KeyboardEvent, key: string): boolean {
+    if (!this._allowedKeys.has(key)) {
+      return true;
+    }
+
+    const path = event.composedPath();
+    const element = this._element;
+
+    if (!path.some((node) => node === element)) {
+      return true;
+    }
+
+    const selector = this._skipSelector;
+
+    if (selector) {
+      return path.some((node) => isElement(node) && node.matches(selector));
+    }
+
     const skip = this._options.skip;
-
-    if (!this._allowedKeys.has(event.key.toLowerCase())) {
-      return true;
-    }
-
-    if (!getElementFromPath((e) => e === this._element, event)) {
-      return true;
-    }
-
-    if (Array.isArray(skip)) {
-      if (!this._skipSelector) {
-        return false;
-      }
-
-      return Boolean(getElementFromPath(this._skipSelector, event));
-    }
 
     return isFunction(skip)
       ? skip.call(this._host, event.target as Element, event)
@@ -341,24 +364,22 @@ class KeyBindingController implements ReactiveController {
    *
    */
   private _handleKeyEvent(event: KeyboardEvent): void {
-    if (this._shouldSkip(event)) {
+    const key = event.key.toLowerCase();
+    const isModifier = MODIFIERS.has(key);
+
+    if (this._shouldSkip(event, key)) {
       // Always clean up on keyup regardless of whether the event is otherwise skipped.
-      const key = event.key.toLowerCase();
-      if (!MODIFIERS.has(key) && isKeyup(event)) {
+      if (!isModifier && isKeyup(event)) {
         this._pressedKeys.delete(key);
       }
       return;
     }
 
-    const key = event.key.toLowerCase();
-
-    if (!MODIFIERS.has(key)) {
+    if (!isModifier) {
       this._pressedKeys.add(key);
     }
 
-    const activeModifiers = ALL_MODIFIER_VALUES.filter(
-      (mod) => event[MODIFIER_EVENT_KEYS[mod] as keyof KeyboardEvent]
-    );
+    const activeModifiers = getActiveModifiers(event);
 
     const combination = createCombinationKey(
       Array.from(this._pressedKeys),
@@ -381,7 +402,7 @@ class KeyBindingController implements ReactiveController {
       binding.handler.call(this._host, event);
     }
 
-    if (!MODIFIERS.has(key) && isKeyup(event)) {
+    if (!isModifier && isKeyup(event)) {
       this._pressedKeys.delete(key);
     }
   }
@@ -419,7 +440,7 @@ class KeyBindingController implements ReactiveController {
     bindingOptions?: KeyBindingOptions
   ): this {
     const { keys, modifiers } = parseKeys(key);
-    const combination = createCombinationKey(keys, modifiers);
+    const combination = createCombinationKey(keys, sortModifiers(modifiers));
     const options = toMerged(
       this._options.bindingDefaults!,
       bindingOptions ?? {}

--- a/src/internals/controllers/mutation-observer.ts
+++ b/src/internals/controllers/mutation-observer.ts
@@ -66,21 +66,28 @@ export type MutationControllerParams<T extends Node = Node> = {
   observer: MutationController<T>;
 };
 
-function applyNodeFilter<T extends Node = Node>(
-  nodes: T[],
-  predicate?: MutationControllerFilter<T>
-): T[] {
-  if (!predicate) {
-    return nodes;
+/**
+ * Resolves a filter configuration into a node predicate.
+ *
+ * A list of selectors is joined once into a single selector list, so matching a
+ * node is a single `matches` call instead of one per selector.
+ */
+function createNodeMatcher<T extends Node = Node>(
+  filter?: MutationControllerFilter<T>
+): (node: T) => boolean {
+  if (!filter) {
+    return () => true;
   }
 
-  return Array.isArray(predicate)
-    ? nodes.filter(
-        (node) =>
-          isElement(node) &&
-          predicate.some((selector) => node.matches(selector))
-      )
-    : nodes.filter(predicate);
+  if (!Array.isArray(filter)) {
+    return filter;
+  }
+
+  const selector = filter.join(',');
+
+  return selector
+    ? (node) => isElement(node) && node.matches(selector)
+    : () => false;
 }
 
 class MutationController<T extends Node = Node> implements ReactiveController {
@@ -88,7 +95,7 @@ class MutationController<T extends Node = Node> implements ReactiveController {
   private readonly _target: Element;
   private readonly _config: MutationObserverInit;
   private readonly _callback: MutationControllerCallback<T>;
-  private readonly _filter?: MutationControllerFilter<T>;
+  private readonly _matches: (node: T) => boolean;
 
   private _observer?: MutationObserver;
 
@@ -100,7 +107,7 @@ class MutationController<T extends Node = Node> implements ReactiveController {
     this._callback = options.callback;
     this._config = options.config;
     this._target = options.target ?? this._host;
-    this._filter = options.filter;
+    this._matches = createNodeMatcher(options.filter);
 
     if (!isServer) {
       this._observer = new MutationObserver((records) => {
@@ -123,8 +130,19 @@ class MutationController<T extends Node = Node> implements ReactiveController {
     this.disconnect();
   }
 
+  private _collect(
+    nodes: NodeList,
+    target: Element,
+    into: MutationDOMChange<T>[]
+  ): void {
+    for (const node of nodes) {
+      if (this._matches(node as T)) {
+        into.push({ target, node: node as T });
+      }
+    }
+  }
+
   private _process(records: MutationRecord[]): MutationControllerParams<T> {
-    const predicate = this._filter;
     const changes: MutationChange<T> = {
       attributes: [],
       added: [],
@@ -135,27 +153,12 @@ class MutationController<T extends Node = Node> implements ReactiveController {
       const { type, target, attributeName, addedNodes, removedNodes } = record;
 
       if (type === 'attributes') {
-        changes.attributes.push(
-          ...applyNodeFilter([target as T], predicate).map((node) => ({
-            node,
-            attributeName,
-          }))
-        );
+        if (this._matches(target as T)) {
+          changes.attributes.push({ node: target as T, attributeName });
+        }
       } else if (type === 'childList') {
-        changes.added.push(
-          ...applyNodeFilter([...addedNodes] as T[], predicate).map((node) => ({
-            target: target as Element,
-            node,
-          }))
-        );
-        changes.removed.push(
-          ...applyNodeFilter([...removedNodes] as T[], predicate).map(
-            (node) => ({
-              target: target as Element,
-              node,
-            })
-          )
-        );
+        this._collect(addedNodes, target as Element, changes.added);
+        this._collect(removedNodes, target as Element, changes.removed);
       }
     }
 

--- a/src/internals/controllers/resize-observer.ts
+++ b/src/internals/controllers/resize-observer.ts
@@ -71,7 +71,10 @@ class ResizeObserverController implements ReactiveController {
   public observe(target: Element): void {
     this._targets.add(target);
     this._observer.observe(target, this._config.options);
+    this._requestUpdate();
+  }
 
+  private _requestUpdate(): void {
     if (this._config.requestUpdate ?? true) {
       this._host.requestUpdate();
     }
@@ -86,7 +89,11 @@ class ResizeObserverController implements ReactiveController {
   /** @internal */
   public hostConnected(): void {
     for (const target of this._targets) {
-      this.observe(target);
+      this._observer.observe(target, this._config.options);
+    }
+
+    if (this._targets.size > 0) {
+      this._requestUpdate();
     }
   }
 

--- a/src/internals/controllers/root-click.ts
+++ b/src/internals/controllers/root-click.ts
@@ -1,7 +1,6 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import { createAbortHandle } from '../abort-handler.js';
 import { isEmpty } from '../utils/arrays.js';
-import { getElementFromPath } from '../utils/events.js';
 
 /** Configuration options for the RootClickController */
 type RootClickControllerConfig = {
@@ -49,37 +48,43 @@ const HOST_CONFIGURATIONS = new WeakMap<
 
 const ACTIVE_HOSTS = new Set<RootClickControllerHost>();
 
-/** Returns the set of elements that should be considered as "inside" the host. */
-function getHostTargets(
+/**
+ * Whether the event occurred "inside" the host, that is on the host itself or
+ * on the additional `target` of its configuration.
+ *
+ * Takes an already resolved composed path, so a single one is shared by all the
+ * active hosts instead of being rebuilt for each of them.
+ */
+function isInsideHost(
+  path: EventTarget[],
   host: RootClickControllerHost,
-  config?: RootClickControllerConfig
-): Set<Element> {
-  return new Set(config?.target ? [host, config.target] : [host]);
+  target?: HTMLElement
+): boolean {
+  return path.some((node) => node === host || node === target);
 }
 
 function handlePointerDown(event: PointerEvent): void {
   POINTER_DOWN_HOSTS.clear();
+  const path = event.composedPath();
 
   for (const host of ACTIVE_HOSTS) {
-    const config = HOST_CONFIGURATIONS.get(host);
-    const targets = getHostTargets(host, config);
-
-    if (getElementFromPath((node) => targets.has(node), event)) {
+    if (isInsideHost(path, host, HOST_CONFIGURATIONS.get(host)?.target)) {
       POINTER_DOWN_HOSTS.add(host);
     }
   }
 }
 
 function handleRootClick(event: PointerEvent): void {
+  const path = event.composedPath();
+
   for (const host of [...ACTIVE_HOSTS]) {
     if (host.keepOpenOnOutsideClick || POINTER_DOWN_HOSTS.has(host)) {
       continue;
     }
 
     const config = HOST_CONFIGURATIONS.get(host);
-    const targets = getHostTargets(host, config);
 
-    if (!getElementFromPath((node) => targets.has(node), event)) {
+    if (!isInsideHost(path, host, config?.target)) {
       config?.onHide ? config.onHide.call(host) : host.hide();
     }
   }
@@ -121,10 +126,6 @@ class RootClickController implements ReactiveController {
   private _addActiveHost(): void {
     ACTIVE_HOSTS.add(this._host);
 
-    if (this._config) {
-      HOST_CONFIGURATIONS.set(this._host, this._config);
-    }
-
     if (!ROOT_CLICK_LISTENER_ACTIVE) {
       const options: AddEventListenerOptions = {
         capture: true,
@@ -146,7 +147,6 @@ class RootClickController implements ReactiveController {
    */
   private _removeActiveHost(): void {
     ACTIVE_HOSTS.delete(this._host);
-    HOST_CONFIGURATIONS.delete(this._host);
     POINTER_DOWN_HOSTS.delete(this._host);
 
     if (isEmpty(ACTIVE_HOSTS) && ROOT_CLICK_LISTENER_ACTIVE) {

--- a/src/internals/controllers/root-scroll.ts
+++ b/src/internals/controllers/root-scroll.ts
@@ -14,86 +14,108 @@ type RootScrollControllerHost = ReactiveControllerHost & {
 
 type ScrollRecord = { scrollTop: number; scrollLeft: number };
 
+/**
+ * `scroll` is not cancelable, so the listener never calls `preventDefault` and
+ * is registered as passive to keep it off the scrolling critical path.
+ */
+const scrollListenerOptions: AddEventListenerOptions = {
+  capture: true,
+  passive: true,
+};
+
+function readScroll(element: Element): ScrollRecord {
+  return { scrollTop: element.scrollTop, scrollLeft: element.scrollLeft };
+}
+
+function writeScroll(element: Element, record: ScrollRecord): void {
+  element.scrollTop = record.scrollTop;
+  element.scrollLeft = record.scrollLeft;
+}
+
 class RootScrollController implements ReactiveController {
-  private _cache: WeakMap<Element, ScrollRecord>;
+  private readonly _host: RootScrollControllerHost;
+  private _config?: RootScrollControllerConfig;
+  private _cache = new WeakMap<Element, ScrollRecord>();
 
   constructor(
-    private readonly host: RootScrollControllerHost,
-    private config?: RootScrollControllerConfig
+    host: RootScrollControllerHost,
+    config?: RootScrollControllerConfig
   ) {
-    this._cache = new WeakMap();
-    this.host.addController(this);
+    this._host = host;
+    this._config = config;
+    this._host.addController(this);
   }
 
-  private configureListeners() {
-    this.host.open ? this.addEventListeners() : this.removeEventListeners();
+  private _configureListeners(): void {
+    this._host.open ? this._addEventListeners() : this._removeEventListeners();
   }
 
-  private hide() {
-    this.config?.hideCallback
-      ? this.config.hideCallback.call(this.host)
-      : this.host.hide();
+  private _hide(): void {
+    this._config?.hideCallback
+      ? this._config.hideCallback.call(this._host)
+      : this._host.hide();
   }
 
-  private addEventListeners() {
-    if (this.host.scrollStrategy !== 'scroll') {
-      document.addEventListener('scroll', this, { capture: true });
+  private _addEventListeners(): void {
+    if (this._host.scrollStrategy !== 'scroll') {
+      document.addEventListener('scroll', this, scrollListenerOptions);
     }
   }
 
-  private removeEventListeners() {
-    document.removeEventListener('scroll', this, { capture: true });
+  private _removeEventListeners(): void {
+    document.removeEventListener('scroll', this, scrollListenerOptions);
     this._cache = new WeakMap();
   }
 
-  public handleEvent(event: Event) {
-    this.host.scrollStrategy === 'close' ? this.hide() : this._block(event);
+  /** @internal */
+  public handleEvent(event: Event): void {
+    this._host.scrollStrategy === 'close' ? this._hide() : this._block(event);
   }
 
-  private _block(event: Event) {
-    event.preventDefault();
+  private _block(event: Event): void {
     const element = event.target as Element;
-    const cache = this._cache;
+    const child = element.firstElementChild;
 
-    if (!cache.has(element)) {
-      cache.set(element, {
-        scrollTop: element.firstElementChild?.scrollTop ?? element.scrollTop,
-        scrollLeft: element.firstElementChild?.scrollLeft ?? element.scrollLeft,
-      });
+    let record = this._cache.get(element);
+
+    if (!record) {
+      record = readScroll(child ?? element);
+      this._cache.set(element, record);
     }
 
-    const record = cache.get(element)!;
-    Object.assign(element, record);
+    writeScroll(element, record);
 
-    if (element.firstElementChild) {
-      Object.assign(element.firstElementChild, record);
+    if (child) {
+      writeScroll(child, record);
     }
   }
 
-  public update(config?: RootScrollControllerConfig) {
+  public update(config?: RootScrollControllerConfig): void {
     if (config) {
-      this.config = { ...this.config, ...config };
+      this._config = { ...this._config, ...config };
     }
 
     if (config?.resetListeners) {
-      this.removeEventListeners();
+      this._removeEventListeners();
     }
 
-    this.configureListeners();
+    this._configureListeners();
   }
 
-  public hostConnected() {
-    this.configureListeners();
+  /** @internal */
+  public hostConnected(): void {
+    this._configureListeners();
   }
 
-  public hostDisconnected() {
-    this.removeEventListeners();
+  /** @internal */
+  public hostDisconnected(): void {
+    this._removeEventListeners();
   }
 }
 
 export function addRootScrollHandler(
   host: RootScrollControllerHost,
   config?: RootScrollControllerConfig
-) {
+): RootScrollController {
   return new RootScrollController(host, config);
 }

--- a/src/internals/controllers/slot.ts
+++ b/src/internals/controllers/slot.ts
@@ -54,6 +54,7 @@ class SlotController<T> implements ReactiveController {
   private readonly _host: ReactiveControllerHost & LitElement;
   private readonly _options: SlotControllerOptions<T>;
   private readonly _slots?: Set<T>;
+  private readonly _slotCache = new Map<T | undefined, HTMLSlotElement>();
   private _initialized = false;
 
   constructor(
@@ -67,17 +68,33 @@ class SlotController<T> implements ReactiveController {
     this._slots = options?.slots ? new Set(options.slots) : undefined;
   }
 
+  /**
+   * The query results are cached, since the accessors below are routinely called
+   * from a host's `render`. Only a still connected slot is served from the cache -
+   * one removed by a conditional template falls back to a fresh query.
+   */
   private _getSlot(slotName?: T): HTMLSlotElement | null {
     if (isServer) return null;
-    if (slotName === DefaultSlot) {
-      return this._host.renderRoot.querySelector<HTMLSlotElement>(
-        'slot:not([name])'
-      );
+
+    const cached = this._slotCache.get(slotName);
+
+    if (cached?.isConnected) {
+      return cached;
     }
 
-    return this._host.renderRoot.querySelector<HTMLSlotElement>(
-      `slot[name="${slotName}"]`
-    );
+    const selector =
+      slotName === DefaultSlot
+        ? 'slot:not([name])'
+        : `slot[name="${slotName}"]`;
+    const slot = this._host.renderRoot.querySelector<HTMLSlotElement>(selector);
+
+    if (slot) {
+      this._slotCache.set(slotName, slot);
+    } else {
+      this._slotCache.delete(slotName);
+    }
+
+    return slot;
   }
 
   /**
@@ -135,11 +152,9 @@ class SlotController<T> implements ReactiveController {
     const slot = event.target as HTMLSlotElement;
     const name = slot.name as T;
     const isDefault = name === '';
+    const observed = isDefault ? (DefaultSlot as T) : name;
 
-    if (
-      !this._slots ||
-      this._slots.has(isDefault ? (DefaultSlot as T) : (slot.name as T))
-    ) {
+    if (!this._slots || this._slots.has(observed)) {
       this._options.onChange?.call(this._host, {
         slot: name,
         isDefault,


### PR DESCRIPTION
## Description

Fixes:
- Gestures never reset `touch-action`. It was cleared by assigning `undefined`, which CSSOM stringifies to an invalid value and ignores, so the property kept its previous value. After the first swipe on `igc-carousel` the element stayed at `touch-action: none` and native panning over it was permanently dead.
- Gestures emitted a phantom swipe on a plain press. Without a `pointermove` the current pointer state stayed at the zeroed default, so the delta was measured against `{x: 0, y: 0}` - a tap low on the page and near the left edge satisfied the "up" threshold. The current state is now seeded from the pointerdown.
- `requestFullscreen()` rejections went unhandled and left the controller reporting a fullscreen state the document was not in. The state is now rolled back and the host re-rendered.

Performance:
- `RootClickController` built one composed path per active host on every pointerdown and click, plus a `Set` per host to hold at most two elements. A single path is now shared across the hosts.
- `KeyBindingController` resolved the composed path twice and lowercased `event.key` up to three times per key event, and re-sorted an already sorted modifier list on every combination lookup.
- `MutationController` ran one `matches()` per configured selector per node; the selector list is now joined once into a single selector, and change aggregation no longer builds intermediate arrays per record.
- The root scroll listener is passive. It called `preventDefault()` on `scroll`, which is not cancelable, so a non-passive document-wide capture listener was blocking scrolling for nothing.
- `KeyboardFocusRingController` requested an update on every `pointerup` and `focusout` even when the state had not changed.
- `SlotController` caches its slot lookups, guarded on `isConnected` so a conditionally rendered slot cannot go stale.
- Smaller: `AdoptedStylesController` tracks its sheets in a `Set` rather than scanning an array, and `ResizeObserverController` requests one update per connect instead of one per observed target.

Simplification:
- The parallel modifier tables in key-bindings derive from a single-entry list, and `_shouldSkip` loses a branch that `_skipSelector` already discriminated.
- root-scroll gets read/write scroll helpers in place of `Object.assign` onto DOM nodes and adopts the `_host`/`_config` conventions its sibling controllers use.
- id-resolver collects added and removed ids through one helper instead of two identical loops.
- `AsyncContextConsumer` no longer awaits `updateComplete` on a reconnect that will not create a consumer.

No public API changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
