### PR TITLE
fix(button-group): repair selection identity, disabled inheritance and ARIA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `select()` now matches a tab's `label` as well as its IDREF, so the value reported by `selected` can be passed back into it.
 
 ### Changed
+- #### Button group
+  - **Behavioral change:** a disabled group no longer writes `disabled` onto its buttons. The state is inherited, so a button disabled in its own right stays disabled once the group is enabled again, and buttons added to a disabled group are disabled as well.
+  - Improved accessibility: the `single` and `single-required` modes expose a `radiogroup` of `radio` buttons instead of toggle buttons with `aria-pressed`. The `focused` CSS part of `igc-toggle-button` is now documented.
 - #### Combo
   - The dropdown list is now virtualized using the new `igc-virtual-scroll` component instead of the third-party `@lit-labs/virtualizer` package. [#2222](https://github.com/IgniteUI/igniteui-webcomponents/pull/2222)
 - #### Dropdown
@@ -71,6 +74,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Improved accessibility: the default `sticky` mode close action is a real, labelled `<button>` rather than a bare icon, so it can be reached and activated from the keyboard. It is exposed through the new `close-button` CSS part.
 
 ### Fixed
+- #### Button group
+  - Single selection compared button values, so buttons without a `value` - or sharing one - could never hand the selection over: clicking a second button only cleared the first. Selection is now tracked per element. [#2229](https://github.com/IgniteUI/igniteui-webcomponents/issues/2229)
+  - `selectedItems` added to the current selection instead of replacing it, and left out buttons whose `value` is an empty string.
+  - A disabled group could still be interacted with through buttons added to it after it was disabled.
+  - `focus()`, `blur()` and `click()` on `igc-toggle-button` threw when called before its first render.
+  - Toggle buttons that are not direct children of the group took part in its selection state, which could leave two buttons selected in a single selection mode, or drop the selection altogether.
 - #### Calendar
   - A calendar showing several months announced every navigation once per visible month, because the off screen live region holding the current period was rendered together with each month's navigation. There is now a single live region for the whole calendar.
   - A calendar showing more than one month exposed one tab stop per visible month, so tabbing through it stepped into every month's grid instead of leaving the calendar. Only the active days view now holds the tab stop of its active date.

--- a/src/components/button-group/button-group.spec.ts
+++ b/src/components/button-group/button-group.spec.ts
@@ -1,21 +1,14 @@
-import {
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-  unsafeStatic,
-} from '@open-wc/testing';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { type TemplateResult } from 'lit';
 import { spy } from 'sinon';
-
-import {
-  defineComponents,
-  IgcButtonGroupComponent,
-  IgcToggleButtonComponent,
-} from '../../index.js';
+import { defineComponents } from '#internals/definitions/defineComponents.js';
+import { simulateClick } from '#internals/testing/simulate.spec.js';
+import IgcButtonGroupComponent from './button-group.js';
+import IgcToggleButtonComponent from './toggle-button.js';
 
 describe('Button Group', () => {
   before(() => {
-    defineComponents(IgcButtonGroupComponent);
+    defineComponents(IgcButtonGroupComponent, IgcToggleButtonComponent);
   });
 
   const DIFF_OPTIONS = {
@@ -29,9 +22,9 @@ describe('Button Group', () => {
   describe('', () => {
     beforeEach(async () => {
       buttonGroup = await createButtonGroupComponent();
-      buttons = buttonGroup.querySelectorAll(
-        'igc-toggle-button'
-      ) as unknown as IgcToggleButtonComponent[];
+      buttons = Array.from(
+        buttonGroup.querySelectorAll(IgcToggleButtonComponent.tagName)
+      );
     });
 
     describe('Initialization Tests', () => {
@@ -54,11 +47,11 @@ describe('Button Group', () => {
       });
 
       it('should render proper role and attributes', () => {
-        const buttonGroupElement = buttonGroup.shadowRoot?.querySelector('div');
+        const buttonGroupElement = buttonGroup.renderRoot.querySelector('div');
 
         expect(buttonGroupElement).not.to.be.null;
         expect(buttonGroupElement).to.have.attribute('part', 'group');
-        expect(buttonGroupElement).to.have.attribute('role', 'group');
+        expect(buttonGroupElement).to.have.attribute('role', 'radiogroup');
         expect(buttonGroupElement).to.have.attribute('aria-disabled', 'false');
       });
     });
@@ -86,15 +79,22 @@ describe('Button Group', () => {
           DIFF_OPTIONS
         );
 
-        buttons.forEach((b) => {
-          expect(b.disabled).to.be.true;
-          expect(b).dom.to.equal(
-            `<igc-toggle-button disabled>${b.textContent?.trim()}</igc-toggle-button>`,
+        // The buttons inherit the disabled state of the group without having
+        // their own overwritten.
+        for (const button of buttons) {
+          await elementUpdated(button);
+
+          expect(button.disabled).to.be.false;
+          expect(button).dom.to.equal(
+            `<igc-toggle-button>${button.textContent?.trim()}</igc-toggle-button>`,
             {
               ignoreAttributes: ['value'],
             }
           );
-        });
+          expect(button.renderRoot.querySelector('button')).to.have.attribute(
+            'disabled'
+          );
+        }
 
         buttonGroup.disabled = false;
         await elementUpdated(buttonGroup);
@@ -105,15 +105,20 @@ describe('Button Group', () => {
           DIFF_OPTIONS
         );
 
-        buttons.forEach((b) => {
-          expect(b.disabled).to.be.false;
-          expect(b).dom.to.equal(
-            `<igc-toggle-button>${b.textContent?.trim()}</igc-toggle-button>`,
+        for (const button of buttons) {
+          await elementUpdated(button);
+
+          expect(button.disabled).to.be.false;
+          expect(button).dom.to.equal(
+            `<igc-toggle-button>${button.textContent?.trim()}</igc-toggle-button>`,
             {
               ignoreAttributes: ['value'],
             }
           );
-        });
+          expect(
+            button.renderRoot.querySelector('button')
+          ).not.to.have.attribute('disabled');
+        }
       });
 
       it('sets `alignment` property successfully', async () => {
@@ -146,34 +151,43 @@ describe('Button Group', () => {
     describe('Selection Tests', () => {
       it('should initialize a button group with initial selection state through attribute', async () => {
         // single mode
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selected-items='["left"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group .selectedItems=${['left']}>
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // single-required mode
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selection="single-required" selected-items='["left"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group
+            selection="single-required"
+            .selectedItems=${['left']}
+          >
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // multiple mode
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selection="multiple" selected-items='["left", "right"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group
+            selection="multiple"
+            .selectedItems=${['left', 'right']}
+          >
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(2);
         expect(buttonGroup.selectedItems).to.have.same.members([
@@ -184,34 +198,39 @@ describe('Button Group', () => {
 
       it('should initialize a button group with initial selection state through child attribute', async () => {
         // single mode
-        buttonGroup = await createButtonGroupComponent(`
+        buttonGroup = await createButtonGroupComponent(html`
           <igc-button-group>
             <igc-toggle-button value="left" selected>Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // single-required mode
-        buttonGroup = await createButtonGroupComponent(`
+        buttonGroup = await createButtonGroupComponent(html`
           <igc-button-group selection="single-required">
             <igc-toggle-button value="left" selected>Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // multiple mode
-        buttonGroup = await createButtonGroupComponent(`
+        buttonGroup = await createButtonGroupComponent(html`
           <igc-button-group selection="multiple">
             <igc-toggle-button value="left" selected>Left</igc-toggle-button>
-            <igc-toggle-button value="center" selected>Center</igc-toggle-button>
+            <igc-toggle-button value="center" selected
+              >Center</igc-toggle-button
+            >
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(2);
         expect(buttonGroup.selectedItems).to.have.same.members([
@@ -287,23 +306,27 @@ describe('Button Group', () => {
       it('should set the selectedItems to be the last selected button if multiple buttons are selected', async () => {
         // single mode
         // through selected-items attribute
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selected-items='["right", "left"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group .selectedItems=${['right', 'left']}>
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // through child selected attribute
-        buttonGroup = await createButtonGroupComponent(`
+        buttonGroup = await createButtonGroupComponent(html`
           <igc-button-group>
             <igc-toggle-button value="left" selected>Left</igc-toggle-button>
-            <igc-toggle-button value="center" selected>Center</igc-toggle-button>
+            <igc-toggle-button value="center" selected
+              >Center</igc-toggle-button
+            >
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['center']);
@@ -318,34 +341,42 @@ describe('Button Group', () => {
 
         // single-required mode
         // through selected-items attribute
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selection="single-required" selected-items='["right", "left"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group
+            selection="single-required"
+            .selectedItems=${['right', 'left']}
+          >
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // through child selected attribute
-        buttonGroup = await createButtonGroupComponent(`
+        buttonGroup = await createButtonGroupComponent(html`
           <igc-button-group selection="single-required">
             <igc-toggle-button value="left" selected>Left</igc-toggle-button>
-            <igc-toggle-button value="center" selected>Center</igc-toggle-button>
+            <igc-toggle-button value="center" selected
+              >Center</igc-toggle-button
+            >
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['center']);
 
         // through selectedItems property
-        buttonGroup = await createButtonGroupComponent(`
+        buttonGroup = await createButtonGroupComponent(html`
           <igc-button-group selection="single-required">
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right">Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         buttonGroup.selectedItems = ['right', 'left'];
         await elementUpdated(buttonGroup);
@@ -478,35 +509,44 @@ describe('Button Group', () => {
 
       it('initial selection through child selection attribute has higher priority', async () => {
         // single mode
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selected-items='["left"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group .selectedItems=${['left']}>
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right" selected>Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['right']);
 
         // single-required mode
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selection="single-required" selected-items='["left"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group
+            selection="single-required"
+            .selectedItems=${['left']}
+          >
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right" selected>Right</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['right']);
 
         // multiple mode
-        buttonGroup = await createButtonGroupComponent(`
-          <igc-button-group selection="multiple" selected-items='["left", "center"]'>
+        buttonGroup = await createButtonGroupComponent(html`
+          <igc-button-group
+            selection="multiple"
+            .selectedItems=${['left', 'center']}
+          >
             <igc-toggle-button value="left">Left</igc-toggle-button>
             <igc-toggle-button value="center">Center</igc-toggle-button>
             <igc-toggle-button value="right" selected>Right</igc-toggle-button>
             <igc-toggle-button value="top" selected>Top</igc-toggle-button>
-          </igc-button-group>`);
+          </igc-button-group>
+        `);
 
         expect(buttonGroup.selectedItems.length).to.equal(2);
         expect(buttonGroup.selectedItems).to.have.same.members([
@@ -522,21 +562,21 @@ describe('Button Group', () => {
         expect(buttonGroup.selectedItems.length).to.equal(0);
 
         // select first button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // select second button
-        buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[1]);
         await elementUpdated(buttonGroup);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['center']);
 
         // deselect second button
-        buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[1]);
         await elementUpdated(buttonGroup);
 
         expect(buttonGroup.selectedItems.length).to.equal(0);
@@ -554,7 +594,7 @@ describe('Button Group', () => {
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
         // deselect button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
@@ -568,13 +608,13 @@ describe('Button Group', () => {
         expect(buttonGroup.selection).to.equal('multiple');
         expect(buttonGroup.selectedItems.length).to.equal(0);
 
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         expect(buttonGroup.selectedItems.length).to.equal(1);
         expect(buttonGroup.selectedItems).to.have.same.members(['left']);
 
-        buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[1]);
         await elementUpdated(buttonGroup);
 
         expect(buttonGroup.selectedItems.length).to.equal(2);
@@ -590,7 +630,7 @@ describe('Button Group', () => {
 
         expect(buttonGroup.disabled).to.be.true;
 
-        const buttonGroupElement = buttonGroup.shadowRoot?.querySelector('div');
+        const buttonGroupElement = buttonGroup.renderRoot.querySelector('div');
         expect(buttonGroupElement).to.have.attribute('aria-disabled', 'true');
 
         buttons.forEach((button) => {
@@ -602,7 +642,7 @@ describe('Button Group', () => {
       it('should emit `igcSelect` event on select', async () => {
         const eventSpy = spy(buttonGroup, 'emitEvent');
 
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         const args = { detail: buttons[0].value };
@@ -624,7 +664,7 @@ describe('Button Group', () => {
         await elementUpdated(buttonGroup);
 
         // deselect button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         const args = { detail: buttons[0].value };
@@ -642,7 +682,7 @@ describe('Button Group', () => {
         const deselectArgs = { detail: '' };
 
         // select first button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         selectArgs.detail = buttons[0].value;
@@ -654,7 +694,7 @@ describe('Button Group', () => {
         ]);
 
         // select second button
-        buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[1]);
         await elementUpdated(buttonGroup);
 
         selectArgs.detail = buttons[1].value;
@@ -677,7 +717,7 @@ describe('Button Group', () => {
         await elementUpdated(buttonGroup);
 
         // select first button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         selectArgs.detail = buttons[0].value;
@@ -692,7 +732,7 @@ describe('Button Group', () => {
 
         // deselect first button
         // should not emit events when interacting with an already selected button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         expect(eventSpy).not.calledWith('igcDeselect');
@@ -703,7 +743,7 @@ describe('Button Group', () => {
         ]);
 
         // select second button
-        buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[1]);
         await elementUpdated(buttonGroup);
 
         selectArgs.detail = buttons[1].value;
@@ -726,7 +766,7 @@ describe('Button Group', () => {
         await elementUpdated(buttonGroup);
 
         // select first button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         selectArgs.detail = buttons[0].value;
@@ -738,7 +778,7 @@ describe('Button Group', () => {
         ]);
 
         // select second button
-        buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[1]);
         await elementUpdated(buttonGroup);
 
         selectArgs.detail = buttons[1].value;
@@ -752,7 +792,7 @@ describe('Button Group', () => {
         ]);
 
         // deselect first button
-        buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        simulateClick(buttons[0]);
         await elementUpdated(buttonGroup);
 
         deselectArgs.detail = buttons[0].value;
@@ -766,14 +806,276 @@ describe('Button Group', () => {
     });
   });
 
-  const createButtonGroupComponent = (
-    template = `
-      <igc-button-group>
-        <igc-toggle-button value="left">Left</igc-toggle-button>
-        <igc-toggle-button value="center">Center</igc-toggle-button>
-        <igc-toggle-button value="right">Right</igc-toggle-button>
-      </igc-button-group>`
-  ) => {
-    return fixture<IgcButtonGroupComponent>(html`${unsafeStatic(template)}`);
-  };
+  describe('Selection reconciliation', () => {
+    it('moves the selection between buttons without a `value`', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group>
+          <igc-toggle-button>Left</igc-toggle-button>
+          <igc-toggle-button>Right</igc-toggle-button>
+        </igc-button-group>
+      `);
+      const items = Array.from(
+        group.querySelectorAll(IgcToggleButtonComponent.tagName)
+      );
+
+      simulateClick(items[0]);
+      await elementUpdated(group);
+
+      expect(items[0].selected).to.be.true;
+
+      simulateClick(items[1]);
+      await elementUpdated(group);
+
+      expect(items[0].selected).to.be.false;
+      expect(items[1].selected).to.be.true;
+    });
+
+    it('moves the selection between buttons sharing the same `value`', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group>
+          <igc-toggle-button value="same">Left</igc-toggle-button>
+          <igc-toggle-button value="same">Right</igc-toggle-button>
+        </igc-button-group>
+      `);
+      const items = Array.from(
+        group.querySelectorAll(IgcToggleButtonComponent.tagName)
+      );
+
+      simulateClick(items[0]);
+      await elementUpdated(group);
+
+      simulateClick(items[1]);
+      await elementUpdated(group);
+
+      expect(items[0].selected).to.be.false;
+      expect(items[1].selected).to.be.true;
+    });
+
+    it('replaces the previous selection when setting `selectedItems` (multiple)', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group selection="multiple">
+          <igc-toggle-button value="left">Left</igc-toggle-button>
+          <igc-toggle-button value="center">Center</igc-toggle-button>
+          <igc-toggle-button value="right">Right</igc-toggle-button>
+        </igc-button-group>
+      `);
+
+      group.selectedItems = ['left', 'center'];
+      await elementUpdated(group);
+
+      expect(group.selectedItems).to.have.same.members(['left', 'center']);
+
+      group.selectedItems = ['right'];
+
+      // The new selection is in effect synchronously
+      expect(group.selectedItems).to.have.same.members(['right']);
+    });
+
+    it('replaces the previous selection when setting `selectedItems` (single)', async () => {
+      const group = await createButtonGroupComponent();
+
+      group.selectedItems = ['left'];
+      await elementUpdated(group);
+
+      group.selectedItems = ['right'];
+
+      expect(group.selectedItems).to.have.same.members(['right']);
+    });
+
+    it('keeps buttons with an empty `value` in `selectedItems`', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group selection="multiple">
+          <igc-toggle-button value="" selected>Empty</igc-toggle-button>
+          <igc-toggle-button value="right" selected>Right</igc-toggle-button>
+        </igc-button-group>
+      `);
+
+      expect(group.selectedItems).to.have.same.members(['', 'right']);
+    });
+
+    it('ignores toggle buttons that are not direct children of the group', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group>
+          <igc-toggle-button value="left" selected>Left</igc-toggle-button>
+          <div>
+            <igc-toggle-button value="nested">Nested</igc-toggle-button>
+          </div>
+        </igc-button-group>
+      `);
+
+      const own = group.querySelector<IgcToggleButtonComponent>(
+        ':scope > igc-toggle-button'
+      )!;
+      const nested = group.querySelector<IgcToggleButtonComponent>(
+        ':scope > div > igc-toggle-button'
+      )!;
+
+      nested.selected = true;
+      await elementUpdated(group);
+
+      // The nested button is not part of the group and does not affect its selection
+      expect(own.selected).to.be.true;
+      expect(group.selectedItems).to.have.same.members(['left']);
+
+      simulateClick(nested);
+      await elementUpdated(group);
+
+      expect(group.selectedItems).to.have.same.members(['left']);
+    });
+  });
+
+  describe('Disabled state', () => {
+    const getNativeButton = (button: IgcToggleButtonComponent) =>
+      button.renderRoot.querySelector('button');
+
+    it('disables buttons added while the group is disabled', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group disabled>
+          <igc-toggle-button value="left">Left</igc-toggle-button>
+        </igc-button-group>
+      `);
+
+      const added = document.createElement(IgcToggleButtonComponent.tagName);
+      added.value = 'added';
+      group.appendChild(added);
+      await elementUpdated(added);
+
+      expect(getNativeButton(added)).to.have.attribute('disabled');
+
+      simulateClick(added);
+      await elementUpdated(group);
+
+      expect(group.selectedItems).to.be.empty;
+    });
+
+    it('keeps the own disabled state of its buttons intact', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group>
+          <igc-toggle-button value="left" disabled>Left</igc-toggle-button>
+          <igc-toggle-button value="right">Right</igc-toggle-button>
+        </igc-button-group>
+      `);
+      const items = Array.from(
+        group.querySelectorAll(IgcToggleButtonComponent.tagName)
+      );
+
+      group.disabled = true;
+      await elementUpdated(group);
+
+      for (const button of items) {
+        await elementUpdated(button);
+        expect(getNativeButton(button)).to.have.attribute('disabled');
+      }
+
+      group.disabled = false;
+      await elementUpdated(group);
+
+      for (const button of items) {
+        await elementUpdated(button);
+      }
+
+      expect(items[0].disabled).to.be.true;
+      expect(getNativeButton(items[0])).to.have.attribute('disabled');
+
+      expect(items[1].disabled).to.be.false;
+      expect(getNativeButton(items[1])).not.to.have.attribute('disabled');
+    });
+  });
+
+  describe('ARIA', () => {
+    const getRole = (group: IgcButtonGroupComponent) =>
+      group.renderRoot.querySelector('div')?.getAttribute('role');
+
+    const getButtonPart = (button: IgcToggleButtonComponent) =>
+      button.renderRoot.querySelector('button');
+
+    it('exposes radio semantics in the single selection modes', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group selection="single-required">
+          <igc-toggle-button value="left" selected>Left</igc-toggle-button>
+          <igc-toggle-button value="right">Right</igc-toggle-button>
+        </igc-button-group>
+      `);
+      const items = Array.from(
+        group.querySelectorAll(IgcToggleButtonComponent.tagName)
+      );
+      await elementUpdated(items[0]);
+      await elementUpdated(items[1]);
+
+      expect(getRole(group)).to.equal('radiogroup');
+
+      for (const button of items) {
+        const element = getButtonPart(button)!;
+
+        expect(element).to.have.attribute('role', 'radio');
+        expect(element).to.have.attribute(
+          'aria-checked',
+          String(button.selected)
+        );
+        expect(element).not.to.have.attribute('aria-pressed');
+      }
+
+      await expect(group).to.be.accessible();
+    });
+
+    it('exposes toggle button semantics in multiple selection mode', async () => {
+      const group = await createButtonGroupComponent(html`
+        <igc-button-group selection="multiple">
+          <igc-toggle-button value="left" selected>Left</igc-toggle-button>
+          <igc-toggle-button value="right">Right</igc-toggle-button>
+        </igc-button-group>
+      `);
+      const items = Array.from(
+        group.querySelectorAll(IgcToggleButtonComponent.tagName)
+      );
+      await elementUpdated(items[0]);
+      await elementUpdated(items[1]);
+
+      expect(getRole(group)).to.equal('group');
+
+      for (const button of items) {
+        const element = getButtonPart(button)!;
+
+        expect(element).not.to.have.attribute('role');
+        expect(element).to.have.attribute(
+          'aria-pressed',
+          String(button.selected)
+        );
+        expect(element).not.to.have.attribute('aria-checked');
+      }
+
+      await expect(group).to.be.accessible();
+    });
+
+    it('updates the semantics when the selection mode changes', async () => {
+      const group = await createButtonGroupComponent();
+      const items = Array.from(
+        group.querySelectorAll(IgcToggleButtonComponent.tagName)
+      );
+
+      expect(getRole(group)).to.equal('radiogroup');
+
+      group.selection = 'multiple';
+      await elementUpdated(group);
+      await elementUpdated(items[0]);
+
+      expect(getRole(group)).to.equal('group');
+      expect(getButtonPart(items[0])).to.have.attribute('aria-pressed');
+    });
+  });
+
+  function createButtonGroupComponent(template?: TemplateResult) {
+    return fixture<IgcButtonGroupComponent>(
+      html`${
+        template ??
+        html`
+          <igc-button-group>
+            <igc-toggle-button value="left">Left</igc-toggle-button>
+            <igc-toggle-button value="center">Center</igc-toggle-button>
+            <igc-toggle-button value="right">Right</igc-toggle-button>
+          </igc-button-group>
+        `
+      }`
+    );
+  }
 });

--- a/src/components/button-group/button-group.ts
+++ b/src/components/button-group/button-group.ts
@@ -1,15 +1,19 @@
-import { html, LitElement } from 'lit';
-import { property, queryAssignedElements } from 'lit/decorators.js';
+import { ContextProvider } from '@lit/context';
 import {
-  createMutationController,
-  type MutationControllerParams,
-} from '#internals/controllers/mutation-observer.js';
-import { watch } from '#internals/decorators/watch.js';
+  html,
+  LitElement,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
+import { property } from 'lit/decorators.js';
+import { buttonGroupContext } from '#internals/context.js';
+import { addSlotController, setSlots } from '#internals/controllers/slot.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import type { Constructor } from '#internals/mixins/constructor.js';
 import { EventEmitterMixin } from '#internals/mixins/event-emitter.js';
-import { lastOf } from '#internals/utils/arrays.js';
+import { asArray, isEmpty, lastOf } from '#internals/utils/arrays.js';
 import { getElementFromPath } from '#internals/utils/events.js';
+import { isDefined } from '#internals/utils/types.js';
 import { addThemingController } from '#theming/theming-controller.js';
 import type { ButtonGroupSelection, ContentOrientation } from '../types.js';
 import { styles } from './themes/group.base.css.js';
@@ -43,59 +47,77 @@ export default class IgcButtonGroupComponent extends EventEmitterMixin<
   public static styles = [styles, shared];
 
   /* blazorSuppress */
-  public static register() {
+  public static register(): void {
     registerComponent(IgcButtonGroupComponent, IgcToggleButtonComponent);
   }
 
-  private get isMultiple() {
+  //#region Internal state & properties
+
+  /** The values set through the `selectedItems` API, applied once the buttons are rendered. */
+  private _selectedItems = new Set<string>();
+
+  private readonly _context = new ContextProvider(this, {
+    context: buttonGroupContext,
+    initialValue: {
+      instance: this,
+      syncSelection: (button) => this._syncSelection(button),
+    },
+  });
+
+  private readonly _slots = addSlotController(this, {
+    slots: setSlots(),
+    onChange: this._enforceSingleSelection,
+  });
+
+  /**
+   * The toggle buttons of the group, in DOM order. There are none to report
+   * before the first render, when the slot they are assigned to does not exist yet.
+   */
+  private get _buttons(): IgcToggleButtonComponent[] {
+    if (!this.hasUpdated) {
+      return [];
+    }
+
+    return this._slots.getAssignedElements('[default]', {
+      selector: IgcToggleButtonComponent.tagName,
+    });
+  }
+
+  private get _isMultiple(): boolean {
     return this.selection === 'multiple';
   }
 
-  private _selectedItems: Set<string> = new Set();
-
-  private _observerCallback({
-    changes: { added, attributes },
-  }: MutationControllerParams<IgcToggleButtonComponent>) {
-    if (this.isMultiple || this._selectedButtons.length <= 1) {
-      return;
-    }
-
-    const buttons = this.toggleButtons;
-    const idx = buttons.indexOf(
-      added.length ? lastOf(added).node : lastOf(attributes).node
-    );
-
-    for (const [i, button] of buttons.entries()) {
-      if (button.selected && i !== idx) {
-        button.selected = false;
-      }
-    }
+  private get _selectedButtons(): IgcToggleButtonComponent[] {
+    return this._buttons.filter((button) => button.selected);
   }
 
-  private get _selectedButtons(): Array<IgcToggleButtonComponent> {
-    return this.toggleButtons.filter((b) => b.selected);
-  }
+  //#endregion
 
-  @queryAssignedElements({ selector: IgcToggleButtonComponent.tagName })
-  private toggleButtons!: Array<IgcToggleButtonComponent>;
+  //#region Public properties
 
   /**
    * Disables all buttons inside the group.
-   * @attr
+   *
+   * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public disabled = false;
 
   /**
-   * Sets the orientation of the buttons in the group.
-   * @attr
+   * The orientation of the buttons in the group.
+   *
+   * @attr alignment
+   * @default 'horizontal'
    */
   @property({ reflect: true })
   public alignment: ContentOrientation = 'horizontal';
 
   /**
    * Controls the mode of selection for the button group.
-   * @attr
+   *
+   * @attr selection
+   * @default 'single'
    */
   @property({ reflect: false })
   public selection: ButtonGroupSelection = 'single';
@@ -106,135 +128,164 @@ export default class IgcButtonGroupComponent extends EventEmitterMixin<
    */
   @property({ attribute: 'selected-items', type: Array, reflect: false })
   public get selectedItems(): string[] {
-    return this._selectedButtons.map((b) => b.value).filter((v) => v);
+    // Buttons are not required to have a value, in which case they report none.
+    return this._selectedButtons
+      .map((button) => button.value)
+      .filter(isDefined);
   }
 
   public set selectedItems(values: string[]) {
-    this._selectedItems = new Set(Array.isArray(values) ? values : []);
-    this.setSelection(this._selectedItems);
+    this._selectedItems = new Set(asArray(values));
+    this._selectFromValues(this._selectedItems);
   }
 
-  @watch('disabled', { waitUntilFirstUpdate: true })
-  protected updateDisabledState() {
-    this.toggleButtons.forEach((b) => {
-      b.disabled = this.disabled;
-    });
-  }
+  //#endregion
 
-  @watch('selection', { waitUntilFirstUpdate: true })
-  protected updateSelectionState() {
-    if (this._selectedButtons.length) {
-      this.toggleButtons.forEach((b) => {
-        b.selected = false;
-      });
-    }
-  }
+  //#region Life-cycle hooks
 
   constructor() {
     super();
-
     addThemingController(this, all);
-
-    createMutationController(this, {
-      callback: this._observerCallback,
-      filter: [IgcToggleButtonComponent.tagName],
-      config: {
-        attributeFilter: ['selected'],
-        childList: true,
-        subtree: true,
-      },
-    });
   }
 
-  protected override firstUpdated() {
-    if (this.disabled) {
-      this.updateDisabledState();
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (!this.hasUpdated) {
+      return;
     }
 
-    const buttons = this._selectedButtons;
+    const selectionChanged = changedProperties.has('selection');
 
-    if (buttons.length) {
-      if (!this.isMultiple) {
-        const index = buttons.indexOf(buttons.at(-1)!);
+    if (selectionChanged || changedProperties.has('disabled')) {
+      this._context.updateObservers();
+    }
 
-        for (let i = 0; i < index; i++) {
-          buttons[i].selected = false;
-        }
-      }
+    if (selectionChanged) {
+      // The selection modes are not interchangeable - the group starts over.
+      this._selectedItems.clear();
+      this._applySelection([]);
+    }
+  }
+
+  protected override firstUpdated(): void {
+    if (isEmpty(this._selectedButtons)) {
+      // Nothing is selected through the children, fall back to the values passed in.
+      this._selectFromValues(this._selectedItems);
     } else {
-      this.setSelection(this._selectedItems);
+      // A selection through the children takes priority over the passed in values.
+      this._enforceSingleSelection();
     }
   }
 
-  private handleClick(event: MouseEvent) {
+  //#endregion
+
+  //#region Private API
+
+  /** Applies `next` as the selection, clearing the state of every other button. */
+  private _applySelection(next: IgcToggleButtonComponent[]): void {
+    const selection = new Set(next);
+
+    for (const button of this._buttons) {
+      button.selected = selection.has(button);
+    }
+  }
+
+  /** Selects the buttons matching `values`, honoring the selection mode. */
+  private _selectFromValues(values: Set<string>): void {
+    const matches = this._buttons.filter((button) => values.has(button.value));
+    this._applySelection(this._isMultiple ? matches : matches.slice(0, 1));
+  }
+
+  /**
+   * Reduces a selection made outside of the group - through the children or by
+   * adding buttons that bring their own state - to a single button. The last one wins.
+   */
+  private _enforceSingleSelection(): void {
+    const selected = this._selectedButtons;
+
+    if (!this._isMultiple && selected.length > 1) {
+      this._applySelection([lastOf(selected)]);
+    }
+  }
+
+  /** Reconciles the group with a button of its own that has turned selected. */
+  private _syncSelection(button: IgcToggleButtonComponent): void {
+    if (!this._isMultiple && this._buttons.includes(button)) {
+      this._applySelection([button]);
+    }
+  }
+
+  //#endregion
+
+  //#region Event handlers
+
+  private _handleClick(event: PointerEvent): void {
+    if (this.disabled) {
+      return;
+    }
+
     const button = getElementFromPath(IgcToggleButtonComponent.tagName, event);
 
-    if (button) {
-      this.isMultiple
-        ? this.handleMultipleSelection(button)
-        : this.handleSingleSelection(button);
+    if (!button || !this._buttons.includes(button)) {
+      return;
     }
+
+    this._isMultiple
+      ? this._handleMultipleSelection(button)
+      : this._handleSingleSelection(button);
   }
 
-  private handleSingleSelection(button: IgcToggleButtonComponent) {
-    const singleRequired = this.selection === 'single-required';
-    const selectedButton = this._selectedButtons.at(0);
-    const isSame = selectedButton && selectedButton.value === button.value;
+  private _handleSingleSelection(button: IgcToggleButtonComponent): void {
+    const selected = this._selectedButtons.at(0);
 
-    if (selectedButton) {
-      if (singleRequired && isSame) return;
-      this.emitDeselectEvent(selectedButton);
+    if (selected === button) {
+      // A required selection cannot be toggled off.
+      if (this.selection !== 'single-required') {
+        this._emitDeselectEvent(button);
+      }
+      return;
     }
-    if (isSame) return;
-    this.emitSelectEvent(button);
+
+    if (selected) {
+      this._emitDeselectEvent(selected);
+    }
+
+    this._emitSelectEvent(button);
   }
 
-  private handleMultipleSelection(button: IgcToggleButtonComponent) {
+  private _handleMultipleSelection(button: IgcToggleButtonComponent): void {
     button.selected
-      ? this.emitDeselectEvent(button)
-      : this.emitSelectEvent(button);
+      ? this._emitDeselectEvent(button)
+      : this._emitSelectEvent(button);
   }
 
-  private emitSelectEvent(button: IgcToggleButtonComponent) {
+  private _emitSelectEvent(button: IgcToggleButtonComponent): void {
     button.selected = true;
     this.emitEvent('igcSelect', { detail: button.value });
   }
 
-  private emitDeselectEvent(button: IgcToggleButtonComponent) {
+  private _emitDeselectEvent(button: IgcToggleButtonComponent): void {
     button.selected = false;
     this.emitEvent('igcDeselect', { detail: button.value });
   }
 
-  private setSelection(values: Set<string>) {
-    if (!values.size) {
-      this.toggleButtons.forEach((b) => {
-        b.selected = false;
-      });
-      return;
-    }
+  //#endregion
 
-    for (const button of this.toggleButtons) {
-      if (values.has(button.value)) {
-        button.selected = true;
-        if (!this.isMultiple) {
-          break;
-        }
-      }
-    }
-  }
+  //#region Render
 
-  protected override render() {
+  protected override render(): TemplateResult {
     return html`
       <div
         part="group"
-        role="group"
+        role=${this._isMultiple ? 'group' : 'radiogroup'}
         aria-disabled=${this.disabled}
-        @click=${this.handleClick}
+        @click=${this._handleClick}
       >
         <slot></slot>
       </div>
     `;
   }
+
+  //#endregion
 }
 
 declare global {

--- a/src/components/button-group/toggle-button.spec.ts
+++ b/src/components/button-group/toggle-button.spec.ts
@@ -1,12 +1,7 @@
-import {
-  elementUpdated,
-  expect,
-  fixture,
-  html,
-  unsafeStatic,
-} from '@open-wc/testing';
-
-import { defineComponents, IgcToggleButtonComponent } from '../../index.js';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import type { TemplateResult } from 'lit';
+import { defineComponents } from '#internals/definitions/defineComponents.js';
+import IgcToggleButtonComponent from './toggle-button.js';
 
 describe('Toggle Button', () => {
   before(() => {
@@ -56,15 +51,17 @@ describe('Toggle Button', () => {
     });
 
     it('sets `value` property successfully', async () => {
-      button = await createButtonComponent(`
-        <igc-toggle-button value="button-1">Click</igc-toggle-button>`);
+      button = await createButtonComponent(html`
+        <igc-toggle-button value="button-1">Click</igc-toggle-button>
+      `);
 
       expect(button.value).to.equal('button-1');
     });
 
     it('sets `selected` property successfully', async () => {
-      button = await createButtonComponent(`
-        <igc-toggle-button selected>Click</igc-toggle-button>`);
+      button = await createButtonComponent(html`
+        <igc-toggle-button selected>Click</igc-toggle-button>
+      `);
 
       expect(button.selected).to.be.true;
 
@@ -86,8 +83,9 @@ describe('Toggle Button', () => {
     });
 
     it('sets `disabled` property successfully', async () => {
-      button = await createButtonComponent(`
-        <igc-toggle-button disabled>Click</igc-toggle-button>`);
+      button = await createButtonComponent(html`
+        <igc-toggle-button disabled>Click</igc-toggle-button>
+      `);
 
       expect(button.disabled).to.be.true;
       expect(button).shadowDom.to.equal('<button disabled />', DIFF_OPTIONS);
@@ -112,8 +110,9 @@ describe('Toggle Button', () => {
     });
 
     it('sets `aria-label` successfully', async () => {
-      button = await createButtonComponent(`
-        <igc-toggle-button aria-label="button-1">Click</igc-toggle-button>`);
+      button = await createButtonComponent(html`
+        <igc-toggle-button aria-label="button-1">Click</igc-toggle-button>
+      `);
 
       expect(button.ariaLabel).to.equal('button-1');
       expect(button).shadowDom.to.equal(
@@ -128,7 +127,7 @@ describe('Toggle Button', () => {
 
       expect(document.activeElement).to.equal(button);
 
-      const buttonElement = button.shadowRoot?.children[0];
+      const buttonElement = button.renderRoot.children[0];
       expect(button.shadowRoot?.activeElement).to.equal(buttonElement);
     });
 
@@ -157,9 +156,9 @@ describe('Toggle Button', () => {
     });
   });
 
-  const createButtonComponent = (
-    template = '<igc-toggle-button>Click</igc-toggle-button>'
-  ) => {
-    return fixture<IgcToggleButtonComponent>(html`${unsafeStatic(template)}`);
-  };
+  function createButtonComponent(template?: TemplateResult) {
+    return fixture<IgcToggleButtonComponent>(
+      template ?? html`<igc-toggle-button>Click</igc-toggle-button>`
+    );
+  }
 });

--- a/src/components/button-group/toggle-button.ts
+++ b/src/components/button-group/toggle-button.ts
@@ -1,5 +1,13 @@
-import { html, LitElement } from 'lit';
+import {
+  html,
+  LitElement,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { property, query } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { buttonGroupContext } from '#internals/context.js';
+import { createAsyncContext } from '#internals/controllers/async-consumer.js';
 import { addKeyboardFocusRing } from '#internals/controllers/focus-ring.js';
 import { shadowOptions } from '#internals/decorators/shadow-options.js';
 import { registerComponent } from '#internals/definitions/register.js';
@@ -18,6 +26,7 @@ import { styles as shared } from './themes/shared/button/button.common.css.js';
  * @slot Renders the label/content of the button.
  *
  * @csspart toggle - The native button element.
+ * @csspart focused - The native button element when focused through a keyboard interaction.
  */
 @shadowOptions({ delegatesFocus: true })
 export default class IgcToggleButtonComponent extends LitElement {
@@ -30,9 +39,10 @@ export default class IgcToggleButtonComponent extends LitElement {
   }
 
   private readonly _focusRingManager = addKeyboardFocusRing(this);
+  private readonly _context = createAsyncContext(this, buttonGroupContext);
 
-  @query('[part="toggle"]', true)
-  private readonly _nativeButton!: HTMLButtonElement;
+  @query('[part~="toggle"]', true)
+  private readonly _nativeButton?: HTMLButtonElement;
 
   /**
    * The value of the control.
@@ -42,15 +52,19 @@ export default class IgcToggleButtonComponent extends LitElement {
   public value!: string;
 
   /**
-   * Determines whether the button is selected.
-   * @attr
+   * Whether the button is selected.
+   *
+   * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public selected = false;
 
   /**
-   * Determines whether the button is disabled.
-   * @attr
+   * Whether the button is disabled.
+   *
+   * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public disabled = false;
@@ -60,24 +74,38 @@ export default class IgcToggleButtonComponent extends LitElement {
     addThemingController(this, all);
   }
 
+  protected override updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('selected') && this.selected) {
+      this._context.value?.syncSelection(this);
+    }
+  }
+
   /* alternateName: focusComponent */
   /** Sets focus on the button. */
   public override focus(options?: FocusOptions): void {
-    this._nativeButton.focus(options);
+    this._nativeButton?.focus(options);
   }
 
   /* alternateName: blurComponent */
   /** Removes focus from the button. */
   public override blur(): void {
-    this._nativeButton.blur();
+    this._nativeButton?.blur();
   }
 
   /** Simulates a mouse click on the element. */
   public override click(): void {
-    this._nativeButton.click();
+    this._nativeButton?.click();
   }
 
-  protected override render() {
+  protected override render(): TemplateResult {
+    const group = this._context.value?.instance;
+
+    // A button of a group with a single selection mode is a radio button, and it
+    // is disabled either on its own or through the group it is part of.
+    const isRadio = group != null && group.selection !== 'multiple';
+    const disabled = this.disabled || Boolean(group?.disabled);
+    const selectedState = this.selected ? 'true' : 'false';
+
     return html`
       <button
         part=${partMap({
@@ -85,10 +113,12 @@ export default class IgcToggleButtonComponent extends LitElement {
           focused: this._focusRingManager.focused,
         })}
         type="button"
-        ?disabled=${this.disabled}
+        role=${ifDefined(isRadio ? 'radio' : undefined)}
+        ?disabled=${disabled}
         .ariaLabel=${this.ariaLabel}
-        aria-pressed=${this.selected}
-        aria-disabled=${this.disabled}
+        aria-checked=${ifDefined(isRadio ? selectedState : undefined)}
+        aria-pressed=${ifDefined(isRadio ? undefined : selectedState)}
+        aria-disabled=${disabled}
       >
         <slot></slot>
       </button>

--- a/src/components/button-group/toggle-button.ts
+++ b/src/components/button-group/toggle-button.ts
@@ -54,7 +54,7 @@ export default class IgcToggleButtonComponent extends LitElement {
   /**
    * Whether the button is selected.
    *
-   * @attr disabled
+   * @attr selected
    * @default false
    */
   @property({ type: Boolean, reflect: true })

--- a/src/internals/context.ts
+++ b/src/internals/context.ts
@@ -1,8 +1,20 @@
 import { createContext } from '@lit/context';
 import type { Ref } from 'lit/directives/ref.js';
+import type IgcButtonGroupComponent from '../components/button-group/button-group.js';
+import type IgcToggleButtonComponent from '../components/button-group/toggle-button.js';
 import type IgcCarouselComponent from '../components/carousel/carousel.js';
 import type { ChatState } from '../components/chat/chat-state.js';
 import type IgcTileManagerComponent from '../components/tile-manager/tile-manager.js';
+
+export type ButtonGroupContext = {
+  /** The igc-button-group instance. */
+  instance: IgcButtonGroupComponent;
+  /**
+   * Reconciles the group with a button that has turned selected on its own,
+   * so that the single selection modes can drop the previous selection.
+   */
+  syncSelection: (button: IgcToggleButtonComponent) => void;
+};
 
 export type TileManagerContext = {
   /** The igc-tile-manager instance. */
@@ -12,6 +24,10 @@ export type TileManagerContext = {
   /** Synchronizes the tile manager with the maximized state of its tiles. */
   setMaximizedState: () => void;
 };
+
+const buttonGroupContext = createContext<ButtonGroupContext>(
+  Symbol('button-group-context')
+);
 
 const carouselContext = createContext<IgcCarouselComponent>(
   Symbol('carousel-context')
@@ -27,6 +43,7 @@ const chatUserInputContext = createContext<ChatState>(
 );
 
 export {
+  buttonGroupContext,
   carouselContext,
   chatContext,
   chatUserInputContext,

--- a/stories/button-group.stories.ts
+++ b/stories/button-group.stories.ts
@@ -1,15 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { html } from 'lit';
+import { createRef, ref } from 'lit/directives/ref.js';
 
 import {
+  IgcButtonComponent,
   IgcButtonGroupComponent,
+  type IgcCheckboxChangeEventArgs,
   IgcIconComponent,
+  IgcSwitchComponent,
   defineComponents,
   registerIconFromText,
 } from 'igniteui-webcomponents';
 import { disableStoryControls } from './story.js';
 
-defineComponents(IgcButtonGroupComponent, IgcIconComponent);
+defineComponents(
+  IgcButtonComponent,
+  IgcButtonGroupComponent,
+  IgcIconComponent,
+  IgcSwitchComponent
+);
 
 registerIconFromText(
   'bold',
@@ -74,7 +83,7 @@ const metadata: Meta<IgcButtonGroupComponent> = {
     },
     alignment: {
       type: { name: 'enum', value: ['horizontal', 'vertical'] },
-      description: 'Sets the orientation of the buttons in the group.',
+      description: 'The orientation of the buttons in the group.',
       options: ['horizontal', 'vertical'],
       control: { type: 'inline-radio' },
       table: { defaultValue: { summary: 'horizontal' } },
@@ -95,7 +104,7 @@ export default metadata;
 interface IgcButtonGroupArgs {
   /** Disables all buttons inside the group. */
   disabled: boolean;
-  /** Sets the orientation of the buttons in the group. */
+  /** The orientation of the buttons in the group. */
   alignment: 'horizontal' | 'vertical';
   /** Controls the mode of selection for the button group. */
   selection: 'single' | 'single-required' | 'multiple';
@@ -103,6 +112,61 @@ interface IgcButtonGroupArgs {
 type Story = StoryObj<IgcButtonGroupArgs>;
 
 // endregion
+
+const scenarioStyles = html`
+  <style>
+    .scenario {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      max-width: 46rem;
+    }
+
+    .scenario p {
+      margin: 0;
+    }
+
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: flex-start;
+      gap: 2rem;
+    }
+
+    .case {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .case > strong {
+      font-size: 0.875rem;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .settings-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid var(--ig-gray-200, #e0e0e0);
+      border-radius: 4px;
+    }
+
+    .log {
+      margin: 0;
+      min-height: 1.25rem;
+      font-family: monospace;
+      color: var(--ig-primary-500, #09f);
+    }
+  </style>
+`;
 
 export const Basic: Story = {
   render: ({ selection, disabled, alignment }) => html`
@@ -121,17 +185,19 @@ export const Basic: Story = {
 
 export const SelectionModes: Story = {
   argTypes: disableStoryControls(metadata),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The three selection modes differ in what a click on an already selected button does: `single` deselects it, `single-required` keeps it selected, and `multiple` toggles each button on its own. The mode also drives the announced semantics - the single modes expose a `radiogroup` of `radio` buttons, while `multiple` exposes a `group` of toggle buttons with `aria-pressed`. Mind that `single-required` does not select a button for you: it only refuses to give up a selection it already has.',
+      },
+    },
+  },
   render: () => html`
-    <p>
-      Three selection modes are available: <code>single</code> allows at most
-      one selected item (deselectable), <code>single-required</code> always
-      keeps one selected, and <code>multiple</code> allows any combination.
-    </p>
-    <div style="display: flex; flex-direction: column; gap: 1.5rem;">
-      <div>
-        <p style="margin: 0 0 0.5rem; font-weight: 600;">
-          single — one or none selected
-        </p>
+    ${scenarioStyles}
+    <div class="scenario">
+      <div class="case">
+        <strong>single - one or none selected</strong>
         <igc-button-group selection="single">
           <igc-toggle-button value="day">Day</igc-toggle-button>
           <igc-toggle-button value="week" selected>Week</igc-toggle-button>
@@ -139,10 +205,9 @@ export const SelectionModes: Story = {
           <igc-toggle-button value="year">Year</igc-toggle-button>
         </igc-button-group>
       </div>
-      <div>
-        <p style="margin: 0 0 0.5rem; font-weight: 600;">
-          single-required — exactly one always selected
-        </p>
+
+      <div class="case">
+        <strong>single-required - the selection cannot be given up</strong>
         <igc-button-group selection="single-required">
           <igc-toggle-button value="xs">XS</igc-toggle-button>
           <igc-toggle-button value="sm">SM</igc-toggle-button>
@@ -151,19 +216,18 @@ export const SelectionModes: Story = {
           <igc-toggle-button value="xl">XL</igc-toggle-button>
         </igc-button-group>
       </div>
-      <div>
-        <p style="margin: 0 0 0.5rem; font-weight: 600;">
-          multiple — any number selected
-        </p>
+
+      <div class="case">
+        <strong>multiple - every button toggles on its own</strong>
         <igc-button-group selection="multiple">
           <igc-toggle-button value="bold" aria-label="Bold">
-            <igc-icon name="bold" collection="default"></igc-icon>
+            <igc-icon name="bold"></igc-icon>
           </igc-toggle-button>
           <igc-toggle-button value="italic" aria-label="Italic" selected>
-            <igc-icon name="italic" collection="default"></igc-icon>
+            <igc-icon name="italic"></igc-icon>
           </igc-toggle-button>
           <igc-toggle-button value="underline" aria-label="Underline" selected>
-            <igc-icon name="underline" collection="default"></igc-icon>
+            <igc-icon name="underline"></igc-icon>
           </igc-toggle-button>
         </igc-button-group>
       </div>
@@ -173,40 +237,46 @@ export const SelectionModes: Story = {
 
 export const Alignment: Story = {
   argTypes: disableStoryControls(metadata),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `alignment` attribute lays the buttons out in a row (default) or in a column. The group keeps the rounded corners on the leading and trailing button of whichever axis it runs along.',
+      },
+    },
+  },
   render: () => html`
-    <p>
-      The <code>alignment</code> attribute controls whether the buttons are
-      arranged horizontally (default) or vertically.
-    </p>
-    <div style="display: flex; gap: 3rem; align-items: flex-start;">
-      <div>
-        <p style="margin: 0 0 0.5rem; font-weight: 600;">Horizontal</p>
+    ${scenarioStyles}
+    <div class="row">
+      <div class="case">
+        <strong>horizontal</strong>
         <igc-button-group alignment="horizontal" selection="single-required">
           <igc-toggle-button value="list" aria-label="List view">
-            <igc-icon name="view-list" collection="default"></igc-icon>
+            <igc-icon name="view-list"></igc-icon>
           </igc-toggle-button>
           <igc-toggle-button value="module" aria-label="Module view" selected>
-            <igc-icon name="view-module" collection="default"></igc-icon>
+            <igc-icon name="view-module"></igc-icon>
           </igc-toggle-button>
           <igc-toggle-button value="quilt" aria-label="Quilt view">
-            <igc-icon name="view-quilt" collection="default"></igc-icon>
+            <igc-icon name="view-quilt"></igc-icon>
           </igc-toggle-button>
         </igc-button-group>
       </div>
-      <div>
-        <p style="margin: 0 0 0.5rem; font-weight: 600;">Vertical</p>
+
+      <div class="case">
+        <strong>vertical</strong>
         <igc-button-group alignment="vertical" selection="single-required">
           <igc-toggle-button value="left" aria-label="Align left">
-            <igc-icon name="align-left" collection="default"></igc-icon>
+            <igc-icon name="align-left"></igc-icon>
           </igc-toggle-button>
           <igc-toggle-button value="center" aria-label="Align center" selected>
-            <igc-icon name="align-center" collection="default"></igc-icon>
+            <igc-icon name="align-center"></igc-icon>
           </igc-toggle-button>
           <igc-toggle-button value="right" aria-label="Align right">
-            <igc-icon name="align-right" collection="default"></igc-icon>
+            <igc-icon name="align-right"></igc-icon>
           </igc-toggle-button>
           <igc-toggle-button value="justify" aria-label="Justify">
-            <igc-icon name="align-justify" collection="default"></igc-icon>
+            <igc-icon name="align-justify"></igc-icon>
           </igc-toggle-button>
         </igc-button-group>
       </div>
@@ -216,149 +286,218 @@ export const Alignment: Story = {
 
 export const WithIcons: Story = {
   argTypes: disableStoryControls(metadata),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon-only buttons keep a toolbar compact, but an icon carries no accessible name. Put an `aria-label` on the toggle button - it is forwarded to the native button that assistive technology actually reports.',
+      },
+    },
+  },
   render: () => html`
-    <p>
-      Icon-only toggle buttons work well for compact toolbars. Provide an
-      <code>aria-label</code> on each button for accessibility.
-    </p>
-    <div
-      style="display: flex; gap: 1rem; flex-wrap: wrap; align-items: center;"
-    >
+    ${scenarioStyles}
+    <div class="row">
       <igc-button-group selection="multiple">
         <igc-toggle-button value="bold" aria-label="Bold">
-          <igc-icon name="bold" collection="default"></igc-icon>
+          <igc-icon name="bold"></igc-icon>
         </igc-toggle-button>
         <igc-toggle-button value="italic" aria-label="Italic">
-          <igc-icon name="italic" collection="default"></igc-icon>
+          <igc-icon name="italic"></igc-icon>
         </igc-toggle-button>
         <igc-toggle-button value="underline" aria-label="Underline">
-          <igc-icon name="underline" collection="default"></igc-icon>
+          <igc-icon name="underline"></igc-icon>
         </igc-toggle-button>
       </igc-button-group>
 
       <igc-button-group selection="single-required">
         <igc-toggle-button value="left" aria-label="Align left" selected>
-          <igc-icon name="align-left" collection="default"></igc-icon>
+          <igc-icon name="align-left"></igc-icon>
         </igc-toggle-button>
         <igc-toggle-button value="center" aria-label="Align center">
-          <igc-icon name="align-center" collection="default"></igc-icon>
+          <igc-icon name="align-center"></igc-icon>
         </igc-toggle-button>
         <igc-toggle-button value="right" aria-label="Align right">
-          <igc-icon name="align-right" collection="default"></igc-icon>
+          <igc-icon name="align-right"></igc-icon>
         </igc-toggle-button>
         <igc-toggle-button value="justify" aria-label="Justify">
-          <igc-icon name="align-justify" collection="default"></igc-icon>
+          <igc-icon name="align-justify"></igc-icon>
         </igc-toggle-button>
       </igc-button-group>
     </div>
   `,
+};
+
+export const OptionalValues: Story = {
+  argTypes: disableStoryControls(metadata),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A `value` is optional. The group tracks its buttons by identity, so a group of buttons without values selects and deselects like any other - the value only decides what `selectedItems` reports and what the `selectedItems` setter can match. Buttons that carry no value are simply left out of the reported collection.',
+      },
+    },
+  },
+  render: () => {
+    const log = createRef<HTMLElement>();
+
+    function report(event: Event) {
+      const group = event.currentTarget as IgcButtonGroupComponent;
+
+      if (log.value) {
+        log.value.textContent = `selectedItems: ${JSON.stringify(group.selectedItems)}`;
+      }
+    }
+
+    return html`
+      ${scenarioStyles}
+      <div class="scenario">
+        <div class="case">
+          <strong>No values at all - the selection still moves</strong>
+          <igc-button-group selection="single">
+            <igc-toggle-button>Day</igc-toggle-button>
+            <igc-toggle-button>Week</igc-toggle-button>
+            <igc-toggle-button>Month</igc-toggle-button>
+          </igc-button-group>
+        </div>
+
+        <div class="case">
+          <strong>Only the buttons with a value are reported</strong>
+          <igc-button-group
+            selection="multiple"
+            @igcSelect=${report}
+            @igcDeselect=${report}
+          >
+            <igc-toggle-button value="bold" aria-label="Bold">
+              <igc-icon name="bold"></igc-icon>
+            </igc-toggle-button>
+            <igc-toggle-button value="italic" aria-label="Italic">
+              <igc-icon name="italic"></igc-icon>
+            </igc-toggle-button>
+            <igc-toggle-button aria-label="Underline">
+              <igc-icon name="underline"></igc-icon>
+            </igc-toggle-button>
+          </igc-button-group>
+          <p class="log" ${ref(log)}>selectedItems: []</p>
+        </div>
+      </div>
+    `;
+  },
 };
 
 export const Disabled: Story = {
   argTypes: disableStoryControls(metadata),
-  render: () => html`
-    <p>
-      Setting <code>disabled</code> on the group disables all buttons.
-      Individual buttons can also be disabled independently.
-    </p>
-    <div style="display: flex; flex-direction: column; gap: 1.5rem;">
-      <div>
-        <p style="margin: 0 0 0.5rem; font-weight: 600;">
-          Entire group disabled
-        </p>
-        <igc-button-group selection="single" disabled>
-          <igc-toggle-button value="day" selected>Day</igc-toggle-button>
-          <igc-toggle-button value="week">Week</igc-toggle-button>
-          <igc-toggle-button value="month">Month</igc-toggle-button>
-        </igc-button-group>
-      </div>
-      <div>
-        <p style="margin: 0 0 0.5rem; font-weight: 600;">
-          Individual buttons disabled
-        </p>
-        <igc-button-group selection="single">
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A disabled group turns its buttons off without touching their own `disabled` property. Switch the group back on and MD - which is disabled in its own right - stays disabled, while the rest become interactive again. Buttons added to a group that is already disabled inherit that state as well.',
+      },
+    },
+  },
+  render: () => {
+    const group = createRef<IgcButtonGroupComponent>();
+
+    function toggleGroup({ detail }: CustomEvent<IgcCheckboxChangeEventArgs>) {
+      if (group.value) {
+        group.value.disabled = detail.checked;
+      }
+    }
+
+    return html`
+      ${scenarioStyles}
+      <div class="scenario">
+        <div class="settings-row">
+          <div>
+            <div><strong>Disable the whole group</strong></div>
+            <small>MD is disabled on its own and stays that way.</small>
+          </div>
+
+          <igc-switch @igcChange=${toggleGroup}></igc-switch>
+        </div>
+
+        <igc-button-group ${ref(group)} selection="single">
           <igc-toggle-button value="xs">XS</igc-toggle-button>
           <igc-toggle-button value="sm" selected>SM</igc-toggle-button>
           <igc-toggle-button value="md" disabled>MD</igc-toggle-button>
-          <igc-toggle-button value="lg" disabled>LG</igc-toggle-button>
+          <igc-toggle-button value="lg">LG</igc-toggle-button>
           <igc-toggle-button value="xl">XL</igc-toggle-button>
         </igc-button-group>
       </div>
-    </div>
-  `,
+    `;
+  },
 };
 
 export const ProgrammaticSelection: Story = {
   argTypes: disableStoryControls(metadata),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `selectedItems` property reads and writes the whole selection: assigning to it replaces what was selected before rather than adding to it, and an empty array clears the group. Programmatic changes are silent - `igcSelect` and `igcDeselect` only report what a user did.',
+      },
+    },
+  },
   render: () => {
-    const setItems = (values: string[]) => {
-      const group = document.querySelector<any>('#prog-group');
-      if (group) group.selectedItems = values;
-    };
+    const group = createRef<IgcButtonGroupComponent>();
+    const log = createRef<HTMLElement>();
 
-    const onSelect = (e: CustomEvent<string>) => {
-      const log = document.querySelector<HTMLElement>('#sel-log');
-      if (log) log.textContent = `igcSelect — value: "${e.detail}"`;
-    };
+    function report(message: string) {
+      if (log.value) {
+        log.value.textContent = message;
+      }
+    }
 
-    const onDeselect = (e: CustomEvent<string>) => {
-      const log = document.querySelector<HTMLElement>('#sel-log');
-      if (log) log.textContent = `igcDeselect — value: "${e.detail}"`;
-    };
+    function select(values: string[]) {
+      const element = group.value;
+
+      if (element) {
+        element.selectedItems = values;
+        report(`selectedItems: ${JSON.stringify(element.selectedItems)}`);
+      }
+    }
+
+    function reportEvent(name: string, event: CustomEvent<string | undefined>) {
+      report(`${name}: "${event.detail}"`);
+    }
 
     return html`
-      <p>
-        Use the <code>selectedItems</code> property to get or set the selection
-        programmatically. The <code>igcSelect</code> and
-        <code>igcDeselect</code> events fire on user interaction only.
-      </p>
-      <igc-button-group
-        id="prog-group"
-        selection="multiple"
-        @igcSelect=${onSelect}
-        @igcDeselect=${onDeselect}
-      >
-        <igc-toggle-button value="bold" aria-label="Bold">
-          <igc-icon name="bold" collection="default"></igc-icon>
-        </igc-toggle-button>
-        <igc-toggle-button value="italic" aria-label="Italic">
-          <igc-icon name="italic" collection="default"></igc-icon>
-        </igc-toggle-button>
-        <igc-toggle-button value="underline" aria-label="Underline">
-          <igc-icon name="underline" collection="default"></igc-icon>
-        </igc-toggle-button>
-      </igc-button-group>
+      ${scenarioStyles}
+      <div class="scenario">
+        <igc-button-group
+          ${ref(group)}
+          selection="multiple"
+          @igcSelect=${(e: CustomEvent<string | undefined>) =>
+            reportEvent('igcSelect', e)}
+          @igcDeselect=${(e: CustomEvent<string | undefined>) =>
+            reportEvent('igcDeselect', e)}
+        >
+          <igc-toggle-button value="bold" aria-label="Bold">
+            <igc-icon name="bold"></igc-icon>
+          </igc-toggle-button>
+          <igc-toggle-button value="italic" aria-label="Italic">
+            <igc-icon name="italic"></igc-icon>
+          </igc-toggle-button>
+          <igc-toggle-button value="underline" aria-label="Underline">
+            <igc-icon name="underline"></igc-icon>
+          </igc-toggle-button>
+        </igc-button-group>
 
-      <div
-        style="display: flex; gap: 0.5rem; margin-top: 1rem; flex-wrap: wrap;"
-      >
-        <igc-button variant="flat" @click=${() => setItems(['bold'])}
-          >Select Bold</igc-button
-        >
-        <igc-button
-          variant="flat"
-          @click=${() => setItems(['italic', 'underline'])}
-        >
-          Select Italic + Underline
-        </igc-button>
-        <igc-button
-          variant="flat"
-          @click=${() => setItems(['bold', 'italic', 'underline'])}
-        >
-          Select All
-        </igc-button>
-        <igc-button variant="flat" @click=${() => setItems([])}
-          >Clear</igc-button
-        >
-      </div>
+        <div class="actions">
+          <igc-button variant="outlined" @click=${() => select(['bold'])}>
+            Bold
+          </igc-button>
+          <igc-button
+            variant="outlined"
+            @click=${() => select(['italic', 'underline'])}
+          >
+            Italic + Underline
+          </igc-button>
+          <igc-button variant="outlined" @click=${() => select([])}>
+            Clear
+          </igc-button>
+        </div>
 
-      <div style="margin-top: 1rem;">
-        <p style="margin: 0 0 0.25rem; font-weight: 600;">Event log:</p>
-        <pre
-          id="sel-log"
-          style="margin: 0; padding: 0.75rem; background: var(--ig-gray-100, #f5f5f5); border-radius: 4px; font-size: 0.8rem;"
-        >
-Interact with the buttons to see events.</pre>
+        <p class="log" ${ref(log)}>Interact with the buttons to see events.</p>
       </div>
     `;
   },


### PR DESCRIPTION
## Description

Selection was keyed by `value`, so buttons without one - or sharing one - compared equal and the selection could never move.

- `selectedItems` now replaces the previous selection instead of adding to it, takes effect synchronously, and reports buttons with an empty `value`.
- A disabled group no longer overwrites its buttons' `disabled` property: the state is inherited, so a button disabled in its own right stays disabled and buttons added to a disabled group are disabled as well.
- `focus()`, `blur()` and `click()` no longer throw before the first render.
- Toggle buttons that are not direct children no longer affect the selection.
- The single selection modes expose `radiogroup`/`radio` semantics instead of `aria-pressed`, and the `focused` CSS part is documented.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Behavioral change (fix or feature that causes existing functionality to change)
- [x] Refactoring (code improvements without functional changes)

## Related Issues

Closes #2229.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] Behavioral changes are documented in the description
