### PR TITLE
build(ci): drop the Node 22 pipeline and move to Node 24

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,13 +16,13 @@ For detailed information on issue and pull request statuses, process for testing
 
 ## Set up
 
-You will need at least [Node >= 22.22.0](https://nodejs.org/en) installed on your machine.
+You will need at least [Node >= 24.0.0](https://nodejs.org/en) installed on your machine.
 
 Once you have the minimum Node version installed, you can continue with the rest of the repo setup.
 
 ```shell
 node -v
-v22.22.0
+v24.0.0
 
 git clone https://github.com/IgniteUI/igniteui-webcomponents.git
 cd igniteui-webcomponents

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
       - id: build-publish
         uses: bitovi/github-actions-storybook-to-github-pages@v1.0.4
         with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # Report both versions rather than cancelling the second on the first failure.
+      # Report every version rather than cancelling the rest on the first failure.
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -80,7 +80,7 @@ jobs:
     - run: npm run test
 
     - name: Publish to coveralls.io
-      if: matrix.node-version == '22.x'
+      if: matrix.node-version == '24.x'
       uses: coverallsapp/github-action@v2
       with:
           github-token: ${{ github.token }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Description

The test matrix ran 22.x and 24.x, and every standalone job pinned '22'. Node 22 leaves Maintenance for End-of-Life, so the version we validate and publish under moves up to 24 and the second matrix entry goes away.

The matrix is kept with a single entry rather than inlined, so the next LTS is a one-line addition and the reported check context keeps its shape.

- test matrix: [22.x, 24.x] -> [24.x]
- quality, npm publish and gh-pages jobs: node-version '22' -> '24'
- coveralls upload gate follows the remaining matrix entry
- CONTRIBUTING: raise the contributor Node floor, since 22 is no longer validated anywhere

## Type of Change

- [x] Refactoring (code improvements without functional changes)

