### PR TITLE
fix(popover): repair anchor resolution, open state and middleware order

### DIFF
--- a/src/components/popover/popover.spec.ts
+++ b/src/components/popover/popover.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@open-wc/testing';
 
 import { defineComponents } from '#internals/definitions/defineComponents.js';
-import IgcPopoverComponent from './popover.js';
+import IgcPopoverComponent, { type PopoverPlacement } from './popover.js';
 
 async function waitForPaint(popover: IgcPopoverComponent) {
   await elementUpdated(popover);
@@ -17,6 +17,14 @@ async function waitForPaint(popover: IgcPopoverComponent) {
 
 function getFloater(popover: IgcPopoverComponent) {
   return popover.renderRoot.querySelector('#container') as HTMLElement;
+}
+
+function isFloaterOpen(popover: IgcPopoverComponent) {
+  return getFloater(popover).matches(':popover-open');
+}
+
+function queryPopover(root: ParentNode) {
+  return root.querySelector(IgcPopoverComponent.tagName) as IgcPopoverComponent;
 }
 
 function togglePopover() {
@@ -45,6 +53,17 @@ function createNonSlottedPopover(isOpen = false) {
       </button>
 
       <igc-popover ?open=${isOpen} anchor="btn">
+        <p style="border: 1px solid #ccc">Message</p>
+      </igc-popover>
+    </div>
+  `;
+}
+
+function createAnchorlessPopover() {
+  return html`
+    <div>
+      <button id="btn" type="button">Show message</button>
+      <igc-popover>
         <p style="border: 1px solid #ccc">Message</p>
       </igc-popover>
     </div>
@@ -281,6 +300,231 @@ describe('Popover', () => {
         const delta = floater.getBoundingClientRect();
         expect(delta.top).to.be.lessThan(initial.top);
       });
+    });
+  });
+
+  describe('Anchor resolution', () => {
+    let root: HTMLElement;
+    let popover: IgcPopoverComponent;
+    let anchor: HTMLButtonElement;
+
+    async function openAtButton() {
+      popover.anchor = 'btn';
+      popover.open = true;
+      await waitForPaint(popover);
+    }
+
+    beforeEach(async () => {
+      root = await fixture<HTMLElement>(createAnchorlessPopover());
+      popover = queryPopover(root);
+      anchor = root.querySelector('#btn') as HTMLButtonElement;
+    });
+
+    it('resolves an IDREF appearing after the first render', async () => {
+      popover.anchor = 'late-anchor';
+      await waitForPaint(popover);
+
+      const late = document.createElement('button');
+      late.id = 'late-anchor';
+      late.textContent = 'Late anchor';
+      root.append(late);
+
+      popover.open = true;
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.true;
+      expect(getFloater(popover).getBoundingClientRect().top).to.equal(
+        late.getBoundingClientRect().bottom
+      );
+    });
+
+    it('shows when `anchor` is set while already open', async () => {
+      popover.open = true;
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.false;
+
+      popover.anchor = 'btn';
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.true;
+      expect(getFloater(popover).getBoundingClientRect().top).to.equal(
+        anchor.getBoundingClientRect().bottom
+      );
+    });
+
+    it('shows when a slotted anchor is added while already open', async () => {
+      const slotted = await fixture<IgcPopoverComponent>(
+        html`<igc-popover><p>Message</p></igc-popover>`
+      );
+
+      slotted.open = true;
+      await waitForPaint(slotted);
+
+      expect(isFloaterOpen(slotted)).to.be.false;
+
+      const anchor = document.createElement('button');
+      anchor.slot = 'anchor';
+      anchor.textContent = 'Show message';
+      slotted.prepend(anchor);
+      await waitForPaint(slotted);
+
+      expect(isFloaterOpen(slotted)).to.be.true;
+    });
+
+    it('keeps the current anchor when an IDREF cannot be resolved', async () => {
+      await openAtButton();
+
+      const initial = getFloater(popover).getBoundingClientRect();
+
+      popover.anchor = 'no-such-element';
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.true;
+      expect(getFloater(popover).getBoundingClientRect().top).to.equal(
+        initial.top
+      );
+    });
+
+    it('hides when `anchor` is unset', async () => {
+      await openAtButton();
+
+      expect(isFloaterOpen(popover)).to.be.true;
+
+      popover.anchor = undefined;
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.false;
+    });
+
+    it('hides when the anchor element leaves the DOM', async () => {
+      await openAtButton();
+
+      anchor.remove();
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.false;
+    });
+  });
+
+  describe('Open state', () => {
+    let root: HTMLElement;
+    let popover: IgcPopoverComponent;
+
+    beforeEach(async () => {
+      root = await fixture<HTMLElement>(createNonSlottedPopover(true));
+      popover = queryPopover(root);
+      await waitForPaint(popover);
+    });
+
+    it('hides the floating element when closed', async () => {
+      expect(isFloaterOpen(popover)).to.be.true;
+
+      popover.open = false;
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.false;
+    });
+
+    it('restores the open state when re-attached', async () => {
+      popover.remove();
+      await nextFrame();
+
+      expect(isFloaterOpen(popover)).to.be.false;
+
+      root.append(popover);
+      await waitForPaint(popover);
+
+      expect(isFloaterOpen(popover)).to.be.true;
+    });
+  });
+
+  describe('Middleware', () => {
+    function createOverflowingPopover(placement: PopoverPlacement) {
+      return html`
+        <div style="height: 200vh">
+          <button
+            id="btn"
+            type="button"
+            style="position: absolute; top: calc(100vh - 24px)"
+          >
+            Show message
+          </button>
+          <igc-popover open flip shift anchor="btn" placement=${placement}>
+            <div style="height: 300px; width: 100px">Message</div>
+          </igc-popover>
+        </div>
+      `;
+    }
+
+    for (const placement of ['bottom', 'bottom-start'] as PopoverPlacement[]) {
+      it(`flips a \`${placement}\` placement that overflows the viewport`, async () => {
+        const root = await fixture<HTMLElement>(
+          createOverflowingPopover(placement)
+        );
+        const popover = queryPopover(root);
+        await waitForPaint(popover);
+
+        const anchor = root.querySelector('#btn')!;
+
+        expect(
+          getFloater(popover).getBoundingClientRect().bottom
+        ).to.be.at.most(anchor.getBoundingClientRect().top + 1);
+      });
+    }
+  });
+
+  describe('Arrow element', () => {
+    let popover: IgcPopoverComponent;
+    let arrow: HTMLElement;
+
+    beforeEach(async () => {
+      const root = await fixture<HTMLElement>(html`
+        <div style="padding: 200px">
+          <button id="btn" type="button">Show message</button>
+          <igc-popover open anchor="btn" placement="bottom">
+            <p style="border: 1px solid #ccc">Message</p>
+            <div id="arrow" style="width: 10px; height: 10px"></div>
+          </igc-popover>
+        </div>
+      `);
+
+      popover = queryPopover(root);
+      arrow = root.querySelector('#arrow') as HTMLElement;
+
+      popover.arrow = arrow;
+      await waitForPaint(popover);
+    });
+
+    it('is rendered on the opposite side of the placement', async () => {
+      expect(arrow.part.contains('bottom')).to.be.true;
+      expect(arrow.style.top).to.equal('-10px');
+
+      popover.placement = 'top';
+      await waitForPaint(popover);
+
+      expect(arrow.part.contains('top')).to.be.true;
+      expect(arrow.part.contains('bottom')).to.be.false;
+      expect(arrow.style.bottom).to.equal('-10px');
+    });
+
+    it('keeps parts set outside of the popover', async () => {
+      arrow.part.add('custom');
+
+      popover.placement = 'top';
+      await waitForPaint(popover);
+
+      expect(arrow.part.contains('custom')).to.be.true;
+      expect(arrow.part.contains('top')).to.be.true;
+    });
+
+    it('`arrow-offset` is reflected', async () => {
+      const initial = Number.parseFloat(arrow.style.left);
+
+      popover.arrowOffset = 20;
+      await waitForPaint(popover);
+
+      expect(Number.parseFloat(arrow.style.left) - initial).to.equal(20);
     });
   });
 

--- a/src/components/popover/popover.spec.ts
+++ b/src/components/popover/popover.spec.ts
@@ -508,6 +508,24 @@ describe('Popover', () => {
       expect(arrow.style.bottom).to.equal('-10px');
     });
 
+    it('clears the inset of the previous placement', async () => {
+      expect(arrow.style.top).to.equal('-10px');
+      expect(arrow.style.bottom).to.equal('');
+
+      popover.placement = 'top';
+      await waitForPaint(popover);
+
+      expect(arrow.style.bottom).to.equal('-10px');
+      expect(arrow.style.top).to.equal('');
+
+      popover.placement = 'right';
+      await waitForPaint(popover);
+
+      expect(arrow.style.left).to.equal('-10px');
+      expect(arrow.style.bottom).to.equal('');
+      expect(arrow.style.right).to.equal('');
+    });
+
     it('keeps parts set outside of the popover', async () => {
       arrow.part.add('custom');
 

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -391,11 +391,18 @@ export default class IgcPopoverComponent extends LitElement {
         ? element.offsetHeight
         : element.offsetWidth;
 
-    setStyles(element, {
-      left: x != null ? `${roundByDPR(x + offset)}px` : '',
+    // Every side is reset, otherwise the inset of the previous placement is left
+    // behind and over-constrains the arrow.
+    const styles: Partial<CSSStyleDeclaration> = {
       top: y != null ? `${roundByDPR(y + offset)}px` : '',
-      [staticSide]: `${-inset}px`,
-    });
+      right: '',
+      bottom: '',
+      left: x != null ? `${roundByDPR(x + offset)}px` : '',
+    };
+
+    styles[staticSide] = `${-inset}px`;
+
+    setStyles(element, styles);
   }
 
   //#endregion

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -23,7 +23,8 @@ import { registerComponent } from '#internals/definitions/register.js';
 import { firstOf } from '#internals/utils/arrays.js';
 import {
   getElementByIdFromRoot,
-  getRoot,
+  hasStickyAncestor,
+  isPopoverOpen,
   roundByDPR,
   setStyles,
 } from '#internals/utils/dom.js';
@@ -47,25 +48,16 @@ export type PopoverPlacement =
   | 'left-start'
   | 'left-end';
 
-/**
- * Walks up the DOM tree of the given element, crossing shadow boundaries, and
- * returns whether any ancestor is positioned as `sticky`.
- */
-function hasStickyAncestor(element: Element): boolean {
-  let node: Element | null = element;
+const OPPOSITE_SIDE = {
+  top: 'bottom',
+  right: 'left',
+  bottom: 'top',
+  left: 'right',
+} as const;
 
-  while (node) {
-    if (getComputedStyle(node).position === 'sticky') {
-      return true;
-    }
+type PopoverSide = keyof typeof OPPOSITE_SIDE;
 
-    const root = getRoot(node);
-    node =
-      node.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
-  }
-
-  return false;
-}
+const SIDES = Object.keys(OPPOSITE_SIDE) as PopoverSide[];
 
 /* blazorSuppress */
 /**
@@ -80,15 +72,6 @@ export default class IgcPopoverComponent extends LitElement {
   public static readonly tagName = 'igc-popover';
   public static override styles = styles;
 
-  private static _oppositeArrowSide = new Map(
-    Object.entries({
-      top: 'bottom',
-      right: 'left',
-      bottom: 'top',
-      left: 'right',
-    })
-  );
-
   /* blazorSuppress */
   public static register(): void {
     registerComponent(IgcPopoverComponent);
@@ -98,6 +81,8 @@ export default class IgcPopoverComponent extends LitElement {
 
   private _dispose?: ReturnType<typeof autoUpdate>;
   private _target?: Element;
+  private _middleware?: Middleware[];
+  private _positionId = 0;
 
   /**
    * The positioning strategy resolved when the popover is opened. The `fixed`
@@ -194,34 +179,34 @@ export default class IgcPopoverComponent extends LitElement {
   //#region Life-cycle hooks
 
   protected override update(properties: PropertyValues<this>): void {
-    let targetChanged = false;
+    if (this.hasUpdated) {
+      this._middleware = undefined;
 
-    if (properties.has('anchor')) {
-      const target = isString(this.anchor)
-        ? getElementByIdFromRoot(this, this.anchor)
-        : this.anchor;
-
-      if (target) {
-        this._target = target;
-        targetChanged = true;
+      if (properties.has('sameWidth') && !this.sameWidth) {
+        setStyles(this._container, { width: '' });
       }
-    }
 
-    if (this.hasUpdated && properties.has('open')) {
-      this._setOpenState(this.open);
-    } else if (this.hasUpdated && this.open) {
-      targetChanged ? this._resetAutoUpdate() : this._updatePosition();
+      if (properties.has('open') || properties.has('anchor')) {
+        this._setOpenState(this.open);
+      } else if (this.open) {
+        this._updatePosition();
+      }
     }
 
     super.update(properties);
   }
 
+  protected override firstUpdated(): void {
+    this._setOpenState(this.open);
+  }
+
   /** @internal */
   public override connectedCallback(): void {
     super.connectedCallback();
-    this.updateComplete.then(() => {
+
+    if (this.hasUpdated) {
       this._setOpenState(this.open);
-    });
+    }
   }
 
   /** @internal */
@@ -235,50 +220,67 @@ export default class IgcPopoverComponent extends LitElement {
   private _handleSlotChange({
     isDefault,
   }: SlotChangeCallbackParameters<unknown>): void {
-    if (isDefault) {
+    if (isDefault || this.anchor) {
       return;
     }
 
-    const possibleTarget = firstOf(
-      this._slots.getAssignedElements('anchor', { flatten: true })
-    );
+    this._setOpenState(this.open);
+  }
 
-    if (this.anchor || !possibleTarget) {
-      return;
-    }
-
-    this._target = possibleTarget;
-
-    if (this.open) {
-      this._resetAutoUpdate();
+  private _handleToggle(): void {
+    if (!isPopoverOpen(this._container)) {
+      this._clearDispose();
     }
   }
 
   //#region Internal open state API
+
+  /**
+   * An unresolved IDREF keeps the current target, so that an anchor rendered
+   * after this popover is picked up the next time it opens.
+   */
+  private _resolveTarget(): Element | undefined {
+    if (isString(this.anchor)) {
+      return getElementByIdFromRoot(this, this.anchor) ?? this._target;
+    }
+
+    return (
+      this.anchor ??
+      firstOf(this._slots.getAssignedElements('anchor', { flatten: true }))
+    );
+  }
+
   private _setOpenState(state: boolean): void {
-    state ? this._setDispose() : this._clearDispose();
+    this._clearDispose();
+
+    if (state) {
+      this._target = this._resolveTarget();
+
+      if (this._target) {
+        this._strategy = hasStickyAncestor(this._target) ? 'fixed' : 'absolute';
+        this._dispose = autoUpdate(
+          this._target,
+          this._container,
+          this._updatePosition.bind(this)
+        );
+      }
+    }
+
     this._setPopoverState(state);
   }
 
-  private _setPopoverState(open: boolean): void {
-    if (!this._target) {
-      return;
-    }
-    open ? this._container?.showPopover() : this._container?.hidePopover();
-  }
+  private _setPopoverState(state: boolean): void {
+    const container = this._container;
 
-  private _setDispose(): void {
-    if (!this._target) {
+    if (!container) {
       return;
     }
 
-    this._strategy = hasStickyAncestor(this._target) ? 'fixed' : 'absolute';
+    const shouldOpen = state && this._target != null;
 
-    this._dispose = autoUpdate(
-      this._target,
-      this._container,
-      this._updatePosition.bind(this)
-    );
+    if (shouldOpen !== isPopoverOpen(container)) {
+      shouldOpen ? container.showPopover() : container.hidePopover();
+    }
   }
 
   private _clearDispose(): void {
@@ -286,73 +288,72 @@ export default class IgcPopoverComponent extends LitElement {
     this._dispose = undefined;
   }
 
-  private _resetAutoUpdate(): void {
-    this._clearDispose();
-    this._setDispose();
-  }
   //#endregion
 
   //#region Internal position API
 
+  private get _placement(): PopoverPlacement {
+    return this.placement ?? 'bottom-start';
+  }
+
   private _createMiddleware(): Middleware[] {
-    const middleware: Middleware[] = [];
-    const container = this._container;
+    const shiftMiddleware = this.shift
+      ? shift({ padding: this.shiftPadding, limiter: limitShift() })
+      : null;
+    const flipMiddleware = this.flip ? flip() : null;
 
-    if (this.offset) {
-      middleware.push(offset(this.offset));
-    }
+    // Aligned placements flip before shifting, base placements shift first.
+    // See https://floating-ui.com/docs/flip
+    const positioners = this._placement.includes('-')
+      ? [flipMiddleware, shiftMiddleware]
+      : [shiftMiddleware, flipMiddleware];
 
-    if (this.inline) {
-      middleware.push(inline());
-    }
+    const chain = [
+      this.offset !== 0 ? offset(this.offset) : null,
+      this.inline ? inline() : null,
+      ...positioners,
+      this.sameWidth
+        ? size({
+            apply: ({ rects }) =>
+              setStyles(this._container, {
+                width: `${rects.reference.width}px`,
+              }),
+          })
+        : null,
+      this.arrow ? arrow({ element: this.arrow }) : null,
+    ];
 
-    if (this.shift) {
-      middleware.push(
-        shift({
-          padding: this.shiftPadding,
-          limiter: limitShift(),
-        })
-      );
-    }
-
-    if (this.arrow) {
-      middleware.push(arrow({ element: this.arrow }));
-    }
-
-    if (this.flip) {
-      middleware.push(flip());
-    }
-
-    if (this.sameWidth) {
-      middleware.push(
-        size({
-          apply: ({ rects }) =>
-            setStyles(container, { width: `${rects.reference.width}px` }),
-        })
-      );
-    } else {
-      setStyles(container, { width: '' });
-    }
-
-    return middleware;
+    return chain.filter((entry): entry is Middleware => entry !== null);
   }
 
   private async _updatePosition(): Promise<void> {
-    if (!(this.open && this._target)) {
+    if (!this.open) {
       return;
     }
 
+    if (!this._target?.isConnected) {
+      this._target = undefined;
+      this._clearDispose();
+      this._setPopoverState(false);
+      return;
+    }
+
+    const positionId = ++this._positionId;
     const strategy = this._strategy;
 
     const { x, y, middlewareData, placement } = await computePosition(
       this._target,
       this._container,
       {
-        placement: this.placement ?? 'bottom-start',
-        middleware: this._createMiddleware(),
+        placement: this._placement,
+        middleware: (this._middleware ??= this._createMiddleware()),
         strategy,
       }
     );
+
+    if (positionId !== this._positionId || !this.open) {
+      return;
+    }
 
     setStyles(this._container, {
       position: strategy,
@@ -364,28 +365,36 @@ export default class IgcPopoverComponent extends LitElement {
     this._updateArrowPosition(placement, middlewareData);
   }
 
-  private _updateArrowPosition(placement: Placement, data: MiddlewareData) {
-    if (!(data.arrow && this.arrow)) {
+  private _updateArrowPosition(
+    placement: Placement,
+    data: MiddlewareData
+  ): void {
+    const element = this.arrow;
+
+    if (!(data.arrow && element)) {
       return;
     }
 
     const { x, y } = data.arrow;
-    const arrow = this.arrow;
     const offset = this.arrowOffset;
+    const [side] = placement.split('-') as [PopoverSide];
+    const staticSide = OPPOSITE_SIDE[side];
 
-    // The current placement of the popover along the x/y axis
-    const currentPlacement = firstOf(placement.split('-'));
+    if (!element.part.contains(side)) {
+      element.part.remove(...SIDES);
+      element.part.add(side);
+    }
 
-    // The opposite side where the arrow element should render based on the `currentPlacement`
-    const staticSide =
-      IgcPopoverComponent._oppositeArrowSide.get(currentPlacement)!;
+    // Measured after the part switch, since it is what gives the arrow its size.
+    const inset =
+      staticSide === 'top' || staticSide === 'bottom'
+        ? element.offsetHeight
+        : element.offsetWidth;
 
-    arrow.part = currentPlacement;
-
-    setStyles(arrow, {
+    setStyles(element, {
       left: x != null ? `${roundByDPR(x + offset)}px` : '',
       top: y != null ? `${roundByDPR(y + offset)}px` : '',
-      [staticSide]: '-4px',
+      [staticSide]: `${-inset}px`,
     });
   }
 
@@ -394,7 +403,12 @@ export default class IgcPopoverComponent extends LitElement {
   protected override render() {
     return html`
       <slot name="anchor"></slot>
-      <div id="container" part="container" popover="manual">
+      <div
+        id="container"
+        part="container"
+        popover="manual"
+        @toggle=${this._handleToggle}
+      >
         <slot></slot>
       </div>
     `;

--- a/src/components/tooltip/themes/shared/tooltip.common.scss
+++ b/src/components/tooltip/themes/shared/tooltip.common.scss
@@ -13,31 +13,31 @@ $color-border: rem(4px) solid var-get($theme, 'background');
 }
 
 #arrow {
-    &[part='top'],
-    &[part='bottom'] {
+    &[part~='top'],
+    &[part~='bottom'] {
         border-left: $transparent-border;
         border-right: $transparent-border;
     }
 
-    &[part='top'] {
+    &[part~='top'] {
         border-top: $color-border;
     }
 
-    &[part='bottom'] {
+    &[part~='bottom'] {
         border-bottom: $color-border;
     }
 
-    &[part='left'],
-    &[part='right'] {
+    &[part~='left'],
+    &[part~='right'] {
         border-top: $transparent-border;
         border-bottom: $transparent-border;
     }
 
-    &[part='left'] {
+    &[part~='left'] {
         border-left: $color-border;
     }
 
-    &[part='right'] {
+    &[part~='right'] {
         border-right: $color-border;
     }
 }

--- a/src/internals/utils/dom.ts
+++ b/src/internals/utils/dom.ts
@@ -125,6 +125,28 @@ export function* iterNodes<T extends Node>(
   }
 }
 
+/**
+ * Iterates over `node` and its ancestors, crossing shadow DOM boundaries.
+ *
+ * Shadow roots are traversed through their host, so only elements are yielded.
+ *
+ * @example
+ * ```typescript
+ * for (const ancestor of iterAncestors(element)) { ... }
+ * ```
+ */
+export function* iterAncestors(node?: Node | null): Generator<Element> {
+  let current: Node | null | undefined = node;
+
+  while (current) {
+    if (isElement(current)) {
+      yield current;
+    }
+
+    current = current instanceof ShadowRoot ? current.host : current.parentNode;
+  }
+}
+
 /** Returns the root node (document or shadow root) of the given element. */
 export function getRoot(
   element: Element,
@@ -226,22 +248,27 @@ export function isPopoverOpen(element?: Element): boolean {
 }
 
 /**
+ * Returns whether the given element, or any of its ancestors across shadow DOM
+ * boundaries, is positioned as `sticky`.
+ */
+export function hasStickyAncestor(element: Element): boolean {
+  for (const ancestor of iterAncestors(element)) {
+    if (getComputedStyle(ancestor).position === 'sticky') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Returns the nearest visible ancestor of a given node, traversing through shadow DOM boundaries if necessary. If no visible ancestor is found, returns null.
  */
 export function getVisibleAncestor(startNode: Node): HTMLElement | null {
-  let node: Node | null = startNode.parentNode;
-
-  while (node) {
-    if (node instanceof ShadowRoot) {
-      node = node.host;
-      continue;
+  for (const ancestor of iterAncestors(startNode.parentNode)) {
+    if (ancestor instanceof HTMLElement && ancestor.checkVisibility()) {
+      return ancestor;
     }
-
-    if (node instanceof HTMLElement && node.checkVisibility()) {
-      return node;
-    }
-
-    node = node.parentNode;
   }
 
   return null;


### PR DESCRIPTION
## Description

The target was resolved once per `anchor` change, and the platform popover was only ever shown from the `open` property path, so an anchor that entered the DOM after the first render left the component permanently invisible. The anchor is now resolved every time the popover opens, and every visibility change is committed through a single path.

- An anchor assigned while the popover is already open - by property or through the `anchor` slot - now shows it instead of only positioning it.
- Unsetting `anchor` detaches the popover, and an anchor removed from the DOM hides it instead of leaving it parked in the viewport corner. An id matching no element keeps the current anchor, as `igc-dropdown` does.
- `flip` runs before `shift` for aligned placements and after it for base ones, and `arrow` runs last, per the floating-ui ordering guidance.
- A reposition resolving after a close or an anchor swap no longer commits its stale coordinates, and `autoUpdate` is released when the platform closes the floating element.
- The arrow is inset by its own measured size instead of a fixed `-4px` and no longer discards parts set on it from the outside, which moves the tooltip arrow selectors to `[part~='...']`.
- The middleware chain is built once per update rather than per reposition, and `hasStickyAncestor`/`getVisibleAncestor` share an `iterAncestors` walker.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)


## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
