### PR TITLE
fix(dropdown): repair target lifecycle, selection state and ARIA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Keyboard navigation stopped working on a dropdown opened at an explicit target once it had been closed and reopened without passing that target again, because closing dropped the target along with its key event listeners. The target is now kept until another one replaces it.
   - A dropdown opened at an explicit target and then reopened through its own `target` slot stayed positioned at the previous, detached element. The current anchor is now always resolved and handed to the popover.
   - Passing another target to `show()` while the dropdown is already open left `aria-expanded` behind on the previous element and leaked its key event listeners.
-  - `show()` with an id matching no element threw a `TypeError`. It is now a no-op for the target and leaves the current one in place.
+  - `show()` with an id matching no element threw a `TypeError`. An unresolved target now leaves the current one in place, and when there is no anchor at all `show()` returns `false` without opening - the popover cannot place an anchorless list, so the component would have reported itself open while showing nothing.
   - `clearSelection()` cleared the selection but left keyboard navigation on the cleared item, so the next `ArrowDown` returned to it instead of starting from the top of the list.
   - `selectedItem` kept returning an item that had been removed from the DOM. Items entering and leaving the light DOM are now tracked, so the selection is dropped when its item goes away and navigation falls back to the current selection.
   - `aria-haspopup` and `aria-expanded` were left on the target element after the dropdown had been removed from the DOM, or after another target replaced it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - #### Combo
   - The dropdown list is now virtualized using the new `igc-virtual-scroll` component instead of the third-party `@lit-labs/virtualizer` package. [#2222](https://github.com/IgniteUI/igniteui-webcomponents/pull/2222)
+- #### Dropdown
+  - **Behavioral change:** `igcChange` is no longer emitted when the item that is already selected is picked again. Committing the same selection still closes the list, as before.
+  - Improved accessibility: the target element now declares `aria-haspopup="listbox"` instead of `aria-haspopup="true"`, and while the list is open it carries `aria-activedescendant` pointing at the item keyboard navigation is on, so the highlight is announced. Items are given an id for it only if they have none of their own, and everything the component writes onto the target is taken back off it once it stops using it.
 - #### Library
   - Updated some of the optional peer dependencies (`dompurify`, `marked`, `shiki`) to their latest stable versions.
   - Removed the `@lit-labs/virtualizer` dependency. Virtualization is now implemented internally by the new `igc-virtual-scroll` component. [#2222](https://github.com/IgniteUI/igniteui-webcomponents/pull/2222)
@@ -71,6 +74,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - #### Chat
   - With `adoptRootStyles` enabled, stylesheets that entered the document after the initial adoption were ignored, so custom renderers whose styles are injected while the view is being created - Angular component styles, for instance - rendered unstyled content. The document stylesheets are now tracked while the option is on, and any addition or removal is reflected in the shadow roots that adopted them, including stylesheet links that finish loading later. [#2328](https://github.com/IgniteUI/igniteui-webcomponents/issues/2328)
   - Adopting the document styles no longer discards the theme styles of the message and input parts, which were dropped from their shadow roots because the adoption rebuilt the stylesheet list from the component's static styles alone.
+- #### Dropdown
+  - Pressing `Enter` on an open dropdown before any arrow key threw a `TypeError` instead of doing nothing. The item keyboard navigation moves from was typed as always present while it is in fact unset until the list is navigated or something is selected.
+  - Keyboard navigation stopped working on a dropdown opened at an explicit target once it had been closed and reopened without passing that target again, because closing dropped the target along with its key event listeners. The target is now kept until another one replaces it.
+  - A dropdown opened at an explicit target and then reopened through its own `target` slot stayed positioned at the previous, detached element. The current anchor is now always resolved and handed to the popover.
+  - Passing another target to `show()` while the dropdown is already open left `aria-expanded` behind on the previous element and leaked its key event listeners.
+  - `show()` with an id matching no element threw a `TypeError`. It is now a no-op for the target and leaves the current one in place.
+  - `clearSelection()` cleared the selection but left keyboard navigation on the cleared item, so the next `ArrowDown` returned to it instead of starting from the top of the list.
+  - `selectedItem` kept returning an item that had been removed from the DOM. Items entering and leaving the light DOM are now tracked, so the selection is dropped when its item goes away and navigation falls back to the current selection.
+  - `aria-haspopup` and `aria-expanded` were left on the target element after the dropdown had been removed from the DOM, or after another target replaced it.
+  - `igc-dropdown-header` had no role, leaving it in the accessibility tree as a bare child of the `listbox`, which may only own `option` and `group` nodes. It is now taken out of the tree, as `igc-select-header` already was.
+  - The label of an `igc-dropdown-group` named nothing - it is rendered into the group's shadow root, out of reach of the host ARIA - so groups were announced without their label.
 - #### Form associated components
   - Validation messages no longer disappear right after the first failed form submission. The submit-driven invalid state used to hold only for the update the submission itself scheduled, so any re-render that followed - a `slotchange` from the validation slots the submission had just projected, for instance - silently dropped the projected messages while the invalid styling stayed on.
   - Invalid styling now follows the validity state, so a control that turns valid again (a cleared `required`, a widened `min`/`max`, a disabled control) drops the styles it picked up from an earlier interaction or submission.

--- a/src/components/dropdown/dropdown-group.ts
+++ b/src/components/dropdown/dropdown-group.ts
@@ -1,12 +1,15 @@
 import { html, LitElement } from 'lit';
 import { queryAssignedElements } from 'lit/decorators.js';
 import { addInternalsController } from '#internals/controllers/internals.js';
+import { addSlotController, setSlots } from '#internals/controllers/slot.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import { addThemingController } from '#theming/theming-controller.js';
 import IgcDropdownItemComponent from './dropdown-item.js';
 import { styles } from './themes/dropdown-group.base.css.js';
 import { all } from './themes/group.js';
 import { styles as shared } from './themes/shared/group/dropdown-group.common.css.js';
+
+const Slots = setSlots('label');
 
 /**
  * A container for a group of dropdown items.
@@ -19,13 +22,25 @@ import { styles as shared } from './themes/shared/group/dropdown-group.common.cs
  * @csspart label - The native label element.
  */
 export default class IgcDropdownGroupComponent extends LitElement {
-  public static readonly tagName: string = 'igc-dropdown-group';
+  public static readonly tagName = 'igc-dropdown-group';
   public static override styles = [styles, shared];
 
   /* blazorSuppress */
   public static register(): void {
     registerComponent(IgcDropdownGroupComponent);
   }
+
+  private readonly _internals = addInternalsController(this, {
+    initialARIA: {
+      role: 'group',
+    },
+  });
+
+  private readonly _slots = addSlotController(this, {
+    slots: Slots,
+    initial: true,
+    onChange: this._labelChange,
+  });
 
   /* blazorSuppress */
   /** All child dropdown items. */
@@ -39,12 +54,21 @@ export default class IgcDropdownGroupComponent extends LitElement {
     super();
 
     addThemingController(this, all);
+  }
 
-    addInternalsController(this, {
-      initialARIA: {
-        role: 'group',
-      },
-    });
+  /**
+   * The label is rendered into this shadow root, out of reach of an
+   * `aria-labelledby` on the host, so its text names the `group` directly.
+   */
+  private _labelChange(): void {
+    const label = this._slots
+      .getAssignedNodes('label', true)
+      .map((node) => node.textContent ?? '')
+      .join('')
+      .trim()
+      .replace(/\s+/gu, ' ');
+
+    this._internals.setARIA({ ariaLabel: label || null });
   }
 
   protected override render() {

--- a/src/components/dropdown/dropdown-header.ts
+++ b/src/components/dropdown/dropdown-header.ts
@@ -1,4 +1,5 @@
 import { html, LitElement } from 'lit';
+import { addInternalsController } from '#internals/controllers/internals.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import { addThemingController } from '#theming/theming-controller.js';
 import { styles } from './themes/dropdown-header.base.css.js';
@@ -13,7 +14,7 @@ import { styles as shared } from './themes/shared/header/dropdown-header.common.
  * @slot - Renders the header.
  */
 export default class IgcDropdownHeaderComponent extends LitElement {
-  public static readonly tagName: string = 'igc-dropdown-header';
+  public static readonly tagName = 'igc-dropdown-header';
   public static override styles = [styles, shared];
 
   /* blazorSuppress */
@@ -23,6 +24,11 @@ export default class IgcDropdownHeaderComponent extends LitElement {
 
   constructor() {
     super();
+
+    addInternalsController(this, {
+      initialARIA: { role: 'presentation' },
+      reflectRole: true,
+    });
     addThemingController(this, all);
   }
 
@@ -30,6 +36,7 @@ export default class IgcDropdownHeaderComponent extends LitElement {
     return html`<slot></slot>`;
   }
 }
+
 declare global {
   interface HTMLElementTagNameMap {
     'igc-dropdown-header': IgcDropdownHeaderComponent;

--- a/src/components/dropdown/dropdown.spec.ts
+++ b/src/components/dropdown/dropdown.spec.ts
@@ -267,14 +267,22 @@ describe('Dropdown', () => {
       expect(getActiveItem()).to.equal(dropDown.items[1]);
     });
 
-    it('`show()` with an id matching no element keeps the current target', async () => {
+    it('`show()` with an unresolved target and no anchor does not open', async () => {
       const btn = getButton();
 
-      await openDropdown('no-such-element');
-
-      expect(dropDown.open).to.be.true;
+      expect(await dropDown.show('no-such-element')).to.be.false;
+      expect(dropDown.open).to.be.false;
       expect(btn.getAttribute('aria-haspopup')).to.be.null;
       expect(btn.getAttribute('aria-expanded')).to.be.null;
+    });
+
+    it('`show()` with an unresolved target keeps the current one', async () => {
+      await openDropdown('btn');
+      await closeDropdown();
+
+      expect(await dropDown.show('no-such-element')).to.be.true;
+      expect(dropDown.open).to.be.true;
+      checkTargetARIA('true');
     });
 
     it('passing another target while open moves the ARIA and the key handling', async () => {

--- a/src/components/dropdown/dropdown.spec.ts
+++ b/src/components/dropdown/dropdown.spec.ts
@@ -1,5 +1,6 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { spy } from 'sinon';
+import { internalsOf } from '#internals/controllers/internals.js';
 import {
   arrowDown,
   arrowUp,
@@ -168,7 +169,7 @@ describe('Dropdown', () => {
 
     function checkTargetARIA(state: 'true' | 'false') {
       const btn = getButton();
-      expect(btn.getAttribute('aria-haspopup')).to.equal('true');
+      expect(btn.getAttribute('aria-haspopup')).to.equal('listbox');
       expect(btn.getAttribute('aria-expanded')).to.equal(state);
     }
 
@@ -250,6 +251,123 @@ describe('Dropdown', () => {
 
       expect(dropDown.open).to.be.true;
     });
+
+    it('keyboard navigation survives a close and a reopen without a target', async () => {
+      const btn = getButton();
+
+      await openDropdown('btn');
+      await closeDropdown();
+
+      // The target of the previous invocation is still the current one
+      await openDropdown();
+
+      simulateKeyboard(btn, arrowDown, 2);
+      await elementUpdated(dropDown);
+
+      expect(getActiveItem()).to.equal(dropDown.items[1]);
+    });
+
+    it('`show()` with an id matching no element keeps the current target', async () => {
+      const btn = getButton();
+
+      await openDropdown('no-such-element');
+
+      expect(dropDown.open).to.be.true;
+      expect(btn.getAttribute('aria-haspopup')).to.be.null;
+      expect(btn.getAttribute('aria-expanded')).to.be.null;
+    });
+
+    it('passing another target while open moves the ARIA and the key handling', async () => {
+      const first = getButton();
+      const second = document.createElement(IgcButtonComponent.tagName);
+      second.id = 'btn-2';
+      first.after(second);
+
+      await openDropdown(first);
+      await openDropdown(second);
+
+      expect(first.getAttribute('aria-haspopup')).to.be.null;
+      expect(first.getAttribute('aria-expanded')).to.be.null;
+      expect(second.getAttribute('aria-haspopup')).to.equal('listbox');
+      expect(second.getAttribute('aria-expanded')).to.equal('true');
+
+      // The previous target no longer drives the component
+      simulateKeyboard(first, arrowDown);
+      await elementUpdated(dropDown);
+
+      expect(getActiveItem()).to.be.undefined;
+
+      simulateKeyboard(second, arrowDown);
+      await elementUpdated(dropDown);
+
+      expect(getActiveItem()).to.equal(dropDown.items[0]);
+    });
+
+    it('takes its ARIA off the target when the dropdown is removed', async () => {
+      const btn = getButton();
+
+      await openDropdown('btn');
+      simulateKeyboard(btn, arrowDown);
+      await elementUpdated(dropDown);
+
+      expect(btn.getAttribute('aria-haspopup')).to.equal('listbox');
+      expect(btn.getAttribute('aria-activedescendant')).to.not.be.null;
+
+      dropDown.remove();
+
+      expect(btn.getAttribute('aria-haspopup')).to.be.null;
+      expect(btn.getAttribute('aria-expanded')).to.be.null;
+      expect(btn.getAttribute('aria-activedescendant')).to.be.null;
+    });
+
+    it('keeps driving its target after being moved in the DOM', async () => {
+      const btn = getButton();
+      const parent = dropDown.parentElement!;
+
+      await openDropdown('btn');
+
+      dropDown.remove();
+      parent.append(dropDown);
+      await elementUpdated(dropDown);
+
+      expect(btn.getAttribute('aria-haspopup')).to.equal('listbox');
+
+      await openDropdown();
+      simulateKeyboard(btn, arrowDown);
+      await elementUpdated(dropDown);
+
+      expect(getActiveItem()).to.equal(dropDown.items[0]);
+    });
+
+    it('opening through the slotted target takes the anchor back from a detached one', async () => {
+      const dom = await fixture(html`
+        <div>
+          <igc-button id="external">External</igc-button>
+
+          <igc-dropdown>
+            <igc-button slot="target">Open</igc-button>
+            <igc-dropdown-item value="1">1</igc-dropdown-item>
+            <igc-dropdown-item value="2">2</igc-dropdown-item>
+          </igc-dropdown>
+        </div>
+      `);
+
+      dropDown = dom.querySelector(IgcDropdownComponent.tagName)!;
+      const external = dom.querySelector<IgcButtonComponent>('#external')!;
+      const slotted = getTarget();
+      const popover = dropDown.shadowRoot!.querySelector('igc-popover')!;
+
+      await openDropdown(external);
+      await closeDropdown();
+
+      slotted.click();
+      await elementUpdated(dropDown);
+
+      expect(dropDown.open).to.be.true;
+      expect(popover.anchor).to.equal(slotted);
+      expect(slotted.getAttribute('aria-expanded')).to.equal('true');
+      expect(external.getAttribute('aria-expanded')).to.be.null;
+    });
   });
 
   describe('DOM', () => {
@@ -279,6 +397,78 @@ describe('Dropdown', () => {
       // Closed state again
       await expect(dropDown).dom.to.be.accessible();
       await expect(dropDown).shadowDom.to.be.accessible();
+    });
+
+    it('is accessible with headers and groups', async () => {
+      dropDown = await fixture<IgcDropdownComponent>(
+        createAdvancedDropdown(true)
+      );
+
+      simulateKeyboard(dropDown, arrowDown);
+      await elementUpdated(dropDown);
+
+      await expect(dropDown).dom.to.be.accessible();
+      await expect(dropDown).shadowDom.to.be.accessible();
+    });
+  });
+
+  describe('Accessibility', () => {
+    beforeEach(async () => {
+      dropDown = await fixture<IgcDropdownComponent>(createBasicDropdown());
+    });
+
+    it('the target announces the popup and the active item', async () => {
+      const target = getTarget();
+
+      expect(target.getAttribute('aria-haspopup')).to.equal('listbox');
+      expect(target.getAttribute('aria-expanded')).to.equal('false');
+      expect(target.getAttribute('aria-activedescendant')).to.be.null;
+
+      await openDropdown();
+      simulateKeyboard(dropDown, arrowDown);
+      await elementUpdated(dropDown);
+
+      const active = getActiveItem()!;
+
+      expect(active.id).to.not.be.empty;
+      expect(target.getAttribute('aria-expanded')).to.equal('true');
+      expect(target.getAttribute('aria-activedescendant')).to.equal(active.id);
+
+      await closeDropdown();
+
+      expect(target.getAttribute('aria-expanded')).to.equal('false');
+      expect(target.getAttribute('aria-activedescendant')).to.be.null;
+    });
+
+    it('keeps an id the application put on an item', async () => {
+      const item = dropDown.items[0];
+      item.id = 'my-item';
+
+      await openDropdown();
+      simulateKeyboard(dropDown, arrowDown);
+      await elementUpdated(dropDown);
+
+      expect(item.id).to.equal('my-item');
+      expect(getTarget().getAttribute('aria-activedescendant')).to.equal(
+        'my-item'
+      );
+    });
+
+    it('keeps headers out of the accessibility tree', async () => {
+      dropDown = await fixture<IgcDropdownComponent>(createAdvancedDropdown());
+
+      expect(getHeaders()[0].role).to.equal('presentation');
+    });
+
+    it('names groups after their label slot', async () => {
+      dropDown = await fixture<IgcDropdownComponent>(createAdvancedDropdown());
+
+      const [first, second] = dropDown.groups;
+
+      expect(internalsOf(first)?.getARIA('ariaLabel')).to.equal(
+        'Pre development'
+      );
+      expect(internalsOf(second)?.getARIA('ariaLabel')).to.equal('Development');
     });
   });
 
@@ -349,6 +539,22 @@ describe('Dropdown', () => {
 
       expect(dropDown.selectedItem).to.be.null;
       checkItemState(item, { selected: false, active: false });
+    });
+
+    it('`clearSelection()` clears the selection and resets navigation', async () => {
+      dropDown.select(3);
+      dropDown.clearSelection();
+      await elementUpdated(dropDown);
+
+      expect(dropDown.selectedItem).to.be.null;
+      expect(getActiveItem()).to.be.undefined;
+
+      // Navigation starts over instead of resuming from the cleared item
+      await openDropdown();
+      simulateKeyboard(dropDown, arrowDown);
+      await elementUpdated(dropDown);
+
+      expect(getActiveItem()).to.equal(dropDown.items[0]);
     });
 
     it('`navigateTo()` works', async () => {
@@ -493,6 +699,37 @@ describe('Dropdown', () => {
       await elementUpdated(dropDown);
 
       expect(dropDown.open).to.be.true;
+    });
+
+    it('pressing Enter with no active item is a no-op', async () => {
+      await openDropdown();
+
+      simulateKeyboard(dropDown, enterKey);
+      await elementUpdated(dropDown);
+
+      expect(dropDown.open).to.be.true;
+      expect(dropDown.selectedItem).to.be.null;
+      expect(getActiveItem()).to.be.undefined;
+    });
+
+    it('re-selecting the same item does not emit igcChange again', async () => {
+      const targetItem = dropDown.items[3];
+
+      dropDown.keepOpenOnSelect = true;
+      await openDropdown();
+
+      const eventSpy = spy(dropDown, 'emitEvent');
+
+      simulateClick(targetItem);
+      simulateClick(targetItem);
+      await elementUpdated(dropDown);
+
+      const changes = eventSpy
+        .getCalls()
+        .filter((call) => call.firstArg === 'igcChange');
+
+      expect(changes.length).to.equal(1);
+      expect(dropDown.selectedItem).to.equal(targetItem);
     });
 
     it('pressing Escape closes the dropdown without selection', async () => {
@@ -669,6 +906,39 @@ describe('Dropdown', () => {
     });
   });
 
+  describe('Items collection changes', () => {
+    beforeEach(async () => {
+      dropDown = await fixture<IgcDropdownComponent>(createBasicDropdown());
+    });
+
+    it('drops the selection when the selected item is removed', async () => {
+      dropDown.select(1);
+      await elementUpdated(dropDown);
+
+      dropDown.selectedItem!.remove();
+      await elementUpdated(dropDown);
+
+      expect(dropDown.selectedItem).to.be.null;
+      expect(getActiveItem()).to.be.undefined;
+    });
+
+    it('navigation falls back to the selection when the active item is removed', async () => {
+      dropDown.select(1);
+      await openDropdown();
+
+      simulateKeyboard(dropDown, arrowDown, 2);
+      await elementUpdated(dropDown);
+
+      expect(getActiveItem()).to.equal(dropDown.items[3]);
+
+      getActiveItem()!.remove();
+      await elementUpdated(dropDown);
+
+      expect(getActiveItem()).to.equal(dropDown.items[1]);
+      expect(dropDown.selectedItem).to.equal(dropDown.items[1]);
+    });
+  });
+
   describe('Events', () => {
     beforeEach(async () => {
       dropDown = await fixture<IgcDropdownComponent>(createBasicDropdown());
@@ -831,7 +1101,7 @@ describe('Dropdown', () => {
       `);
     });
 
-    it('', async () => {
+    it('selects the item a click landed inside of', async () => {
       await openDropdown();
 
       const inner = document.getElementById('click-target')!;

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -545,6 +545,12 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
   public override async show(target?: HTMLElement | string): Promise<boolean> {
     if (target) {
       this._setExplicitTarget(target);
+
+      // A target that resolves to nothing, with no anchor to fall back on,
+      // would open a list the popover cannot place - and so cannot show.
+      if (!this._target) {
+        return false;
+      }
     }
 
     return super.show();

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import {
   addKeybindings,
@@ -14,10 +14,13 @@ import {
   type KeyBindingObserverCleanup,
   tabKey,
 } from '#internals/controllers/key-bindings.js';
+import {
+  createMutationController,
+  type MutationControllerParams,
+} from '#internals/controllers/mutation-observer.js';
 import { addRootClickController } from '#internals/controllers/root-click.js';
 import { addRootScrollHandler } from '#internals/controllers/root-scroll.js';
 import { blazorAdditionalDependencies } from '#internals/decorators/blazorAdditionalDependencies.js';
-import { watch } from '#internals/decorators/watch.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import {
   getActiveItems,
@@ -29,8 +32,10 @@ import {
 } from '#internals/mixins/combo-box.js';
 import type { AbstractConstructor } from '#internals/mixins/constructor.js';
 import { EventEmitterMixin } from '#internals/mixins/event-emitter.js';
+import { isEmpty } from '#internals/utils/arrays.js';
 import { getElementByIdFromRoot } from '#internals/utils/dom.js';
 import { getElementFromPath } from '#internals/utils/events.js';
+import { createIdGenerator } from '#internals/utils/strings.js';
 import { isString } from '#internals/utils/types.js';
 import { addThemingController } from '#theming/theming-controller.js';
 import IgcPopoverComponent, {
@@ -51,6 +56,8 @@ export interface IgcDropdownComponentEventMap {
   igcClosed: CustomEvent<void>;
   igcChange: CustomEvent<IgcDropdownItemComponent>;
 }
+
+const nextItemId = createIdGenerator('igc-dropdown-item');
 
 /**
  * Represents a Dropdown component.
@@ -80,7 +87,7 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
   public static styles = [styles, shared];
 
   /* blazorSuppress */
-  public static register() {
+  public static register(): void {
     registerComponent(
       IgcDropdownComponent,
       IgcDropdownGroupComponent,
@@ -90,26 +97,46 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
     );
   }
 
+  //#region Internal state
+
   private readonly _keyBindings: KeyBindingController;
 
-  private _rootScrollController = addRootScrollHandler(this, {
-    hideCallback: this.handleClosing,
+  private readonly _rootScrollController = addRootScrollHandler(this, {
+    hideCallback: this._handleClosing,
   });
 
   protected override readonly _rootClickController = addRootClickController(
     this,
     {
-      onHide: this.handleClosing,
+      onHide: this._handleClosing,
     }
   );
 
-  @state()
-  protected _selectedItem: IgcDropdownItemComponent | null = null;
+  private _selectedItem: IgcDropdownItemComponent | null = null;
 
-  @state()
-  protected _activeItem!: IgcDropdownItemComponent;
+  /** The item keyboard navigation moves from. Only {@link _activateItem} assigns it. */
+  private _activeItem: IgcDropdownItemComponent | null = null;
 
-  private get _activeItems() {
+  /** The anchor passed to `show()` / `toggle()`, if any. */
+  private _explicitTarget?: HTMLElement;
+
+  /** The anchor in use - the popover is positioned against it. */
+  @state()
+  private _target?: HTMLElement;
+
+  private _targetListeners?: KeyBindingObserverCleanup;
+
+  @query('slot[name="target"]')
+  private readonly _targetSlot!: HTMLSlotElement | null;
+
+  /** The element currently assigned to the `target` slot, if any. */
+  private get _slottedTarget(): HTMLElement | undefined {
+    const [target] =
+      this._targetSlot?.assignedElements({ flatten: true }) ?? [];
+    return target as HTMLElement | undefined;
+  }
+
+  private get _activeItems(): IgcDropdownItemComponent[] {
     return Array.from(
       getActiveItems<IgcDropdownItemComponent>(
         this,
@@ -118,13 +145,9 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
     );
   }
 
-  private _targetListeners!: KeyBindingObserverCleanup;
+  //#endregion
 
-  @state()
-  private _target?: HTMLElement;
-
-  @query('slot[name="target"]', true)
-  protected trigger!: HTMLSlotElement;
+  //#region Public attributes and properties
 
   /** The preferred placement of the component around the target element.
    * @attr
@@ -162,14 +185,14 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
   public sameWidth = false;
 
   /** Returns the items of the dropdown. */
-  public get items() {
+  public get items(): IgcDropdownItemComponent[] {
     return Array.from(
       getItems<IgcDropdownItemComponent>(this, IgcDropdownItemComponent.tagName)
     );
   }
 
   /** Returns the group items of the dropdown. */
-  public get groups() {
+  public get groups(): IgcDropdownGroupComponent[] {
     return Array.from(
       getItems<IgcDropdownGroupComponent>(
         this,
@@ -179,28 +202,13 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
   }
 
   /** Returns the selected item from the dropdown or null. */
-  public get selectedItem() {
+  public get selectedItem(): IgcDropdownItemComponent | null {
     return this._selectedItem;
   }
 
-  @watch('scrollStrategy', { waitUntilFirstUpdate: true })
-  protected scrollStrategyChanged() {
-    this._rootScrollController.update({ resetListeners: true });
-  }
+  //#endregion
 
-  @watch('open', { waitUntilFirstUpdate: true })
-  @watch('keepOpenOnOutsideClick', { waitUntilFirstUpdate: true })
-  protected openStateChange() {
-    this._updateAnchorAccessibility(this._target);
-    this._rootClickController.update();
-    this._rootScrollController.update();
-
-    if (!this.open) {
-      this._target = undefined;
-      this._targetListeners?.unsubscribe();
-      this._rootClickController.update({ target: undefined });
-    }
-  }
+  //#region Life-cycle
 
   constructor() {
     super();
@@ -211,148 +219,334 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
       skip: () => !this.open,
       bindingDefaults: { preventDefault: true, repeat: true },
     })
-      .set(tabKey, this.onTabKey, {
+      .set(tabKey, this._handleTab, {
         preventDefault: false,
       })
-      .set(escapeKey, this.onEscapeKey)
-      .set(arrowUp, this.onArrowUp)
-      .set(arrowLeft, this.onArrowUp)
-      .set(arrowDown, this.onArrowDown)
-      .set(arrowRight, this.onArrowDown)
-      .set(enterKey, this.onEnterKey)
-      .set(homeKey, this.onHomeKey)
-      .set(endKey, this.onEndKey);
+      .set(escapeKey, this._handleClosing)
+      .set(arrowUp, this._handleArrowUp)
+      .set(arrowLeft, this._handleArrowUp)
+      .set(arrowDown, this._handleArrowDown)
+      .set(arrowRight, this._handleArrowDown)
+      .set(enterKey, this._commitActiveItem)
+      .set(homeKey, this._handleHome)
+      .set(endKey, this._handleEnd);
+
+    createMutationController(this, {
+      callback: this._handleItemsChange,
+      filter: [IgcDropdownItemComponent.tagName],
+      config: { childList: true, subtree: true },
+    });
   }
 
-  protected override async firstUpdated() {
+  /** @internal */
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    // Re-establish what `disconnectedCallback` tore down.
+    this._observeTarget();
+    this._syncAnchorARIA();
+  }
+
+  /** @internal */
+  public override disconnectedCallback(): void {
+    this._releaseTarget();
+    super.disconnectedCallback();
+  }
+
+  protected override willUpdate(properties: PropertyValues<this>): void {
+    if (!this.hasUpdated) {
+      return;
+    }
+
+    const openChanged = properties.has('open');
+    const strategyChanged = properties.has('scrollStrategy');
+
+    if (openChanged || properties.has('keepOpenOnOutsideClick')) {
+      this._rootClickController.update();
+    }
+
+    if (openChanged || strategyChanged) {
+      this._rootScrollController.update({ resetListeners: strategyChanged });
+    }
+  }
+
+  protected override async firstUpdated(): Promise<void> {
     await this.updateComplete;
     const selected = setInitialSelectionState(this.items);
+
     if (selected) {
       this._selectItem(selected, false);
     }
   }
 
-  public override disconnectedCallback() {
-    this._targetListeners?.unsubscribe();
-    super.disconnectedCallback();
+  protected override updated(): void {
+    this._syncAnchorARIA();
   }
 
-  private handleListBoxClick(event: MouseEvent) {
+  //#endregion
+
+  //#region Event handlers
+
+  /**
+   * Re-resolves the selection whenever items enter or leave the light DOM -
+   * frameworks routinely render them after the initial paint, and a selected or
+   * navigated item may be taken out from under us.
+   */
+  private _handleItemsChange({
+    changes: { added, removed },
+  }: MutationControllerParams<IgcDropdownItemComponent>): void {
+    if (!this.hasUpdated || (isEmpty(added) && isEmpty(removed))) {
+      return;
+    }
+
+    const items = this.items;
+
+    if (this._selectedItem && !items.includes(this._selectedItem)) {
+      this._clearSelectedItem();
+    } else if (this._activeItem && !items.includes(this._activeItem)) {
+      this._activateItem(this._selectedItem);
+    }
+  }
+
+  private _handleListBoxClick(event: MouseEvent): void {
     const item = getElementFromPath(IgcDropdownItemComponent.tagName, event);
-    if (item && this._activeItems.includes(item)) {
+
+    if (item && !item.disabled) {
       this._selectItem(item);
     }
   }
 
-  private handleChange(item: IgcDropdownItemComponent) {
-    this.emitEvent('igcChange', { detail: item });
+  protected override _handleAnchorClick(): void {
+    // Opening through our own anchor hands the anchor role back to it.
+    this._explicitTarget = undefined;
+    this._updateTarget();
+
+    super._handleAnchorClick();
   }
 
-  private handleSlotChange() {
-    this._updateAnchorAccessibility();
+  private _handleClosing(): void {
+    this._hide(true);
   }
 
-  private onArrowUp() {
+  private _handleArrowUp(): void {
     this._navigateToActiveItem(
       getPreviousActiveItem(this.items, this._activeItem)
     );
   }
 
-  private onArrowDown() {
+  private _handleArrowDown(): void {
     this._navigateToActiveItem(getNextActiveItem(this.items, this._activeItem));
   }
 
-  protected onHomeKey() {
+  private _handleHome(): void {
     this._navigateToActiveItem(this._activeItems.at(0));
   }
 
-  protected onEndKey() {
+  private _handleEnd(): void {
     this._navigateToActiveItem(this._activeItems.at(-1));
   }
 
-  protected onTabKey() {
+  private _handleTab(): void {
+    this._commitActiveItem();
+
+    // Tab commits and leaves, whatever `keepOpenOnSelect` says.
+    this._hide(true);
+  }
+
+  //#endregion
+
+  //#region Internal API
+
+  /** Selects the item navigation is on, if there is one. */
+  private _commitActiveItem(): void {
     if (this._activeItem) {
       this._selectItem(this._activeItem);
     }
-    if (this.open) {
-      this._hide(true);
-    }
   }
 
-  protected onEscapeKey() {
-    this._hide(true);
-  }
-
-  protected onEnterKey() {
-    this._selectItem(this._activeItem);
-  }
-
-  protected handleClosing() {
-    this._hide(true);
-  }
-
-  private activateItem(item: IgcDropdownItemComponent) {
-    if (this._activeItem) {
+  private _activateItem(item: IgcDropdownItemComponent | null): void {
+    if (this._activeItem && this._activeItem !== item) {
       this._activeItem.active = false;
     }
 
     this._activeItem = item;
-    this._activeItem.active = true;
-  }
 
-  private _navigateToActiveItem(item?: IgcDropdownItemComponent) {
     if (item) {
-      this.activateItem(item);
-      item.scrollIntoView({ behavior: 'auto', block: 'nearest' });
+      item.active = true;
     }
+
+    this._syncAnchorARIA();
   }
 
-  private _selectItem(item: IgcDropdownItemComponent, emit = true) {
-    if (this._selectedItem) {
+  private _setSelectedItem(item: IgcDropdownItemComponent): void {
+    if (this._selectedItem && this._selectedItem !== item) {
       this._selectedItem.selected = false;
     }
 
-    this.activateItem(item);
     this._selectedItem = item;
-    this._selectedItem.selected = true;
+    item.selected = true;
+    this._activateItem(item);
+  }
 
-    if (emit) this.handleChange(this._selectedItem);
-    if (emit && !this.keepOpenOnSelect) this._hide(true);
+  private _selectItem(
+    item?: IgcDropdownItemComponent | null,
+    emit = true
+  ): IgcDropdownItemComponent | null {
+    if (!item) {
+      this._clearSelectedItem();
+      return null;
+    }
+
+    // Re-selecting the current item is not a change, but still a commit.
+    const changed = this._selectedItem !== item;
+
+    changed ? this._setSelectedItem(item) : this._activateItem(item);
+
+    if (emit) {
+      if (changed) {
+        this.emitEvent('igcChange', { detail: item });
+      }
+
+      if (!this.keepOpenOnSelect) {
+        this._hide(true);
+      }
+    }
 
     return this._selectedItem;
   }
 
-  private _updateAnchorAccessibility(anchor?: HTMLElement | null) {
-    const target =
-      anchor ?? this.trigger.assignedElements({ flatten: true }).at(0);
+  private _clearSelectedItem(): void {
+    if (this._selectedItem) {
+      this._selectedItem.selected = false;
+    }
 
-    // Find tabbable elements ?
-    if (target) {
-      target.setAttribute('aria-haspopup', 'true');
-      target.setAttribute('aria-expanded', this.open ? 'true' : 'false');
+    this._selectedItem = null;
+    this._activateItem(null);
+  }
+
+  /** Highlights `item` and, while the list is open, brings it into view. */
+  private _navigateToActiveItem(item?: IgcDropdownItemComponent | null): void {
+    if (!item) {
+      return;
+    }
+
+    this._activateItem(item);
+
+    // Closed, the list is inert and off screen.
+    if (this.open) {
+      item.scrollIntoView({ behavior: 'auto', block: 'nearest' });
     }
   }
 
-  private getItem(value: string) {
-    return this.items.find((item) => item.value === value);
+  /** Resolves an item by its `value`, or by its index in {@link items}. */
+  private _resolveItem(
+    value: string | number
+  ): IgcDropdownItemComponent | undefined {
+    return isString(value)
+      ? this.items.find((item) => item.value === value)
+      : this.items[value];
   }
 
-  private _setTarget(anchor: HTMLElement | string) {
-    const target = isString(anchor)
-      ? getElementByIdFromRoot(this, anchor)!
-      : anchor;
+  /**
+   * Moves everything bound to the anchor - key event listeners, outside click
+   * exemption and ARIA - over to the one currently in effect.
+   */
+  private _updateTarget(): void {
+    const target = this._explicitTarget ?? this._slottedTarget;
+
+    if (target === this._target) {
+      return;
+    }
+
+    this._releaseTarget();
 
     this._target = target;
-    this._targetListeners = this._keyBindings.observeElement(target);
     this._rootClickController.update({ target });
+    this._observeTarget();
+    this._syncAnchorARIA();
   }
+
+  /**
+   * Only an anchor outside of our own DOM needs listeners of its own - keyboard
+   * events on a slotted one already reach the host.
+   */
+  private _observeTarget(): void {
+    const target = this._target;
+
+    if (target && !this._targetListeners && !this.contains(target)) {
+      this._targetListeners = this._keyBindings.observeElement(target);
+    }
+  }
+
+  private _setExplicitTarget(anchor: HTMLElement | string): void {
+    const target = isString(anchor)
+      ? getElementByIdFromRoot(this, anchor)
+      : anchor;
+
+    // An id matching nothing leaves the current anchor in place.
+    if (!target) {
+      return;
+    }
+
+    this._explicitTarget = target;
+    this._updateTarget();
+  }
+
+  /**
+   * Publishes the popup state and the navigation position on the current anchor.
+   *
+   * `aria-activedescendant` goes on the anchor because that is what holds DOM
+   * focus - the list is never focused, since the key bindings are observed on
+   * the anchor itself. There is no `aria-controls` to go with it: the list it
+   * would name lives in this shadow root, which an IDREF cannot cross and ARIA
+   * element reflection only ever resolves out of, never into.
+   */
+  private _syncAnchorARIA(): void {
+    const anchor = this._target;
+
+    if (!anchor) {
+      return;
+    }
+
+    const active = this.open ? this._activeItem : null;
+
+    anchor.setAttribute('aria-haspopup', 'listbox');
+    anchor.setAttribute('aria-expanded', `${this.open}`);
+
+    if (active) {
+      // Items only need an id if they have none of their own
+      active.id ||= nextItemId();
+      anchor.setAttribute('aria-activedescendant', active.id);
+    } else {
+      anchor.removeAttribute('aria-activedescendant');
+    }
+  }
+
+  /**
+   * Stops driving the current anchor: its key event listeners go, along with
+   * everything {@link _syncAnchorARIA} wrote onto it.
+   */
+  private _releaseTarget(): void {
+    this._targetListeners?.unsubscribe();
+    this._targetListeners = undefined;
+
+    const anchor = this._target;
+
+    anchor?.removeAttribute('aria-haspopup');
+    anchor?.removeAttribute('aria-expanded');
+    anchor?.removeAttribute('aria-activedescendant');
+  }
+
+  //#endregion
+
+  //#region Public API
 
   /* blazorSuppress */
   /** Shows the component. */
   public override async show(target?: HTMLElement | string): Promise<boolean> {
     if (target) {
-      this._setTarget(target);
+      this._setExplicitTarget(target);
     }
+
     return super.show();
   }
 
@@ -373,7 +567,7 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
   /* blazorSuppress */
   /** Navigates to the specified item. If it exists, returns the found item, otherwise - null. */
   public navigateTo(value: string | number): IgcDropdownItemComponent | null {
-    const item = isString(value) ? this.getItem(value) : this.items[value];
+    const item = this._resolveItem(value);
 
     if (item) {
       this._navigateToActiveItem(item);
@@ -391,17 +585,16 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
   /* blazorSuppress */
   /** Selects the specified item. If it exists, returns the found item, otherwise - null. */
   public select(value: string | number): IgcDropdownItemComponent | null {
-    const item = isString(value) ? this.getItem(value) : this.items[value];
+    const item = this._resolveItem(value);
     return item ? this._selectItem(item, false) : null;
   }
 
   /**  Clears the current selection of the dropdown. */
-  public clearSelection() {
-    if (this._selectedItem) {
-      this._selectedItem.selected = false;
-    }
-    this._selectedItem = null;
+  public clearSelection(): void {
+    this._clearSelectedItem();
   }
+
+  //#endregion
 
   protected override render() {
     return html`<igc-popover
@@ -418,9 +611,9 @@ export default class IgcDropdownComponent extends EventEmitterMixin<
         name="target"
         slot="anchor"
         @click=${this._handleAnchorClick}
-        @slotchange=${this.handleSlotChange}
+        @slotchange=${this._updateTarget}
       ></slot>
-      <div part="base" @click=${this.handleListBoxClick} .inert=${!this.open}>
+      <div part="base" @click=${this._handleListBoxClick} .inert=${!this.open}>
         <div
           id="dropdown-list"
           role="listbox"

--- a/stories/dropdown.stories.ts
+++ b/stories/dropdown.stories.ts
@@ -259,6 +259,11 @@ const scenarioStyles = html`
       font-size: 2rem;
     }
 
+    .file:focus-visible {
+      outline: 2px solid var(--ig-primary-500, #09f);
+      outline-offset: 1px;
+    }
+
     .file {
       display: flex;
       flex-direction: column;
@@ -634,7 +639,7 @@ export const ContextMenu: Story = {
     docs: {
       description: {
         story:
-          'A file browser context menu. `contextmenu` is cancelled and the dropdown is anchored to the tile that was right-clicked, so one menu serves the whole grid and the list opens against the item it acts on. Escape and an outside click dismiss it, as with any other invocation.',
+          'A file browser context menu. `contextmenu` is cancelled and the dropdown is anchored to the tile that was right-clicked, so one menu serves the whole grid and the list opens against the item it acts on. The tiles are focusable and the clicked one is focused before the menu opens: keyboard handling follows the target, so that is what makes the arrow keys, Enter and Escape work on the open list.',
       },
     },
   },
@@ -646,7 +651,12 @@ export const ContextMenu: Story = {
     function openMenu(name: string, event: MouseEvent) {
       event.preventDefault();
       activeFile = name;
-      menu.value?.show(event.currentTarget as HTMLElement);
+
+      // The dropdown observes key events on its target, so the tile has to hold
+      // focus for Escape and the arrow keys to reach the open list
+      const tile = event.currentTarget as HTMLElement;
+      tile.focus();
+      menu.value?.show(tile);
     }
 
     function onChange({ detail }: CustomEvent<IgcDropdownItemComponent>) {
@@ -658,13 +668,14 @@ export const ContextMenu: Story = {
     return html`
       ${scenarioStyles}
       <div class="scenario">
-        <p>Right-click a file.</p>
+        <p>Right-click a file, then navigate the menu with the keyboard.</p>
 
         <div class="files">
           ${files.map(
             ({ name, icon }) => html`
               <div
                 class="file"
+                tabindex="0"
                 @contextmenu=${(event: MouseEvent) => openMenu(name, event)}
               >
                 <igc-icon collection="internal" name=${icon}></igc-icon>

--- a/stories/dropdown.stories.ts
+++ b/stories/dropdown.stories.ts
@@ -1,30 +1,48 @@
-import { github, whiteHouse1 } from '@igniteui/material-icons-extended';
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { html } from 'lit';
 import { range } from 'lit/directives/range.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 
 import {
+  IgcAvatarComponent,
   IgcButtonComponent,
   IgcDropdownComponent,
+  type IgcDropdownItemComponent,
+  IgcIconButtonComponent,
   IgcIconComponent,
   IgcInputComponent,
   defineComponents,
-  registerIconFromText,
+  registerIcon,
 } from 'igniteui-webcomponents';
 import { disableStoryControls } from './story.js';
 
-const icons = [github, whiteHouse1];
-
-icons.forEach((icon) => {
-  registerIconFromText(icon.name, icon.value);
-});
-
 defineComponents(
-  IgcDropdownComponent,
-  IgcInputComponent,
+  IgcAvatarComponent,
   IgcButtonComponent,
-  IgcIconComponent
+  IgcDropdownComponent,
+  IgcIconButtonComponent,
+  IgcIconComponent,
+  IgcInputComponent
 );
+
+const materialIcons = 'https://unpkg.com/material-design-icons@3.0.1';
+
+for (const [name, path] of [
+  ['archive', 'content/svg/production/ic_archive_24px.svg'],
+  ['delete', 'action/svg/production/ic_delete_24px.svg'],
+  ['download', 'file/svg/production/ic_file_download_24px.svg'],
+  ['edit', 'image/svg/production/ic_edit_24px.svg'],
+  ['language', 'action/svg/production/ic_language_24px.svg'],
+  ['open_external', 'action/svg/production/ic_open_in_new_24px.svg'],
+  ['person', 'social/svg/production/ic_person_24px.svg'],
+  ['settings', 'action/svg/production/ic_settings_24px.svg'],
+  ['share', 'social/svg/production/ic_share_24px.svg'],
+  ['sign_out', 'action/svg/production/ic_exit_to_app_24px.svg'],
+  ['sort', 'content/svg/production/ic_sort_24px.svg'],
+  ['view', 'action/svg/production/ic_visibility_24px.svg'],
+]) {
+  registerIcon(name, `${materialIcons}/${path}`);
+}
 
 // region default
 const metadata: Meta<IgcDropdownComponent> = {
@@ -180,34 +198,116 @@ type Story = StoryObj<IgcDropdownArgs>;
 
 // endregion
 
-const Items = [
-  'Specification',
-  'Implementation',
-  'Testing',
-  'Samples',
-  'Documentation',
-  'Builds',
-].map(
-  (each) =>
-    html`<igc-dropdown-item value=${each}
-      ><igc-icon slot="prefix" name="github"></igc-icon>${each}<igc-icon
-        slot="suffix"
-        name="github"
-      ></igc-icon
-    ></igc-dropdown-item>`
-);
+/** Shared styling for the application-like story scenarios. */
+const scenarioStyles = html`
+  <style>
+    .scenario {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      max-width: 46rem;
+    }
 
-const overflowItems = Array.from(range(1, 51)).map(
-  (each) =>
-    html`<igc-dropdown-item value=${each}>Item ${each}</igc-dropdown-item>`
-);
+    .scenario table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+
+    .scenario th,
+    .scenario td {
+      border-bottom: 1px solid var(--ig-gray-200, #e0e0e0);
+      padding: 0.25rem 0.75rem;
+      text-align: start;
+      white-space: nowrap;
+    }
+
+    .scenario th:last-child,
+    .scenario td:last-child {
+      text-align: end;
+      width: 3rem;
+    }
+
+    .numeric {
+      text-align: end !important;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .app-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      background: var(--ig-gray-100, #f5f5f5);
+    }
+
+    .user-target::part(base) {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-height: fit-content;
+    }
+
+    .files {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+      gap: 0.5rem;
+    }
+
+    .file igc-icon {
+      font-size: 2rem;
+    }
+
+    .file {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.75rem 0.5rem;
+      border: 1px solid var(--ig-gray-200, #e0e0e0);
+      border-radius: 4px;
+      cursor: context-menu;
+      user-select: none;
+    }
+
+    .settings-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.75rem 1rem;
+      border: 1px solid var(--ig-gray-200, #e0e0e0);
+      border-radius: 4px;
+    }
+
+    .panel {
+      height: 16rem;
+      overflow: auto;
+      padding: 1rem;
+      border: 1px solid var(--ig-gray-200, #e0e0e0);
+      border-radius: 4px;
+    }
+
+    .log {
+      margin: 0;
+      min-height: 1.25rem;
+      font-family: monospace;
+      color: var(--ig-primary-500, #09f);
+    }
+
+    .danger::part(content) {
+      color: var(--ig-error-500, #d32f2f);
+    }
+  </style>
+`;
 
 export const Default: Story = {
   parameters: {
     docs: {
       description: {
         story:
-          'A basic dropdown anchored to a button target via the `target` slot. All placement, scroll strategy, and open/close behavior can be configured from the controls panel.',
+          'The component and its parts, wired to the controls panel. A button in the `target` slot anchors the list; everything else - placement, distance, scroll strategy and the open/close behavior - is configurable here.',
       },
     },
   },
@@ -222,7 +322,6 @@ export const Default: Story = {
     scrollStrategy,
   }) => html`
     <igc-dropdown
-      id="dropdown"
       ?open=${open}
       ?flip=${flip}
       ?keep-open-on-outside-click=${keepOpenOnOutsideClick}
@@ -232,293 +331,513 @@ export const Default: Story = {
       .distance=${distance}
       .scrollStrategy=${scrollStrategy}
     >
-      <igc-button slot="target">Tasks</igc-button>
-      <igc-dropdown-header>Available tasks:</igc-dropdown-header>
-      ${Items}
-    </igc-dropdown>
-  `,
-};
+      <igc-button slot="target">Move to</igc-button>
 
-export const Overflow: Story = {
-  args: {
-    sameWidth: true,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'A dropdown with a large number of items whose list height is constrained via `::part(list)`. Demonstrates vertical scrolling inside the list and the `scrollStrategy` behavior when scrolling the page.',
-      },
-    },
-  },
-  render: ({
-    distance,
-    open,
-    flip,
-    keepOpenOnOutsideClick,
-    keepOpenOnSelect,
-    placement,
-    sameWidth,
-    scrollStrategy,
-  }) => html`
-    <style>
-      .dropdown-container {
-        display: flex;
-        margin: 20rem auto;
-        justify-content: center;
-      }
-
-      #overflowing::part(list) {
-        max-height: 50vh;
-      }
-    </style>
-    <div class="dropdown-container">
-      <igc-dropdown
-        id="overflowing"
-        ?same-width=${sameWidth}
-        ?open=${open}
-        ?flip=${flip}
-        ?keep-open-on-outside-click=${keepOpenOnOutsideClick}
-        ?keep-open-on-select=${keepOpenOnSelect}
-        .placement=${placement}
-        .distance=${distance}
-        .scrollStrategy=${scrollStrategy}
-      >
-        <igc-button slot="target">With vertical overflow</igc-button>
-        <igc-dropdown-header>Items:</igc-dropdown-header>
-        ${overflowItems}
-      </igc-dropdown>
-    </div>
-  `,
-};
-
-const gdpEurope = [
-  {
-    country: 'Luxembourg',
-    value: '135,605',
-    flag: 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/Flag_of_Luxembourg.svg/23px-Flag_of_Luxembourg.svg.png',
-  },
-  {
-    country: 'Ireland',
-    value: '112,248',
-    flag: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Flag_of_Ireland.svg/23px-Flag_of_Ireland.svg.png',
-  },
-  {
-    country: 'Switzerland',
-    value: '102,865',
-    flag: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Flag_of_Switzerland_%28Pantone%29.svg/15px-Flag_of_Switzerland_%28Pantone%29.svg.png',
-  },
-].map(
-  ({ country, flag, value }) =>
-    html`<igc-dropdown-item value=${country}>
-      <img slot="prefix" src=${flag} alt="Flag of ${country}" />
-      ${country} ${value}
-    </igc-dropdown-item>`
-);
-
-const gdpAmericas = [
-  {
-    country: 'United States',
-    value: '80,412',
-    flag: 'https://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/23px-Flag_of_the_United_States.svg.png',
-  },
-  {
-    country: 'Canada',
-    value: '53,247',
-    flag: 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Flag_of_Canada_%28Pantone%29.svg/23px-Flag_of_Canada_%28Pantone%29.svg.png',
-  },
-  {
-    country: 'Puerto Rico',
-    value: '37,093',
-    flag: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Flag_of_Puerto_Rico.svg/23px-Flag_of_Puerto_Rico.svg.png',
-  },
-].map(
-  ({ country, flag, value }) =>
-    html`<igc-dropdown-item value=${country}>
-      <img slot="prefix" src=${flag} alt="Flag of ${country}" />
-      ${country} ${value}
-    </igc-dropdown-item>`
-);
-
-export const GroupsAndHeaders: Story = {
-  args: {
-    sameWidth: true,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Items organized into `igc-dropdown-group` elements with group labels and `igc-dropdown-header` separators. Each item uses the `prefix` slot for a flag image.',
-      },
-    },
-  },
-  render: ({
-    open,
-    keepOpenOnOutsideClick,
-    keepOpenOnSelect,
-    distance,
-    flip,
-    placement,
-    sameWidth,
-  }) => html`
-    <style>
-      igc-dropdown-header {
-        text-align: start;
-      }
-      img {
-        width: 23px;
-        height: 12px;
-      }
-      .group-title {
-        font-size: 0.75rem;
-      }
-    </style>
-    <igc-dropdown
-      id="groups-and-headers"
-      ?open=${open}
-      ?flip=${flip}
-      ?keep-open-on-outside-click=${keepOpenOnOutsideClick}
-      ?keep-open-on-select=${keepOpenOnSelect}
-      ?same-width=${sameWidth}
-      .placement=${placement}
-      .distance=${distance}
-    >
-      <igc-button slot="target"
-        >GDP (in USD) per capita by country (IMF)</igc-button
-      >
+      <igc-dropdown-header>Recent</igc-dropdown-header>
+      <igc-dropdown-item value="inbox">Inbox</igc-dropdown-item>
+      <igc-dropdown-item value="starred">Starred</igc-dropdown-item>
 
       <igc-dropdown-group>
-        <p class="group-title" slot="label">
-          UN Region: <strong>Europe</strong>
-        </p>
-        <igc-dropdown-header>Estimate for 2023</igc-dropdown-header>
-        ${gdpEurope}
-      </igc-dropdown-group>
-
-      <igc-dropdown-group>
-        <p slot="label" class="group-title">
-          UN Region: <strong>Americas</strong>
-        </p>
-        <igc-dropdown-header>Estimate for 2023</igc-dropdown-header>
-        ${gdpAmericas}
+        <span slot="label">Projects</span>
+        <igc-dropdown-item value="website">Website redesign</igc-dropdown-item>
+        <igc-dropdown-item value="mobile">Mobile app</igc-dropdown-item>
+        <igc-dropdown-item value="archive" disabled
+          >Archive (read-only)</igc-dropdown-item
+        >
       </igc-dropdown-group>
     </igc-dropdown>
   `,
 };
 
-function setVersion(event: Event) {
-  const input = document.querySelector<IgcInputComponent>('#versions')!;
-  const value = (event.target as IgcDropdownComponent).selectedItem?.value;
-  input.value = value?.replace(/\p{Extended_Pictographic}/gu, '') ?? '';
+type Order = {
+  id: string;
+  customer: string;
+  total: number;
+  status: string;
+};
+
+const orders: Order[] = [
+  { id: 'ORD-1041', customer: 'Farrell Ltd', total: 1290.5, status: 'Paid' },
+  { id: 'ORD-1042', customer: 'Nordwind GmbH', total: 340, status: 'Pending' },
+  { id: 'ORD-1043', customer: 'Kite & Co', total: 8710.25, status: 'Paid' },
+  { id: 'ORD-1044', customer: 'Vitalis AD', total: 96.9, status: 'Refunded' },
+];
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+/**
+ * The row actions of a table are the textbook case for a single dropdown moved
+ * between targets: one instance serves every row, instead of one per row.
+ */
+function createTableController() {
+  const rowMenu = createRef<IgcDropdownComponent>();
+  const sortMenu = createRef<IgcDropdownComponent>();
+  const body = createRef<HTMLTableSectionElement>();
+  const log = createRef<HTMLElement>();
+
+  let activeOrder: Order | undefined;
+
+  function report(message: string) {
+    if (log.value) {
+      log.value.textContent = message;
+    }
+  }
+
+  function openRowMenu(order: Order, event: Event) {
+    const menu = rowMenu.value;
+    const trigger = event.currentTarget as HTMLElement;
+
+    if (!menu) return;
+
+    // Clicking the trigger of the row the menu is already open for closes it
+    if (menu.open && activeOrder === order) {
+      menu.hide();
+      return;
+    }
+
+    activeOrder = order;
+    menu.show(trigger);
+  }
+
+  function runRowAction({ detail }: CustomEvent<IgcDropdownItemComponent>) {
+    report(`${detail.textContent?.trim()} -> ${activeOrder?.id}`);
+  }
+
+  function toggleSortMenu(event: Event) {
+    sortMenu.value?.toggle(event.currentTarget as HTMLElement);
+  }
+
+  function sortRows({ detail }: CustomEvent<IgcDropdownItemComponent>) {
+    const direction = detail.value;
+    const rows = Array.from(body.value?.rows ?? []);
+
+    if (direction === 'clear') {
+      rows.sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
+      // Nothing is sorted, so the menu should not show a selection either
+      sortMenu.value?.clearSelection();
+      report('Sort cleared');
+    } else {
+      rows.sort((a, b) => {
+        const [left, right] = [
+          Number(a.dataset.total),
+          Number(b.dataset.total),
+        ];
+        return direction === 'asc' ? left - right : right - left;
+      });
+      report(
+        `Sorted by total, ${direction === 'asc' ? 'ascending' : 'descending'}`
+      );
+    }
+
+    body.value?.append(...rows);
+  }
+
+  return {
+    rowMenu,
+    sortMenu,
+    body,
+    log,
+    openRowMenu,
+    runRowAction,
+    toggleSortMenu,
+    sortRows,
+  };
 }
 
-export const OpenFromInteraction: Story = {
+export const TableActions: Story = {
   argTypes: disableStoryControls(metadata),
   parameters: {
     docs: {
       description: {
         story:
-          'Demonstrates calling `toggle()` and `show()` programmatically via `id` references, letting an external button and an input focus event control the same dropdown.',
+          'An orders table with a sort menu on a column header and an actions menu on every row. Both are single dropdown instances: the row menu is moved to whichever trigger was clicked with `show(target)`, which is what keeps a table of a thousand rows down to one popup. The sort menu holds the applied sort as its own selection and `clearSelection()` resets it.',
       },
     },
   },
-  render: () => html`
-    <style>
-      .version-container {
-        padding: 1rem;
-        display: flex;
-        flex-wrap: wrap;
-        align-items: flex-end;
-        justify-content: space-between;
-      }
-    </style>
-    <p>Open the dropdown from the button on the side to choose a version</p>
-    <div class="version-container">
-      <igc-input id="versions" label="Target version" readonly outlined>
-      </igc-input>
+  render: () => {
+    const table = createTableController();
 
-      <igc-button
-        onclick="dropdownVersions.toggle('versions'); versions.focus()"
-        >Select version</igc-button
+    return html`
+      ${scenarioStyles}
+      <div class="scenario">
+        <table>
+          <thead>
+            <tr>
+              <th>Order</th>
+              <th>Customer</th>
+              <th class="numeric">
+                Total
+                <igc-icon-button
+                  variant="flat"
+                  name="sort"
+                  aria-label="Sort by total"
+                  @click=${table.toggleSortMenu}
+                ></igc-icon-button>
+              </th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody ${ref(table.body)}>
+            ${orders.map(
+              (order, index) => html`
+                <tr data-index=${index} data-total=${order.total}>
+                  <td>${order.id}</td>
+                  <td>${order.customer}</td>
+                  <td class="numeric">${currency.format(order.total)}</td>
+                  <td>${order.status}</td>
+                  <td>
+                    <igc-icon-button
+                      variant="flat"
+                      collection="internal"
+                      name="more_horiz"
+                      aria-label="Actions for ${order.id}"
+                      @click=${(event: Event) =>
+                        table.openRowMenu(order, event)}
+                    ></igc-icon-button>
+                  </td>
+                </tr>
+              `
+            )}
+          </tbody>
+        </table>
+
+        <p class="log" ${ref(table.log)}></p>
+      </div>
+
+      <igc-dropdown
+        ${ref(table.sortMenu)}
+        placement="bottom-end"
+        distance="4"
+        @igcChange=${table.sortRows}
       >
-    </div>
+        <igc-dropdown-item value="asc">Sort ascending</igc-dropdown-item>
+        <igc-dropdown-item value="desc">Sort descending</igc-dropdown-item>
+        <igc-dropdown-item value="clear">Clear sort</igc-dropdown-item>
+      </igc-dropdown>
 
-    <igc-dropdown
-      flip
-      same-width
-      id="dropdownVersions"
-      @igcChange=${setVersion}
-    >
-      <igc-dropdown-item disabled
-        >5.0 &lt;pending release&gt;
-      </igc-dropdown-item>
-      <igc-dropdown-item>4.11 ⭐</igc-dropdown-item>
-      <igc-dropdown-item>4.10</igc-dropdown-item>
-      <igc-dropdown-item>4.9</igc-dropdown-item>
-      <igc-dropdown-item>4.8</igc-dropdown-item>
-      <igc-dropdown-item>4.7</igc-dropdown-item>
-    </igc-dropdown>
-  `,
+      <igc-dropdown
+        ${ref(table.rowMenu)}
+        placement="bottom-end"
+        distance="4"
+        @igcChange=${table.runRowAction}
+      >
+        <igc-dropdown-item value="view">
+          <igc-icon slot="prefix" name="view"></igc-icon>
+          View details
+        </igc-dropdown-item>
+        <igc-dropdown-item value="edit">
+          <igc-icon slot="prefix" name="edit"></igc-icon>
+          Edit
+        </igc-dropdown-item>
+        <igc-dropdown-item value="duplicate">
+          <igc-icon slot="prefix" collection="internal" name="copy"></igc-icon>
+          Duplicate
+        </igc-dropdown-item>
+        <igc-dropdown-item value="archive">
+          <igc-icon slot="prefix" name="archive"></igc-icon>
+          Archive
+        </igc-dropdown-item>
+        <igc-dropdown-item value="delete" class="danger">
+          <igc-icon slot="prefix" name="delete"></igc-icon>
+          Delete
+        </igc-dropdown-item>
+      </igc-dropdown>
+    `;
+  },
 };
 
-export const WithNonSlottedTarget: Story = {
+export const AccountMenu: Story = {
+  argTypes: disableStoryControls(metadata),
   parameters: {
     docs: {
       description: {
         story:
-          'Shows how to drive a single dropdown from multiple external targets — buttons and an input — by passing the target element reference to `show()`. The dropdown has no `target` slot and is positioned relative to whichever element triggered it.',
+          'The account menu of an application bar: the trigger lives in the `target` slot, so the dropdown follows it wherever the bar puts it, and `bottom-end` keeps the list inside the viewport at the right edge. A header labels the signed-in account, and a group separates the destructive action.',
       },
     },
   },
-  render: ({
-    distance,
-    open,
-    flip,
-    keepOpenOnOutsideClick,
-    keepOpenOnSelect,
-    placement,
-    sameWidth,
-  }) => html`
+  render: () => {
+    const log = createRef<HTMLElement>();
+
+    function onChange({ detail }: CustomEvent<IgcDropdownItemComponent>) {
+      if (log.value) {
+        log.value.textContent = `Navigating to ${detail.value}`;
+      }
+    }
+
+    return html`
+      ${scenarioStyles}
+      <div class="scenario">
+        <div class="app-bar">
+          <strong>Contoso Admin</strong>
+
+          <igc-dropdown
+            placement="bottom-end"
+            distance="6"
+            @igcChange=${onChange}
+          >
+            <igc-button class="user-target" slot="target" variant="flat">
+              <igc-avatar
+                style="--ig-size: 1"
+                initials="AR"
+                shape="circle"
+              ></igc-avatar>
+              Alex Rivera
+              <igc-icon
+                collection="internal"
+                name="keyboard_arrow_down"
+              ></igc-icon>
+            </igc-button>
+
+            <igc-dropdown-header>alex.rivera@contoso.com</igc-dropdown-header>
+            <igc-dropdown-item value="profile">
+              <igc-icon slot="prefix" name="person"></igc-icon>
+              Your profile
+            </igc-dropdown-item>
+            <igc-dropdown-item value="preferences">
+              <igc-icon slot="prefix" name="settings"></igc-icon>
+              Preferences
+            </igc-dropdown-item>
+
+            <igc-dropdown-group>
+              <span slot="label">Session</span>
+              <igc-dropdown-item value="sign-out">
+                <igc-icon slot="prefix" name="sign_out"></igc-icon>
+                Sign out
+              </igc-dropdown-item>
+            </igc-dropdown-group>
+          </igc-dropdown>
+        </div>
+
+        <p class="log" ${ref(log)}></p>
+      </div>
+    `;
+  },
+};
+
+const files = [
+  { name: 'Q3-report.pdf', icon: 'file_pdf' },
+  { name: 'budget.xlsx', icon: 'file_xls' },
+  { name: 'contacts.csv', icon: 'file_csv' },
+  { name: 'logo.svg', icon: 'file_svg' },
+  { name: 'notes.txt', icon: 'file_txt' },
+  { name: 'archive.zip', icon: 'file_zip' },
+];
+
+export const ContextMenu: Story = {
+  argTypes: disableStoryControls(metadata),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A file browser context menu. `contextmenu` is cancelled and the dropdown is anchored to the tile that was right-clicked, so one menu serves the whole grid and the list opens against the item it acts on. Escape and an outside click dismiss it, as with any other invocation.',
+      },
+    },
+  },
+  render: () => {
+    const menu = createRef<IgcDropdownComponent>();
+    const log = createRef<HTMLElement>();
+    let activeFile = '';
+
+    function openMenu(name: string, event: MouseEvent) {
+      event.preventDefault();
+      activeFile = name;
+      menu.value?.show(event.currentTarget as HTMLElement);
+    }
+
+    function onChange({ detail }: CustomEvent<IgcDropdownItemComponent>) {
+      if (log.value) {
+        log.value.textContent = `${detail.textContent?.trim()} -> ${activeFile}`;
+      }
+    }
+
+    return html`
+      ${scenarioStyles}
+      <div class="scenario">
+        <p>Right-click a file.</p>
+
+        <div class="files">
+          ${files.map(
+            ({ name, icon }) => html`
+              <div
+                class="file"
+                @contextmenu=${(event: MouseEvent) => openMenu(name, event)}
+              >
+                <igc-icon collection="internal" name=${icon}></igc-icon>
+                <small>${name}</small>
+              </div>
+            `
+          )}
+        </div>
+
+        <p class="log" ${ref(log)}></p>
+      </div>
+
+      <igc-dropdown ${ref(menu)} distance="2" @igcChange=${onChange}>
+        <igc-dropdown-item value="open">
+          <igc-icon slot="prefix" name="open_external"></igc-icon>
+          Open
+        </igc-dropdown-item>
+        <igc-dropdown-item value="rename">
+          <igc-icon slot="prefix" name="edit"></igc-icon>
+          Rename
+        </igc-dropdown-item>
+        <igc-dropdown-item value="download">
+          <igc-icon slot="prefix" name="download"></igc-icon>
+          Download
+        </igc-dropdown-item>
+        <igc-dropdown-item value="share">
+          <igc-icon slot="prefix" name="share"></igc-icon>
+          Share
+        </igc-dropdown-item>
+        <igc-dropdown-item value="delete" class="danger">
+          <igc-icon slot="prefix" name="delete"></igc-icon>
+          Delete
+        </igc-dropdown-item>
+      </igc-dropdown>
+    `;
+  },
+};
+
+const languages = [
+  { region: 'Americas', locale: 'en-US', flag: '🇺🇸', label: 'English (US)' },
+  { region: 'Americas', locale: 'pt-BR', flag: '🇧🇷', label: 'Português (BR)' },
+  { region: 'Europe', locale: 'en-GB', flag: '🇬🇧', label: 'English (UK)' },
+  { region: 'Europe', locale: 'de-DE', flag: '🇩🇪', label: 'Deutsch' },
+  { region: 'Europe', locale: 'bg-BG', flag: '🇧🇬', label: 'Български' },
+  { region: 'Asia', locale: 'ja-JP', flag: '🇯🇵', label: '日本語' },
+];
+
+const regions = [...new Set(languages.map(({ region }) => region))];
+
+export const LanguagePicker: Story = {
+  argTypes: disableStoryControls(metadata),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A settings row backed by application state. The current locale is rendered as a `selected` item, which the component picks up as its initial selection on its own, and `igcChange` writes the choice back into the trigger. `same-width` keeps the list aligned with the field it belongs to, and the locales are grouped by region.',
+      },
+    },
+  },
+  render: () => {
+    const label = createRef<HTMLElement>();
+    let locale = 'en-GB';
+
+    function onChange({ detail }: CustomEvent<IgcDropdownItemComponent>) {
+      locale = detail.value;
+      const choice = languages.find((each) => each.locale === locale);
+
+      if (label.value && choice) {
+        label.value.textContent = `${choice.flag} ${choice.label}`;
+      }
+    }
+
+    const current = languages.find((each) => each.locale === locale)!;
+
+    return html`
+      ${scenarioStyles}
+      <div class="scenario">
+        <div class="settings-row">
+          <div>
+            <div><strong>Interface language</strong></div>
+            <small>Applies to menus, dates and number formats.</small>
+          </div>
+
+          <igc-dropdown same-width flip @igcChange=${onChange}>
+            <igc-button slot="target" variant="outlined">
+              <igc-icon slot="prefix" name="language"></igc-icon>
+              <span ${ref(label)}>${current.flag} ${current.label}</span>
+            </igc-button>
+
+            ${regions.map(
+              (region) => html`
+                <igc-dropdown-group>
+                  <span slot="label">${region}</span>
+                  ${languages
+                    .filter((each) => each.region === region)
+                    .map(
+                      ({ locale: value, flag, label: name }) => html`
+                        <igc-dropdown-item
+                          value=${value}
+                          ?selected=${value === locale}
+                        >
+                          <span slot="prefix">${flag}</span>
+                          ${name}
+                        </igc-dropdown-item>
+                      `
+                    )}
+                </igc-dropdown-group>
+              `
+            )}
+          </igc-dropdown>
+        </div>
+      </div>
+    `;
+  },
+};
+
+const timeZones = Array.from(range(-11, 13)).flatMap((offset) =>
+  ['00', '30'].map(
+    (minutes) => html`
+      <igc-dropdown-item value="${offset}:${minutes}">
+        UTC${offset < 0 ? offset : `+${offset}`}:${minutes}
+      </igc-dropdown-item>
+    `
+  )
+);
+
+export const InScrollingPanel: Story = {
+  args: {
+    sameWidth: false,
+    scrollStrategy: 'block',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A long list opened from inside a scrolling panel - a settings pane, a dialog body, a side drawer. The list height is capped with `::part(list)` so it scrolls on its own, and `scroll-strategy` decides what scrolling the panel underneath does to it: `scroll` lets it follow, `block` freezes the panel, `close` dismisses the list.',
+      },
+    },
+  },
+  render: ({ scrollStrategy, sameWidth, flip, distance, placement }) => html`
+    ${scenarioStyles}
     <style>
-      .container {
-        display: flex;
-        justify-content: space-between;
+      #time-zones::part(list) {
+        max-height: 14rem;
       }
     </style>
-    <div class="container">
-      <igc-button id="1st" onclick="detachedDropdown.show('1st')"
-        >First</igc-button
-      >
-      <igc-button id="2nd" onclick="detachedDropdown.show('2nd')"
-        >Second</igc-button
-      >
-      <igc-button id="3rd" onclick="detachedDropdown.show('3rd')"
-        >Third</igc-button
-      >
-      <igc-button id="4th" onclick="detachedDropdown.show('4th')"
-        >Fourth</igc-button
-      >
-    </div>
-    <igc-input
-      id="input"
-      style="max-width: 15rem"
-      label="Focus me"
-      onfocus="detachedDropdown.show('input')"
-    ></igc-input>
 
-    <igc-dropdown
-      id="detachedDropdown"
-      .distance=${distance}
-      ?open=${open}
-      ?flip=${flip}
-      ?keep-open-on-outside-click=${keepOpenOnOutsideClick}
-      ?keep-open-on-select=${keepOpenOnSelect}
-      .placement=${placement}
-      ?same-width=${sameWidth}
-    >
-      <igc-dropdown-item>1</igc-dropdown-item>
-      <igc-dropdown-item>2</igc-dropdown-item>
-      <igc-dropdown-item>3</igc-dropdown-item>
-    </igc-dropdown>
+    <div class="scenario">
+      <div class="panel">
+        <h4>Regional settings</h4>
+        <p>
+          Scroll this panel with the list open to compare the scroll strategies.
+        </p>
+
+        <igc-dropdown
+          id="time-zones"
+          ?same-width=${sameWidth}
+          ?flip=${flip}
+          .placement=${placement}
+          .distance=${distance}
+          .scrollStrategy=${scrollStrategy}
+        >
+          <igc-button slot="target">Time zone</igc-button>
+          <igc-dropdown-header>UTC offset</igc-dropdown-header>
+          ${timeZones}
+        </igc-dropdown>
+
+        <p>
+          ${Array.from(range(1, 12)).map(
+            () => html`Regional formatting affects dates, times and numbers. `
+          )}
+        </p>
+      </div>
+    </div>
   `,
 };


### PR DESCRIPTION
## Description

Fixes:
- Enter on an open dropdown before any arrow key threw a TypeError.
- Keyboard navigation died once a dropdown opened at an explicit target was closed and reopened without that target, or after being moved in the DOM. The resolved target now outlives the open state.
- Reopening through the `target` slot left the list positioned at a previously passed, detached element.
- `show(other)` while open left `aria-expanded` on the previous element and leaked its key event listeners; `show('unknown-id')` threw.
- `clearSelection()` left navigation on the cleared item.
- `selectedItem` kept returning items removed from the DOM.
- `aria-haspopup` / `aria-expanded` outlived the dropdown on its target.
- `igc-dropdown-header` had no role inside the `listbox`, and an `igc-dropdown-group` label named nothing - both ports of what `igc-select-header` and `igc-select-group` already do.

Accessibility: the target declares `aria-haspopup="listbox"` and, while open, `aria-activedescendant` for the item navigation is on, so the highlight is announced. Focus stays on the target, which is what the key bindings are observed on, so that is where the relation belongs.

Behavioral change: `igcChange` is no longer emitted when the already selected item is picked again; the list still closes.

Refactor: `@watch` gives way to `willUpdate`, target resolution funnels through one step that carries key listeners, outside-click exemption and ARIA with it, selection follows select's shape, and the internals are `_`-prefixed and laid out in regions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Behavioral change 
- [x] Refactoring (code improvements without functional changes)


## Testing

16 new specs cover the fixed behaviors. No public API changes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
