### PR TITLE
fix(carousel, rating): repair autoplay lifecycle, value precision and ARIA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - A carousel with fewer projected `igc-carousel-indicator` elements than slides threw a `TypeError` during render. The indicators now map to the slides by position, for any count of each.
   - The removal of the active slide left the carousel with no active slide. The slide that takes its position now becomes active.
   - The component set `aria-controls` on the host, where it described nothing. Each projected indicator now carries it, and points at the slide that it selects.
+  - Slides that entered an empty carousel after its first render stayed inactive, thus the carousel showed nothing. The authored active slide, or the first slide, now becomes active.
+  - A change of `interval` on a carousel that left the DOM started a timer that no rotation used. Only a return to the DOM now starts the timer again.
   - A carousel that left the DOM before its first render completed threw an unhandled `TypeError` from the gestures controller. The controller now verifies that the element is still present.
   - The documentation of the component now includes the `indicator` slot.
 - #### Chat
@@ -128,6 +130,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - A non-numeric `max` or `step` attribute produced `NaN`: the component rendered no symbols and announced `NaN of 5`. Both now fall back to a valid number.
   - The slider had no accessible name without a `label`. The component now forwards the `aria-label` of the host, and sets `aria-labelledby` only when it renders a label.
   - The component now exposes its `readonly` and `disabled` state through `aria-readonly` and `aria-disabled`.
+  - A change of the `aria-label` of the host after the first render left the accessible name of the slider as it was.
   - `igcHover` did not fire when the pointer left the component, and then entered again over the same symbol.
 - #### Select
   - `ArrowUp` on a closed select that had a selection cleared the selection and showed the placeholder, instead of a move to the previous item. The component set the item that keyboard navigation moves from only through its own selection path. Thus a selection through the `value` property, or through a `selected` attribute on an item, left that item unset, and a backward step from "no item" went off the start of the list. Navigation now always starts from the current selection. If there is no item to move to, the selection does not change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - The component now resolves time-only date strings against the current local date and not the UTC date. Before, the parsed date moved by one day near midnight in some time zones.
   - `week-start` stayed stale until a subsequent update corrected the view. The component now resolves and renders `week-start` correctly on the initial render.
   - Keyboard navigation over a large number of disabled dates could hang the browser. The navigation is now a no-op in this condition.
+- #### Carousel
+  - A pointer over a carousel, or focus inside it, started the rotation of a carousel that you paused through `pause()`. The component now starts the rotation again only if an interaction paused it.
+  - A change of `interval` set the playing state and left the paused state as it was, thus `isPlaying` and `isPaused` were both `true`. A clear of `interval` also reported the carousel as playing, without a rotation. Both states now describe the rotation correctly.
+  - An interaction that changes nothing - a key press at the last slide with `disableLoop` - left a timer that ran without a rotation, and nothing cleared it.
+  - A key press at the last slide with `disableLoop` moved the focus to an indicator on the next slide change that came from `select()`, `next()` or `prev()`.
+  - A carousel with fewer projected `igc-carousel-indicator` elements than slides threw a `TypeError` during render. The indicators now map to the slides by position, for any count of each.
+  - The removal of the active slide left the carousel with no active slide. The slide that takes its position now becomes active.
+  - The component set `aria-controls` on the host, where it described nothing. Each projected indicator now carries it, and points at the slide that it selects.
+  - A carousel that left the DOM before its first render completed threw an unhandled `TypeError` from the gestures controller. The controller now verifies that the element is still present.
+  - The documentation of the component now includes the `indicator` slot.
 - #### Chat
   - With `adoptRootStyles` enabled the component ignored the stylesheets that entered the document after the initial adoption. Thus custom renderers whose styles are injected during view creation - Angular component styles, for example - showed unstyled content. The component now tracks the document stylesheets while the option is on, and applies each addition or removal to the shadow roots that adopted them, including stylesheet links that load later. [#2328](https://github.com/IgniteUI/igniteui-webcomponents/issues/2328)
   - Adoption of the document styles no longer removes the theme styles of the message and the input parts. Before, the adoption built the stylesheet list from the static styles of the component only.
@@ -112,6 +122,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - #### Icon
   - An icon that renders through a reference stayed blank when you registered the target icon later, because the component reacted only to registrations that match its own `name` and `collection` and not to the resolved target. It now resolves again on each change of the registry.
   - `igc-icon` declares `role="img"` only when it has an accessible name: the `<title>` of the icon, or an `aria-label` or `aria-labelledby` on the host. Before, a decorative icon appeared in the accessibility tree as an image without a name.
+- #### Rating
+  - Keyboard input, `stepUp()` and `stepDown()` produced values such as `0.30000000000000004` with a fractional `step`. The value, the `igcChange` payload and `aria-valuenow` now hold the exact value. `stepUp(n)` and `stepDown(n)` also move by `n` steps, and not to the next step above the result.
+  - `aria-valuetext` reported a value rounded up to the next step, thus it disagreed with `aria-valuenow` for a fractional value such as `2.5` with `step` of `1`.
+  - A non-numeric `max` or `step` attribute produced `NaN`: the component rendered no symbols and announced `NaN of 5`. Both now fall back to a valid number.
+  - The slider had no accessible name without a `label`. The component now forwards the `aria-label` of the host, and sets `aria-labelledby` only when it renders a label.
+  - The component now exposes its `readonly` and `disabled` state through `aria-readonly` and `aria-disabled`.
+  - `igcHover` did not fire when the pointer left the component, and then entered again over the same symbol.
 - #### Select
   - `ArrowUp` on a closed select that had a selection cleared the selection and showed the placeholder, instead of a move to the previous item. The component set the item that keyboard navigation moves from only through its own selection path. Thus a selection through the `value` property, or through a `selected` attribute on an item, left that item unset, and a backward step from "no item" went off the start of the list. Navigation now always starts from the current selection. If there is no item to move to, the selection does not change.
   - Type-ahead threw a `TypeError` on the first character that you type, on a select that had a selection.

--- a/src/components/carousel/carousel.spec.ts
+++ b/src/components/carousel/carousel.spec.ts
@@ -64,6 +64,24 @@ describe('Carousel', () => {
     </igc-carousel>
   `;
 
+  /** Renders a carousel with the given number of projected indicators and slides. */
+  const createCarousel = ({ indicators = 0, slides = 0 }) => html`
+    <igc-carousel>
+      ${Array.from(
+        { length: indicators },
+        (_, i) =>
+          html`<igc-carousel-indicator
+            ><span>${i}</span></igc-carousel-indicator
+          >`
+      )}
+      ${Array.from(
+        { length: slides },
+        (_, i) =>
+          html`<igc-carousel-slide><span>${i}</span></igc-carousel-slide>`
+      )}
+    </igc-carousel>
+  `;
+
   let carousel: IgcCarouselComponent;
   let slides: IgcCarouselSlideComponent[];
   let carouselSlidesContainer: Element;
@@ -1157,6 +1175,232 @@ describe('Carousel', () => {
 
         expect(eventSpy.callCount).to.equal(1);
       });
+    });
+  });
+
+  describe('Autoplay lifecycle', () => {
+    let clock: SinonFakeTimers;
+
+    beforeEach(() => {
+      clock = useFakeTimers({
+        toFake: ['setInterval', 'clearInterval', 'setTimeout'],
+      });
+    });
+
+    afterEach(() => clock.restore());
+
+    async function startRotation(interval = 1000) {
+      carousel.interval = interval;
+      await elementUpdated(carousel);
+    }
+
+    it('should stop the rotation when removed from the DOM', async () => {
+      await startRotation();
+
+      const eventSpy = spy(carousel, 'emitEvent');
+      carousel.remove();
+      await clock.tickAsync(3500);
+
+      expect(eventSpy.callCount).to.equal(0);
+      expect(clock.countTimers()).to.equal(0);
+    });
+
+    it('should resume the rotation when re-attached while playing', async () => {
+      await startRotation();
+
+      const parent = carousel.parentElement!;
+      carousel.remove();
+      parent.append(carousel);
+      await elementUpdated(carousel);
+
+      expect(carousel.isPlaying).to.be.true;
+      expect(clock.countTimers()).to.equal(1);
+    });
+
+    it('should not resume a paused carousel on pointer interaction', async () => {
+      const eventSpy = spy(carousel, 'emitEvent');
+
+      await startRotation();
+
+      carousel.pause();
+      carousel.dispatchEvent(new PointerEvent('pointerenter'));
+      await elementUpdated(carousel);
+
+      expect(carousel.isPlaying).to.be.false;
+
+      carousel.dispatchEvent(new PointerEvent('pointerleave'));
+      await elementUpdated(carousel);
+
+      expect(carousel.isPlaying).to.be.false;
+      expect(carousel.isPaused).to.be.true;
+      expect(eventSpy).not.calledWith('igcPlaying');
+    });
+
+    it('should not resume a paused carousel on focus interaction', async () => {
+      await startRotation();
+
+      carousel.pause();
+      carousel.dispatchEvent(new FocusEvent('focusin'));
+      carousel.dispatchEvent(new FocusEvent('focusout'));
+      await elementUpdated(carousel);
+
+      expect(carousel.isPlaying).to.be.false;
+      expect(carousel.isPaused).to.be.true;
+    });
+
+    it('should reset the playing state when the interval is cleared', async () => {
+      await startRotation();
+
+      expect(carousel.isPlaying).to.be.true;
+
+      carousel.interval = undefined;
+      await elementUpdated(carousel);
+
+      expect(carousel.isPlaying).to.be.false;
+      expect(carousel.isPaused).to.be.false;
+      expect(clock.countTimers()).to.equal(0);
+    });
+
+    it('should restart the rotation of a paused carousel on a new interval', async () => {
+      await startRotation();
+
+      carousel.pause();
+      expect(carousel.isPaused).to.be.true;
+
+      await startRotation(500);
+
+      expect(carousel.isPlaying).to.be.true;
+      expect(carousel.isPaused).to.be.false;
+    });
+
+    it('should not leave a timer behind at the `disableLoop` end stop', async () => {
+      carousel.disableLoop = true;
+      await startRotation();
+
+      await carousel.select(2);
+      await slideChangeComplete(slides[0], slides[2]);
+
+      simulateKeyboard(defaultIndicators[2], arrowRight);
+      await elementUpdated(carousel);
+      await nextFrame();
+
+      expect(carousel.current).to.equal(2);
+      expect(carousel.isPlaying).to.be.false;
+      expect(clock.countTimers()).to.equal(0);
+    });
+  });
+
+  describe('Slide and indicator integrity', () => {
+    async function removeSlide(slide: IgcCarouselSlideComponent) {
+      slide.remove();
+      await elementUpdated(carousel);
+      await nextFrame();
+    }
+
+    it('should move the active state when the active slide is removed', async () => {
+      await carousel.select(1);
+      await slideChangeComplete(slides[0], slides[1]);
+
+      await removeSlide(slides[1]);
+
+      expect(carousel.total).to.equal(2);
+      expect(carousel.current).to.equal(1);
+      expect(carousel.slides.map((slide) => slide.active)).to.eql([
+        false,
+        true,
+      ]);
+    });
+
+    it('should activate the last slide when the removed one was last', async () => {
+      await carousel.select(2);
+      await slideChangeComplete(slides[0], slides[2]);
+
+      await removeSlide(slides[2]);
+
+      expect(carousel.current).to.equal(1);
+      expect(carousel.slides[1].active).to.be.true;
+    });
+
+    it('should not throw when the last remaining slide is removed', async () => {
+      const single = await fixture<IgcCarouselComponent>(
+        createCarousel({ slides: 1 })
+      );
+      await nextFrame();
+
+      single.slides[0].remove();
+      await elementUpdated(single);
+      await nextFrame();
+
+      expect(single.total).to.equal(0);
+      expect(single.current).to.equal(0);
+    });
+
+    it('should render with fewer projected indicators than slides', async () => {
+      const errors: unknown[] = [];
+      const onError = (event: ErrorEvent) =>
+        errors.push(event.error ?? event.message);
+
+      window.addEventListener('error', onError);
+
+      const el = await fixture<IgcCarouselComponent>(
+        createCarousel({ indicators: 1, slides: 2 })
+      );
+      await nextFrame();
+      window.removeEventListener('error', onError);
+
+      const [indicator] = el.querySelectorAll(
+        IgcCarouselIndicatorComponent.tagName
+      );
+
+      expect(errors).to.be.empty;
+      expect(indicator.active).to.be.true;
+      expect(indicator.getAttribute('aria-controls')).to.equal(el.slides[0].id);
+    });
+
+    it('should render with more projected indicators than slides', async () => {
+      const el = await fixture<IgcCarouselComponent>(
+        createCarousel({ indicators: 2, slides: 1 })
+      );
+      await nextFrame();
+
+      const indicators = Array.from(
+        el.querySelectorAll(IgcCarouselIndicatorComponent.tagName)
+      );
+
+      expect(indicators[1].active).to.be.false;
+      expect(indicators[1].hasAttribute('aria-controls')).to.be.false;
+    });
+
+    it('should not steal focus on a programmatic change after a no-op key press', async () => {
+      carousel.disableLoop = true;
+      await carousel.select(2);
+      await slideChangeComplete(slides[0], slides[2]);
+
+      // At the last slide with `disableLoop` the key press changes nothing
+      simulateKeyboard(defaultIndicators[2], arrowRight);
+      await elementUpdated(carousel);
+      await nextFrame();
+
+      (carousel.shadowRoot!.activeElement as HTMLElement | null)?.blur();
+
+      await carousel.select(0);
+      await slideChangeComplete(slides[2], slides[0]);
+
+      expect(carousel.shadowRoot!.activeElement).to.be.null;
+    });
+
+    it('should not throw on `select` before the first render', async () => {
+      const el = document.createElement(IgcCarouselComponent.tagName);
+
+      for (const _ of [0, 1, 2]) {
+        el.appendChild(
+          document.createElement(IgcCarouselSlideComponent.tagName)
+        );
+      }
+
+      document.body.appendChild(el);
+      expect(await el.select(1)).to.be.false;
+      el.remove();
     });
   });
 });

--- a/src/components/carousel/carousel.spec.ts
+++ b/src/components/carousel/carousel.spec.ts
@@ -1273,6 +1273,56 @@ describe('Carousel', () => {
       expect(carousel.isPaused).to.be.false;
     });
 
+    it('should keep an explicit pause after the interaction ends', async () => {
+      await startRotation();
+
+      carousel.dispatchEvent(new PointerEvent('pointerenter'));
+      await elementUpdated(carousel);
+
+      carousel.pause();
+      carousel.dispatchEvent(new PointerEvent('pointerleave'));
+      await elementUpdated(carousel);
+
+      expect(carousel.isPlaying).to.be.false;
+      expect(carousel.isPaused).to.be.true;
+    });
+
+    it('should keep the rotation paused when the interval changes during an interaction', async () => {
+      await startRotation();
+
+      carousel.dispatchEvent(new PointerEvent('pointerenter'));
+      await elementUpdated(carousel);
+
+      await startRotation(500);
+
+      expect(carousel.isPlaying).to.be.false;
+      expect(clock.countTimers()).to.equal(0);
+
+      carousel.dispatchEvent(new PointerEvent('pointerleave'));
+      await elementUpdated(carousel);
+
+      expect(carousel.isPlaying).to.be.true;
+    });
+
+    it('should not start a timer while detached', async () => {
+      const parent = carousel.parentElement!;
+      carousel.remove();
+
+      carousel.interval = 1000;
+      await elementUpdated(carousel);
+
+      const eventSpy = spy(carousel, 'emitEvent');
+      await clock.tickAsync(3500);
+
+      expect(eventSpy).not.calledWith('igcSlideChanged');
+      expect(clock.countTimers()).to.equal(0);
+
+      parent.append(carousel);
+      await elementUpdated(carousel);
+
+      expect(clock.countTimers()).to.equal(1);
+    });
+
     it('should not leave a timer behind at the `disableLoop` end stop', async () => {
       carousel.disableLoop = true;
       await startRotation();
@@ -1369,6 +1419,24 @@ describe('Carousel', () => {
 
       expect(indicators[1].active).to.be.false;
       expect(indicators[1].hasAttribute('aria-controls')).to.be.false;
+    });
+
+    it('should not activate a projected indicator without a slide', async () => {
+      const el = await fixture<IgcCarouselComponent>(
+        createCarousel({ indicators: 2, slides: 1 })
+      );
+      await nextFrame();
+
+      el.slides[0].remove();
+      await elementUpdated(el);
+      await nextFrame();
+
+      const indicators = Array.from(
+        el.querySelectorAll(IgcCarouselIndicatorComponent.tagName)
+      );
+
+      expect(el.total).to.equal(0);
+      expect(indicators.some((indicator) => indicator.active)).to.be.false;
     });
 
     it('should not steal focus on a programmatic change after a no-op key press', async () => {

--- a/src/components/carousel/carousel.spec.ts
+++ b/src/components/carousel/carousel.spec.ts
@@ -1421,6 +1421,39 @@ describe('Carousel', () => {
       expect(indicators[1].hasAttribute('aria-controls')).to.be.false;
     });
 
+    it('should activate a slide added to an empty carousel', async () => {
+      const el = await fixture<IgcCarouselComponent>(createCarousel({}));
+      await nextFrame();
+
+      const slide = document.createElement(IgcCarouselSlideComponent.tagName);
+      el.append(slide);
+      await elementUpdated(el);
+      await nextFrame();
+
+      expect(el.total).to.equal(1);
+      expect(el.current).to.equal(0);
+      expect(slide.active).to.be.true;
+    });
+
+    it('should activate a slide added after the carousel was emptied', async () => {
+      const el = await fixture<IgcCarouselComponent>(
+        createCarousel({ slides: 1 })
+      );
+      await nextFrame();
+
+      el.slides[0].remove();
+      await elementUpdated(el);
+      await nextFrame();
+
+      const slide = document.createElement(IgcCarouselSlideComponent.tagName);
+      el.append(slide);
+      await elementUpdated(el);
+      await nextFrame();
+
+      expect(el.total).to.equal(1);
+      expect(slide.active).to.be.true;
+    });
+
     it('should not activate a projected indicator without a slide', async () => {
       const el = await fixture<IgcCarouselComponent>(
         createCarousel({ indicators: 2, slides: 1 })

--- a/src/components/carousel/carousel.ts
+++ b/src/components/carousel/carousel.ts
@@ -430,11 +430,7 @@ export default class IgcCarouselComponent extends I18nMixin(
     // Republish for consumers created after their own first render (Blazor timing).
     this._context.publish();
 
-    if (!isEmpty(this._slides)) {
-      this._activateSlide(
-        this._slides.findLast((slide) => slide.active) ?? firstOf(this._slides)
-      );
-    }
+    this._activateInitialSlide();
   }
 
   protected override updated(): void {
@@ -484,6 +480,10 @@ export default class IgcCarouselComponent extends I18nMixin(
 
       if (previousSlide && !this._slides.includes(previousSlide)) {
         this._reactivateSlide(previousSlide, previousIndex);
+      } else if (this.hasUpdated && !this._activeSlide) {
+        // Slides came into an empty carousel after the first render. Without
+        // this, no slide is active, and the carousel shows nothing.
+        this._activateInitialSlide();
       }
     }
 
@@ -637,6 +637,15 @@ export default class IgcCarouselComponent extends I18nMixin(
     if (this._hasKeyboardInteractionOnIndicators) {
       this._indicators[this.current]?.focus();
       this._hasKeyboardInteractionOnIndicators = false;
+    }
+  }
+
+  /** Activates the authored active slide, or the first slide. */
+  private _activateInitialSlide(): void {
+    if (!isEmpty(this._slides)) {
+      this._activateSlide(
+        this._slides.findLast((slide) => slide.active) ?? firstOf(this._slides)
+      );
     }
   }
 

--- a/src/components/carousel/carousel.ts
+++ b/src/components/carousel/carousel.ts
@@ -80,6 +80,7 @@ const i18n: I18nControllerConfig<ICarouselResourceStrings> = {
  * @element igc-carousel
  *
  * @slot Default slot for the carousel. Any carousel slides should be projected here.
+ * @slot indicator - Renders the custom indicators of the carousel. An `igc-carousel-indicator` sets this slot itself.
  * @slot previous-button - Renders content inside the previous button.
  * @slot next-button - Renders content inside the next button.
  *
@@ -121,16 +122,22 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   private readonly _carouselId = nextId();
   private _paused = false;
-  private _lastInterval!: ReturnType<typeof setInterval> | null;
+  private _lastInterval: ReturnType<typeof setInterval> | null = null;
   private _hasKeyboardInteractionOnIndicators = false;
   private _hasPointerInteraction = false;
   private _hasInnerFocus = false;
+
+  /**
+   * Whether an interaction - a pointer over the carousel, or focus inside it -
+   * caused the current paused state. An explicit `pause()` call does not set it.
+   */
+  private _pausedByInteraction = false;
 
   private _slides: IgcCarouselSlideComponent[] = [];
   private _projectedIndicators: IgcCarouselIndicatorComponent[] = [];
 
   @state()
-  private _activeSlide!: IgcCarouselSlideComponent;
+  private _activeSlide?: IgcCarouselSlideComponent;
 
   @state()
   private _playing = false;
@@ -159,6 +166,13 @@ export default class IgcCarouselComponent extends I18nMixin(
     return !isEmpty(this._projectedIndicators);
   }
 
+  /** The indicators that the carousel shows. */
+  private get _indicators(): IgcCarouselIndicatorComponent[] {
+    return this._hasProjectedIndicators
+      ? this._projectedIndicators
+      : Array.from(this._defaultIndicators);
+  }
+
   private get _showIndicatorsLabel(): boolean {
     return this.total > this.maximumIndicatorsCount;
   }
@@ -177,14 +191,18 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   /**
    * Whether the carousel should skip rotating to the first slide after it reaches the last.
+   *
    * @attr disable-loop
+   * @default false
    */
   @property({ type: Boolean, reflect: true, attribute: 'disable-loop' })
   public disableLoop = false;
 
   /**
    * Whether the carousel should ignore use interactions and not pause on them.
+   *
    * @attr disable-pause-on-interaction
+   * @default false
    */
   @property({
     type: Boolean,
@@ -195,28 +213,36 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   /**
    * Whether the carousel should skip rendering of the default navigation buttons.
+   *
    * @attr hide-navigation
+   * @default false
    */
   @property({ type: Boolean, reflect: true, attribute: 'hide-navigation' })
   public hideNavigation = false;
 
   /**
    * Whether the carousel should render the indicator controls (dots).
+   *
    * @attr hide-indicators
+   * @default false
    */
   @property({ type: Boolean, reflect: true, attribute: 'hide-indicators' })
   public hideIndicators = false;
 
   /**
    * Whether the carousel has vertical alignment.
+   *
    * @attr vertical
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public vertical = false;
 
   /**
-   * Sets the orientation of the indicator controls (dots).
+   * The orientation of the indicator controls (dots).
+   *
    * @attr indicators-orientation
+   * @default end
    */
   @property({ attribute: 'indicators-orientation' })
   public indicatorsOrientation: CarouselIndicatorsOrientation = 'end';
@@ -270,50 +296,46 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   /**
    * The maximum number of indicator controls (dots) that can be shown. Default value is `10`.
+   *
    * @attr maximum-indicators-count
+   * @default 10
    */
   @property({ type: Number, attribute: 'maximum-indicators-count' })
   public maximumIndicatorsCount = 10;
 
   /**
    * The animation type.
+   *
    * @attr animation-type
+   * @default 'slide'
    */
   @property({ attribute: 'animation-type' })
   public animationType: HorizontalTransitionAnimation = 'slide';
 
   /* blazorSuppress */
-  /**
-   * The slides of the carousel.
-   */
+  /** The slides of the carousel. */
   public get slides(): IgcCarouselSlideComponent[] {
     return Array.from(this._slides);
   }
 
-  /**
-   * The total number of slides.
-   */
+  /** Total number of slides. */
   public get total(): number {
     return this._slides.length;
   }
 
-  /**
-   * The index of the current active slide.
-   */
+  /** The index of the current active slide. */
   public get current(): number {
-    return Math.max(0, this._slides.indexOf(this._activeSlide));
+    return this._activeSlide
+      ? Math.max(0, this._slides.indexOf(this._activeSlide))
+      : 0;
   }
 
-  /**
-   * Whether the carousel is in playing state.
-   */
+  /** Whether the carousel is in playing state. */
   public get isPlaying(): boolean {
     return this._playing;
   }
 
-  /**
-   * Whether the carousel in in paused state.
-   */
+  /** Whether the carousel is in paused state. */
   public get isPaused(): boolean {
     return this._paused;
   }
@@ -377,12 +399,23 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has('interval')) {
-      if (!this.isPlaying) {
-        this._playing = true;
-      }
+      this._setRotation(asNumber(this.interval) > 0);
+    }
+  }
 
+  /** @internal */
+  public override connectedCallback(): void {
+    super.connectedCallback();
+
+    if (this.hasUpdated) {
       this._restartInterval();
     }
+  }
+
+  /** @internal */
+  public override disconnectedCallback(): void {
+    this._resetInterval();
+    super.disconnectedCallback();
   }
 
   protected override async firstUpdated(): Promise<void> {
@@ -397,6 +430,12 @@ export default class IgcCarouselComponent extends I18nMixin(
     }
   }
 
+  protected override updated(): void {
+    if (this._hasProjectedIndicators) {
+      this._updateProjectedIndicators();
+    }
+  }
+
   private _observerCallback({
     changes: { added, attributes },
   }: MutationControllerParams<IgcCarouselSlideComponent>) {
@@ -406,9 +445,11 @@ export default class IgcCarouselComponent extends I18nMixin(
       return;
     }
 
-    const idx = this._slides.indexOf(
-      added.length ? lastOf(added).node : lastOf(attributes).node
-    );
+    const node = isEmpty(added)
+      ? (lastOf(attributes)?.node ?? lastOf(activeSlides))
+      : lastOf(added).node;
+
+    const idx = this._slides.indexOf(node);
 
     for (const [i, slide] of this._slides.entries()) {
       if (slide.active && i !== idx) {
@@ -427,9 +468,16 @@ export default class IgcCarouselComponent extends I18nMixin(
     params: SlotChangeCallbackParameters<InferSlotNames<typeof Slots>>
   ): void {
     if (params.isDefault || params.isInitial) {
+      const previousSlide = this._activeSlide;
+      const previousIndex = this.current;
+
       this._slides = this._slots.getAssignedElements('[default]', {
         selector: IgcCarouselSlideComponent.tagName,
       });
+
+      if (previousSlide && !this._slides.includes(previousSlide)) {
+        this._reactivateSlide(previousSlide, previousIndex);
+      }
     }
 
     if (params.slot === 'indicator') {
@@ -441,10 +489,7 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   private _handlePointerInteraction(event: PointerEvent): void {
     this._hasPointerInteraction = event.type === 'pointerenter';
-
-    if (!this._hasInnerFocus) {
-      this._handlePauseOnInteraction();
-    }
+    this._handlePauseOnInteraction();
   }
 
   private _handleFocusInteraction(event: FocusEvent): void {
@@ -457,21 +502,16 @@ export default class IgcCarouselComponent extends I18nMixin(
     }
 
     this._hasInnerFocus = event.type === 'focusin';
-
-    if (!this._hasPointerInteraction) {
-      this._handlePauseOnInteraction();
-    }
+    this._handlePauseOnInteraction();
   }
 
-  private async _handleIndicatorClick(event: PointerEvent): Promise<void> {
+  private _handleIndicatorClick(event: PointerEvent): void {
     const indicator = getElementFromPath(
       IgcCarouselIndicatorComponent.tagName,
       event
     )!;
 
-    const index = this._hasProjectedIndicators
-      ? this._projectedIndicators.indexOf(indicator)
-      : Array.from(this._defaultIndicators).indexOf(indicator);
+    const index = this._indicators.indexOf(indicator);
 
     this._handleInteraction(() =>
       this.select(this._slides[index], index > this.current ? 'next' : 'prev')
@@ -482,24 +522,24 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   //#region Keyboard event listeners
 
-  private async _handleArrowLeft(): Promise<void> {
+  private _handleArrowLeft(): void {
     this._hasKeyboardInteractionOnIndicators = true;
     this._handleInteraction(isLTR(this) ? this.prev : this.next);
   }
 
-  private async _handleArrowRight(): Promise<void> {
+  private _handleArrowRight(): void {
     this._hasKeyboardInteractionOnIndicators = true;
     this._handleInteraction(isLTR(this) ? this.next : this.prev);
   }
 
-  private async _handleHomeKey(): Promise<void> {
+  private _handleHomeKey(): void {
     this._hasKeyboardInteractionOnIndicators = true;
     this._handleInteraction(() =>
       this.select(isLTR(this) ? firstOf(this._slides) : lastOf(this._slides))
     );
   }
 
-  private async _handleEndKey(): Promise<void> {
+  private _handleEndKey(): void {
     this._hasKeyboardInteractionOnIndicators = true;
     this._handleInteraction(() =>
       this.select(isLTR(this) ? lastOf(this._slides) : firstOf(this._slides))
@@ -552,6 +592,8 @@ export default class IgcCarouselComponent extends I18nMixin(
       this.emitEvent('igcSlideChanged', { detail: this.current });
     }
 
+    this._hasKeyboardInteractionOnIndicators = false;
+
     if (this.interval) {
       this._restartInterval();
     }
@@ -560,10 +602,18 @@ export default class IgcCarouselComponent extends I18nMixin(
   private _handlePauseOnInteraction(): void {
     if (!this.interval || this.disablePauseOnInteraction) return;
 
-    if (this.isPlaying) {
+    const interacting = this._hasPointerInteraction || this._hasInnerFocus;
+
+    if (interacting) {
+      if (!this.isPlaying) return;
+
       this.pause();
+      this._pausedByInteraction = true;
       this.emitEvent('igcPaused');
-    } else {
+      return;
+    }
+
+    if (this._pausedByInteraction) {
       this.play();
       this.emitEvent('igcPlaying');
     }
@@ -578,24 +628,52 @@ export default class IgcCarouselComponent extends I18nMixin(
     this._activeSlide.active = true;
 
     if (this._hasKeyboardInteractionOnIndicators) {
-      this._hasProjectedIndicators
-        ? this._projectedIndicators[this.current].focus()
-        : this._defaultIndicators[this.current].focus();
-
+      this._indicators[this.current]?.focus();
       this._hasKeyboardInteractionOnIndicators = false;
     }
   }
 
-  private _updateProjectedIndicators(): void {
-    for (const [idx, slide] of this._slides.entries()) {
-      const indicator = this._projectedIndicators[idx];
-      indicator.active = slide.active;
-      indicator.index = idx;
-    }
+  /**
+   * Moves the active state from a slide that left the carousel to the slide
+   * that takes its position.
+   */
+  private _reactivateSlide(
+    removed: IgcCarouselSlideComponent,
+    index: number
+  ): void {
+    removed.active = false;
+    this._activeSlide = undefined;
 
-    if (this._activeSlide) {
-      this.setAttribute('aria-controls', this._activeSlide.id);
+    if (!isEmpty(this._slides)) {
+      this._activateSlide(this._slides[Math.min(index, this.total - 1)]);
     }
+  }
+
+  private _updateProjectedIndicators(): void {
+    const current = this.current;
+
+    for (const [idx, indicator] of this._projectedIndicators.entries()) {
+      const slide = this._slides.at(idx);
+
+      indicator.active = idx === current;
+      indicator.index = idx;
+
+      if (slide) {
+        indicator.setAttribute('aria-controls', slide.id);
+      } else {
+        indicator.removeAttribute('aria-controls');
+      }
+    }
+  }
+
+  /**
+   * Sets the rotation state of the carousel, and starts or clears its timer.
+   */
+  private _setRotation(playing: boolean, paused = false): void {
+    this._playing = playing;
+    this._paused = paused;
+    this._pausedByInteraction = false;
+    this._restartInterval();
   }
 
   private _resetInterval(): void {
@@ -608,20 +686,22 @@ export default class IgcCarouselComponent extends I18nMixin(
   private _restartInterval(): void {
     this._resetInterval();
 
-    if (asNumber(this.interval) > 0) {
-      this._lastInterval = setInterval(() => {
-        if (
-          this.isPlaying &&
-          this.total &&
-          !(this.disableLoop && this._nextIndex === 0)
-        ) {
-          this.select(this.slides[this._nextIndex], 'next');
-          this.emitEvent('igcSlideChanged', { detail: this.current });
-        } else {
-          this.pause();
-        }
-      }, this.interval);
+    if (!this.isPlaying || asNumber(this.interval) <= 0) {
+      return;
     }
+
+    this._lastInterval = setInterval(() => {
+      if (
+        this.isPlaying &&
+        this.total &&
+        !(this.disableLoop && this._nextIndex === 0)
+      ) {
+        this.select(this._slides[this._nextIndex], 'next');
+        this.emitEvent('igcSlideChanged', { detail: this.current });
+      } else {
+        this.pause();
+      }
+    }, this.interval);
   }
 
   private async _animateSlides(
@@ -655,9 +735,7 @@ export default class IgcCarouselComponent extends I18nMixin(
    */
   public play(): void {
     if (!this.isPlaying) {
-      this._paused = false;
-      this._playing = true;
-      this._restartInterval();
+      this._setRotation(true);
     }
   }
 
@@ -666,9 +744,7 @@ export default class IgcCarouselComponent extends I18nMixin(
    */
   public pause(): void {
     if (this.isPlaying) {
-      this._playing = false;
-      this._paused = true;
-      this._resetInterval();
+      this._setRotation(false, true);
     }
   }
 
@@ -732,6 +808,11 @@ export default class IgcCarouselComponent extends I18nMixin(
 
     const dir = animationDirection ?? (index > this.current ? 'next' : 'prev');
 
+    if (!this._activeSlide) {
+      this._activateSlide(slide);
+      return true;
+    }
+
     await this._animateSlides(slide, this._activeSlide, dir);
     return true;
   }
@@ -779,10 +860,7 @@ export default class IgcCarouselComponent extends I18nMixin(
           .active=${slide.active}
           .index=${i}
         >
-          <div
-            part="dot"
-            style=${styleMap({ visibility: backward, zIndex: 1 })}
-          ></div>
+          <div part="dot" style=${styleMap({ visibility: backward })}></div>
           <div
             part="dot active"
             slot="active"
@@ -808,9 +886,7 @@ export default class IgcCarouselComponent extends I18nMixin(
         >
           <slot name="indicator" @click=${this._handleIndicatorClick}>
             ${cache(
-              this._hasProjectedIndicators
-                ? this._updateProjectedIndicators()
-                : this._renderIndicators()
+              this._hasProjectedIndicators ? nothing : this._renderIndicators()
             )}
           </slot>
         </div>

--- a/src/components/carousel/carousel.ts
+++ b/src/components/carousel/carousel.ts
@@ -80,7 +80,7 @@ const i18n: I18nControllerConfig<ICarouselResourceStrings> = {
  * @element igc-carousel
  *
  * @slot Default slot for the carousel. Any carousel slides should be projected here.
- * @slot indicator - Renders the custom indicators of the carousel. An `igc-carousel-indicator` sets this slot itself.
+ * @slot indicator - Renders the custom indicators of the carousel. An indicator element sets this slot itself.
  * @slot previous-button - Renders content inside the previous button.
  * @slot next-button - Renders content inside the next button.
  *
@@ -399,7 +399,14 @@ export default class IgcCarouselComponent extends I18nMixin(
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has('interval')) {
-      this._setRotation(asNumber(this.interval) > 0);
+      const play = asNumber(this.interval) > 0;
+      const interacting =
+        play &&
+        !this.disablePauseOnInteraction &&
+        (this._hasPointerInteraction || this._hasInnerFocus);
+
+      this._setRotation(play && !interacting, interacting);
+      this._pausedByInteraction = interacting;
     }
   }
 
@@ -607,7 +614,7 @@ export default class IgcCarouselComponent extends I18nMixin(
     if (interacting) {
       if (!this.isPlaying) return;
 
-      this.pause();
+      this._pause();
       this._pausedByInteraction = true;
       this.emitEvent('igcPaused');
       return;
@@ -655,7 +662,7 @@ export default class IgcCarouselComponent extends I18nMixin(
     for (const [idx, indicator] of this._projectedIndicators.entries()) {
       const slide = this._slides.at(idx);
 
-      indicator.active = idx === current;
+      indicator.active = Boolean(slide) && idx === current;
       indicator.index = idx;
 
       if (slide) {
@@ -676,6 +683,13 @@ export default class IgcCarouselComponent extends I18nMixin(
     this._restartInterval();
   }
 
+  /** Stops the rotation, and keeps the interaction state as it is. */
+  private _pause(): void {
+    if (this.isPlaying) {
+      this._setRotation(false, true);
+    }
+  }
+
   private _resetInterval(): void {
     if (this._lastInterval) {
       clearInterval(this._lastInterval);
@@ -686,7 +700,8 @@ export default class IgcCarouselComponent extends I18nMixin(
   private _restartInterval(): void {
     this._resetInterval();
 
-    if (!this.isPlaying || asNumber(this.interval) <= 0) {
+    // A detached carousel starts no timer. The reconnect starts it again.
+    if (!this.isConnected || !this.isPlaying || asNumber(this.interval) <= 0) {
       return;
     }
 
@@ -699,7 +714,7 @@ export default class IgcCarouselComponent extends I18nMixin(
         this.select(this._slides[this._nextIndex], 'next');
         this.emitEvent('igcSlideChanged', { detail: this.current });
       } else {
-        this.pause();
+        this._pause();
       }
     }, this.interval);
   }
@@ -743,9 +758,8 @@ export default class IgcCarouselComponent extends I18nMixin(
    * Pauses the rotation of the carousel slides.
    */
   public pause(): void {
-    if (this.isPlaying) {
-      this._setRotation(false, true);
-    }
+    this._pause();
+    this._pausedByInteraction = false;
   }
 
   /**
@@ -753,7 +767,7 @@ export default class IgcCarouselComponent extends I18nMixin(
    */
   public async next(): Promise<boolean> {
     if (this.disableLoop && this._nextIndex === 0) {
-      this.pause();
+      this._pause();
       return false;
     }
 
@@ -765,7 +779,7 @@ export default class IgcCarouselComponent extends I18nMixin(
    */
   public async prev(): Promise<boolean> {
     if (this.disableLoop && this._previousIndex === this.total - 1) {
-      this.pause();
+      this._pause();
       return false;
     }
 

--- a/src/components/carousel/themes/carousel.base.scss
+++ b/src/components/carousel/themes/carousel.base.scss
@@ -39,6 +39,10 @@
     min-width: rem(46px);
 }
 
+[part='dot'] {
+    z-index: 1;
+}
+
 [part~='dot'] {
     position: relative;
     width: rem(12px);

--- a/src/components/rating/rating.spec.ts
+++ b/src/components/rating/rating.spec.ts
@@ -660,6 +660,31 @@ describe('Rating component', () => {
       expect(rating.value).to.be.at.most(rating.max);
     });
 
+    it('keeps a high precision value as it is', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating></igc-rating>`
+      );
+
+      rating.value = 2.555123456789;
+      await elementUpdated(rating);
+
+      expect(rating.value).to.equal(2.555123456789);
+      expect(getRatingWrapper(rating).getAttribute('aria-valuenow')).to.equal(
+        '2.555123456789'
+      );
+    });
+
+    it('keeps the decimals of the value when it steps', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating value="2.555" step="0.1"></igc-rating>`
+      );
+
+      rating.stepUp();
+      await elementUpdated(rating);
+
+      expect(rating.value).to.equal(2.655);
+    });
+
     it('falls back on a non-numeric `max` and `step`', async () => {
       const rating = await fixture<IgcRatingComponent>(
         html`<igc-rating></igc-rating>`
@@ -700,6 +725,19 @@ describe('Rating component', () => {
       expect(slider.hasAttribute('aria-labelledby')).to.be.false;
       await expect(rating).to.be.accessible();
       await expect(rating).shadowDom.to.be.accessible();
+    });
+
+    it('names the slider after a change of the host `aria-label`', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating aria-label="Score"></igc-rating>`
+      );
+
+      rating.setAttribute('aria-label', 'Rating');
+      await elementUpdated(rating);
+
+      expect(getRatingWrapper(rating).getAttribute('aria-label')).to.equal(
+        'Rating'
+      );
     });
 
     it('exposes the readonly state', async () => {

--- a/src/components/rating/rating.spec.ts
+++ b/src/components/rating/rating.spec.ts
@@ -21,6 +21,7 @@ import { createFormAssociatedTestBed } from '#internals/testing/form-testbed.spe
 import {
   simulateClick,
   simulateKeyboard,
+  simulatePointerLeave,
   simulatePointerMove,
 } from '#internals/testing/simulate.spec.js';
 import IgcRatingSymbolComponent from './rating-symbol.js';
@@ -581,6 +582,148 @@ describe('Rating component', () => {
 
         expect(spec.element.value).to.equal(3);
       });
+    });
+  });
+
+  describe('Value precision', () => {
+    beforeEach(async () => {
+      el = await fixture<IgcRatingComponent>(
+        html`<igc-rating step="0.1"></igc-rating>`
+      );
+    });
+
+    it('keeps the value free of floating point noise on stepUp', async () => {
+      el.stepUp();
+      el.stepUp();
+      el.stepUp();
+      await elementUpdated(el);
+
+      expect(el.value).to.equal(0.3);
+      expect(getRatingWrapper(el).getAttribute('aria-valuenow')).to.equal(
+        '0.3'
+      );
+      expect(getRatingWrapper(el).getAttribute('aria-valuetext')).to.equal(
+        '0.3 of 5'
+      );
+    });
+
+    it('increments by `n` steps and not to the next step', async () => {
+      el.stepUp(3);
+      await elementUpdated(el);
+
+      expect(el.value).to.equal(0.3);
+    });
+
+    it('keeps the value free of floating point noise on keyboard input', async () => {
+      const eventSpy = spy(el, 'emitEvent');
+
+      simulateKeyboard(el, arrowUp);
+      simulateKeyboard(el, arrowUp);
+      simulateKeyboard(el, arrowUp);
+      await elementUpdated(el);
+
+      expect(el.value).to.equal(0.3);
+      expect(eventSpy.lastCall).calledWith('igcChange', { detail: 0.3 });
+    });
+
+    it('reports a fractional value as it is', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating value="2.5" step="1"></igc-rating>`
+      );
+
+      expect(getRatingWrapper(rating).getAttribute('aria-valuenow')).to.equal(
+        '2.5'
+      );
+      expect(getRatingWrapper(rating).getAttribute('aria-valuetext')).to.equal(
+        '2.5 of 5'
+      );
+    });
+
+    it('falls back on a non-numeric `max` and `step`', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating></igc-rating>`
+      );
+
+      rating.setAttribute('max', 'abc');
+      rating.setAttribute('step', 'abc');
+      await elementUpdated(rating);
+
+      expect(rating.max).to.equal(0);
+      expect(rating.step).to.equal(1);
+      expect(getRatingWrapper(rating).getAttribute('aria-valuetext')).to.equal(
+        '0 of 0'
+      );
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('names the slider through the `label` attribute', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating label="Rate" aria-label="Score"></igc-rating>`
+      );
+      const slider = getRatingWrapper(rating);
+
+      expect(slider.getAttribute('aria-labelledby')).to.equal('rating-label');
+      expect(slider.hasAttribute('aria-label')).to.be.false;
+      await expect(rating).to.be.accessible();
+    });
+
+    it('names the slider through the host `aria-label`', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating aria-label="Score"></igc-rating>`
+      );
+      const slider = getRatingWrapper(rating);
+
+      expect(slider.getAttribute('aria-label')).to.equal('Score');
+      expect(slider.hasAttribute('aria-labelledby')).to.be.false;
+      await expect(rating).to.be.accessible();
+    });
+
+    it('exposes the readonly state', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating label="Rate" readonly></igc-rating>`
+      );
+      const slider = getRatingWrapper(rating);
+
+      expect(slider.getAttribute('aria-readonly')).to.equal('true');
+      expect(slider.getAttribute('tabindex')).to.equal('0');
+      await expect(rating).to.be.accessible();
+    });
+
+    it('exposes the disabled state', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating label="Rate" disabled></igc-rating>`
+      );
+      const slider = getRatingWrapper(rating);
+
+      expect(slider.getAttribute('aria-disabled')).to.equal('true');
+      expect(slider.getAttribute('tabindex')).to.equal('-1');
+    });
+  });
+
+  describe('Hover', () => {
+    it('emits `igcHover` again when the pointer re-enters the same symbol', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating hover-preview></igc-rating>`
+      );
+      const symbols =
+        rating.renderRoot.querySelector<HTMLElement>('[part="symbols"]')!;
+      const symbol = getRatingSymbols(rating).item(2);
+      const { x, width } = getBoundingRect(symbol);
+      const clientX = x + width / 2;
+
+      simulatePointerMove(symbol, { clientX });
+      await elementUpdated(rating);
+
+      const eventSpy = spy(rating, 'emitEvent');
+
+      simulatePointerLeave(symbols);
+      await elementUpdated(rating);
+
+      simulatePointerMove(symbol, { clientX });
+      await elementUpdated(rating);
+
+      expect(eventSpy).calledOnceWithExactly('igcHover', { detail: 3 });
     });
   });
 });

--- a/src/components/rating/rating.spec.ts
+++ b/src/components/rating/rating.spec.ts
@@ -639,6 +639,27 @@ describe('Rating component', () => {
       );
     });
 
+    it('keeps a fractional value with an integer step', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating value="2.555" step="1"></igc-rating>`
+      );
+
+      expect(rating.value).to.equal(2.555);
+    });
+
+    it('keeps the value inside a fractional `max`', async () => {
+      const rating = await fixture<IgcRatingComponent>(
+        html`<igc-rating></igc-rating>`
+      );
+
+      rating.max = 2.555;
+      rating.value = 2.555;
+      await elementUpdated(rating);
+
+      expect(rating.value).to.equal(2.555);
+      expect(rating.value).to.be.at.most(rating.max);
+    });
+
     it('falls back on a non-numeric `max` and `step`', async () => {
       const rating = await fixture<IgcRatingComponent>(
         html`<igc-rating></igc-rating>`
@@ -666,6 +687,7 @@ describe('Rating component', () => {
       expect(slider.getAttribute('aria-labelledby')).to.equal('rating-label');
       expect(slider.hasAttribute('aria-label')).to.be.false;
       await expect(rating).to.be.accessible();
+      await expect(rating).shadowDom.to.be.accessible();
     });
 
     it('names the slider through the host `aria-label`', async () => {
@@ -677,6 +699,7 @@ describe('Rating component', () => {
       expect(slider.getAttribute('aria-label')).to.equal('Score');
       expect(slider.hasAttribute('aria-labelledby')).to.be.false;
       await expect(rating).to.be.accessible();
+      await expect(rating).shadowDom.to.be.accessible();
     });
 
     it('exposes the readonly state', async () => {
@@ -688,6 +711,7 @@ describe('Rating component', () => {
       expect(slider.getAttribute('aria-readonly')).to.equal('true');
       expect(slider.getAttribute('tabindex')).to.equal('0');
       await expect(rating).to.be.accessible();
+      await expect(rating).shadowDom.to.be.accessible();
     });
 
     it('exposes the disabled state', async () => {
@@ -698,6 +722,8 @@ describe('Rating component', () => {
 
       expect(slider.getAttribute('aria-disabled')).to.equal('true');
       expect(slider.getAttribute('tabindex')).to.equal('-1');
+      await expect(rating).to.be.accessible();
+      await expect(rating).shadowDom.to.be.accessible();
     });
   });
 

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -226,10 +226,10 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
    */
   @property({ type: Number })
   public set value(number: number) {
-    const value = this.hasUpdated
-      ? clamp(asNumber(number), 0, this.max)
-      : Math.max(asNumber(number), 0);
-    this._formValue.setValueAndFormState(this._normalize(value));
+    const value = this._normalize(asNumber(number));
+    this._formValue.setValueAndFormState(
+      this.hasUpdated ? clamp(value, 0, this.max) : Math.max(value, 0)
+    );
   }
 
   public get value(): number {
@@ -400,11 +400,12 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   }
 
   /**
-   * Removes the floating point noise that the step arithmetic introduces. Thus
+   * Removes the floating point noise that the step arithmetic introduces. The
+   * significant digits stay, thus a fractional value keeps its precision, and
    * the value, the event payload and `aria-valuenow` stay readable.
    */
   private _normalize(value: number): number {
-    return roundPrecise(value, numberOfDecimals(this.step) + 2);
+    return Number.parseFloat(value.toPrecision(12));
   }
 
   private _updateProjectedSymbols(): void {

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -13,6 +13,7 @@ import {
   endKey,
   homeKey,
 } from '#internals/controllers/key-bindings.js';
+import { createMutationController } from '#internals/controllers/mutation-observer.js';
 import {
   addSlotController,
   type InferSlotNames,
@@ -226,7 +227,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
    */
   @property({ type: Number })
   public set value(number: number) {
-    const value = this._normalize(asNumber(number));
+    const value = asNumber(number);
     this._formValue.setValueAndFormState(
       this.hasUpdated ? clamp(value, 0, this.max) : Math.max(value, 0)
     );
@@ -289,6 +290,11 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
     super();
 
     addThemingController(this, all);
+
+    createMutationController(this, {
+      callback: () => this.requestUpdate(),
+      config: { attributeFilter: ['aria-label'] },
+    });
 
     addKeybindings(this, {
       skip: () => !this._isInteractive,
@@ -376,7 +382,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   private _emitValueUpdate(next: number): void {
     this._setTouchedState();
 
-    const clamped = clamp(next, 0, this.max);
+    const clamped = clamp(this._normalize(next), 0, this.max);
     if (clamped !== this.value) {
       this.value = clamped;
       this.emitEvent('igcChange', { detail: this.value });
@@ -401,11 +407,15 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
 
   /**
    * Removes the floating point noise that the step arithmetic introduces. The
-   * significant digits stay, thus a fractional value keeps its precision, and
-   * the value, the event payload and `aria-valuenow` stay readable.
+   * decimals of the current value and of the step stay, thus a value that the
+   * consumer sets keeps its precision, and the value, the event payload and
+   * `aria-valuenow` stay readable.
    */
   private _normalize(value: number): number {
-    return Number.parseFloat(value.toPrecision(12));
+    return roundPrecise(
+      value,
+      numberOfDecimals(this.value) + numberOfDecimals(this.step)
+    );
   }
 
   private _updateProjectedSymbols(): void {
@@ -457,7 +467,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
    * step factor.
    */
   public stepUp(n = 1): void {
-    this.value += n * this.step;
+    this.value = this._normalize(this.value + n * this.step);
   }
 
   /**
@@ -465,7 +475,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
    * the step factor.
    */
   public stepDown(n = 1): void {
-    this.value -= n * this.step;
+    this.value = this._normalize(this.value - n * this.step);
   }
 
   //#endregion

--- a/src/components/rating/rating.ts
+++ b/src/components/rating/rating.ts
@@ -1,7 +1,8 @@
 import { html, LitElement, nothing } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { map } from 'lit/directives/map.js';
 import { range } from 'lit/directives/range.js';
-import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import {
   addKeybindings,
@@ -151,11 +152,9 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   }
 
   private get _valueText(): string {
-    // Skip IEEE 754 representation for screen readers
-    const value = this._round(this.value);
     return this.valueFormat
-      ? formatString(this.valueFormat, value, this.max)
-      : `${value} of ${this.max}`;
+      ? formatString(this.valueFormat, this.value, this.max)
+      : `${this.value} of ${this.max}`;
   }
 
   //#endregion
@@ -167,13 +166,16 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
    *
    * If there are projected symbols, the maximum value will be resolved
    * based on the number of symbols.
+   *
    * @attr max
    * @default 5
    */
   @property({ type: Number })
   @coercedProperty<number, IgcRatingComponent>({
     transform: ({ value, host }) =>
-      host._hasProjectedSymbols ? host._symbols.length : Math.max(0, value),
+      host._hasProjectedSymbols
+        ? host._symbols.length
+        : Math.max(0, asNumber(value)),
     onChange: ({ value, host }) => {
       if (value < host.value) {
         host.value = value;
@@ -185,13 +187,16 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   /**
    * The minimum value change allowed.
    *
-   * Valid values are in the interval between 0 and 1 inclusive.
+   * Valid values are in the interval between 0.001 and 1 inclusive.
+   * The component clamps a value outside of the interval to the closest bound.
+   *
    * @attr step
    * @default 1
    */
   @property({ type: Number })
   @coercedProperty<number, IgcRatingComponent>({
-    transform: ({ value, host }) => (host.single ? 1 : clamp(value, 0.001, 1)),
+    transform: ({ value, host }) =>
+      host.single ? 1 : clamp(asNumber(value, 1), 0.001, 1),
   })
   public step = 1;
 
@@ -215,6 +220,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   /* @tsTwoWayProperty(true, "igcChange", "detail", false) */
   /**
    * The value of the component
+   *
    * @attr value
    * @default 0
    */
@@ -223,7 +229,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
     const value = this.hasUpdated
       ? clamp(asNumber(number), 0, this.max)
       : Math.max(asNumber(number), 0);
-    this._formValue.setValueAndFormState(value);
+    this._formValue.setValueAndFormState(this._normalize(value));
   }
 
   public get value(): number {
@@ -231,21 +237,26 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   }
 
   /**
-   * Sets hover preview behavior for the component
+   * Whether to show a preview of the value when hovering over the symbols.
+   *
    * @attr hover-preview
+   * @default false
    */
   @property({ type: Boolean, reflect: true, attribute: 'hover-preview' })
   public hoverPreview = false;
 
   /**
    * Makes the control a readonly field.
+   *
    * @attr readonly
+   * @default false
    */
   @property({ type: Boolean, reflect: true, attribute: 'readonly' })
   public readOnly = false;
 
   /**
    * Toggles single selection visual mode.
+   *
    * @attr single
    * @default false
    */
@@ -263,6 +274,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
 
   /**
    * Whether to reset the rating when the user selects the same value.
+   *
    * @attr allow-reset
    * @default false
    */
@@ -354,6 +366,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
 
   private _handleHoverDisabled(): void {
     this._hoverState = false;
+    this._hoverValue = -1;
   }
 
   //#endregion
@@ -375,14 +388,23 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
       ? pointToFraction(this._container, x, isLTR(this))
       : 0;
 
-    return clamp(this._round(this.max * fraction), this.step, this.max);
+    return clamp(this._ceilToStep(this.max * fraction), this.step, this.max);
   }
 
-  private _round(value: number): number {
+  /** Rounds a value up to the next multiple of the step. */
+  private _ceilToStep(value: number): number {
     return roundPrecise(
       Math.ceil(value / this.step) * this.step,
       numberOfDecimals(this.step)
     );
+  }
+
+  /**
+   * Removes the floating point noise that the step arithmetic introduces. Thus
+   * the value, the event payload and `aria-valuenow` stay readable.
+   */
+  private _normalize(value: number): number {
+    return roundPrecise(value, numberOfDecimals(this.step) + 2);
   }
 
   private _updateProjectedSymbols(): void {
@@ -408,7 +430,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   private _clipSymbol(index: number, isLTR = true) {
     const value = this._hoverState ? this._hoverValue : this.value;
     const progress = index + 1 - value;
-    const exclusive = progress === 0 || value === index + 1 ? 0 : 1;
+    const exclusive = progress === 0 ? 0 : 1;
     const selection = this.single ? exclusive : progress;
     const activate = (p: number) => clamp(p * 100, 0, 100);
 
@@ -434,7 +456,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
    * step factor.
    */
   public stepUp(n = 1): void {
-    this.value += this._round(n * this.step);
+    this.value += n * this.step;
   }
 
   /**
@@ -442,7 +464,7 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
    * the step factor.
    */
   public stepDown(n = 1): void {
-    this.value -= this._round(n * this.step);
+    this.value -= n * this.step;
   }
 
   //#endregion
@@ -450,35 +472,32 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
   private _renderSymbols() {
     const ltr = isLTR(this);
 
-    return html`
-      ${repeat(
-        range(this.max),
-        (i) => i,
-        (i) => {
-          const { forward, backward } = this._clipSymbol(i, ltr);
-          return html`
-            <igc-rating-symbol exportparts="symbol, full, empty">
-              <igc-icon
-                collection="default"
-                name="star_filled"
-                style=${styleMap({ clipPath: forward })}
-              ></igc-icon>
-              <igc-icon
-                collection="default"
-                name="star_outlined"
-                style=${styleMap({ clipPath: backward })}
-                slot="empty"
-              ></igc-icon>
-            </igc-rating-symbol>
-          `;
-        }
-      )}
-    `;
+    return map(range(this.max), (i) => {
+      const { forward, backward } = this._clipSymbol(i, ltr);
+
+      return html`
+        <igc-rating-symbol exportparts="symbol, full, empty">
+          <igc-icon
+            collection="default"
+            name="star_filled"
+            style=${styleMap({ clipPath: forward })}
+          ></igc-icon>
+          <igc-icon
+            collection="default"
+            name="star_outlined"
+            style=${styleMap({ clipPath: backward })}
+            slot="empty"
+          ></igc-icon>
+        </igc-rating-symbol>
+      `;
+    });
   }
 
   protected override render() {
     const hoverActive = this.hoverPreview && this._isInteractive;
     const valueLabelHidden = !this._slots.hasAssignedNodes('value-label', true);
+    const labelId = this.label ? 'rating-label' : undefined;
+    const ariaLabel = this.label ? undefined : (this.ariaLabel ?? undefined);
 
     return html`
       <label part="label" id="rating-label" ?hidden=${!this.label}
@@ -488,11 +507,14 @@ export default class IgcRatingComponent extends FormAssociatedMixin(
         part="base"
         role="slider"
         tabindex=${this.disabled ? -1 : 0}
-        aria-labelledby="rating-label"
+        aria-labelledby=${ifDefined(labelId)}
+        aria-label=${ifDefined(ariaLabel)}
         aria-valuemin="0"
         aria-valuenow=${this.value}
         aria-valuemax=${this.max}
         aria-valuetext=${this._valueText}
+        aria-disabled=${this.disabled}
+        aria-readonly=${this.readOnly}
       >
         <div
           aria-hidden="true"

--- a/src/internals/controllers/gestures.ts
+++ b/src/internals/controllers/gestures.ts
@@ -148,6 +148,10 @@ class GesturesController extends EventTarget implements ReactiveController {
     const { signal } = this._abortHandle;
 
     this._host.updateComplete.then(() => {
+      if (signal.aborted || !this._element) {
+        return;
+      }
+
       for (const event of Events) {
         this._element.addEventListener(event, this, { passive: true, signal });
       }

--- a/stories/carousel.stories.ts
+++ b/stories/carousel.stories.ts
@@ -70,7 +70,7 @@ const metadata: Meta<IgcCarouselComponent> = {
     },
     indicatorsOrientation: {
       type: { name: 'enum', value: ['end', 'start'] },
-      description: 'Sets the orientation of the indicator controls (dots).',
+      description: 'The orientation of the indicator controls (dots).',
       options: ['end', 'start'],
       control: { type: 'inline-radio' },
       table: { defaultValue: { summary: 'end' } },
@@ -139,7 +139,7 @@ interface IgcCarouselArgs {
   hideIndicators: boolean;
   /** Whether the carousel has vertical alignment. */
   vertical: boolean;
-  /** Sets the orientation of the indicator controls (dots). */
+  /** The orientation of the indicator controls (dots). */
   indicatorsOrientation: 'end' | 'start';
   /**
    * The format used to set the aria-label on the carousel indicators.

--- a/stories/rating.stories.ts
+++ b/stories/rating.stories.ts
@@ -44,7 +44,7 @@ const metadata: Meta<IgcRatingComponent> = {
     step: {
       type: 'number',
       description:
-        'The minimum value change allowed.\n\nValid values are in the interval between 0 and 1 inclusive.',
+        'The minimum value change allowed.\n\nValid values are in the interval between 0.001 and 1 inclusive.\nThe component clamps a value outside of the interval to the closest bound.',
       control: 'number',
       table: { defaultValue: { summary: '1' } },
     },
@@ -67,7 +67,8 @@ const metadata: Meta<IgcRatingComponent> = {
     },
     hoverPreview: {
       type: 'boolean',
-      description: 'Sets hover preview behavior for the component',
+      description:
+        'Whether to show a preview of the value when hovering over the symbols.',
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
@@ -134,7 +135,8 @@ interface IgcRatingArgs {
   /**
    * The minimum value change allowed.
    *
-   * Valid values are in the interval between 0 and 1 inclusive.
+   * Valid values are in the interval between 0.001 and 1 inclusive.
+   * The component clamps a value outside of the interval to the closest bound.
    */
   step: number;
   /** The label of the control. */
@@ -148,7 +150,7 @@ interface IgcRatingArgs {
   valueFormat: string;
   /** The value of the component */
   value: number;
-  /** Sets hover preview behavior for the component */
+  /** Whether to show a preview of the value when hovering over the symbols. */
   hoverPreview: boolean;
   /** Makes the control a readonly field. */
   readOnly: boolean;

--- a/stories/virtual-scroll.stories.ts
+++ b/stories/virtual-scroll.stories.ts
@@ -47,7 +47,7 @@ const metadata: Meta<IgcVirtualScrollComponent> = {
     docs: {
       description: {
         component:
-          'A virtual scroll component that efficiently renders large lists by only\nrendering the items currently visible in the viewport.',
+          'A virtual scroll component for large lists. Only the items visible in the\nviewport are rendered.',
       },
     },
     actions: { handles: ['igcStateChange', 'igcDataRequest'] },
@@ -63,14 +63,14 @@ const metadata: Meta<IgcVirtualScrollComponent> = {
     overScan: {
       type: 'number',
       description:
-        'Number of extra items to render beyond the visible area of the viewport.\nHigher values reduce blank flashes during fast scrolling but may impact performance.',
+        'Number of extra items to render beyond the visible area of the viewport.\nHigher values reduce blank flashes during fast scrolling but can lower performance.',
       control: 'number',
       table: { defaultValue: { summary: '2' } },
     },
     estimatedItemSize: {
       type: 'number',
       description:
-        'Estimated item size in pixels used before an item is measured in the DOM.\nThe engine replaces this with the actual measured size after the first render of each item.',
+        'Estimated item size in pixels, used before an item is measured in the DOM.\nAfter the first render of an item, the engine replaces the estimate with the measured size.',
       control: 'number',
       table: { defaultValue: { summary: '50' } },
     },
@@ -85,12 +85,12 @@ interface IgcVirtualScrollArgs {
   orientation: 'vertical' | 'horizontal';
   /**
    * Number of extra items to render beyond the visible area of the viewport.
-   * Higher values reduce blank flashes during fast scrolling but may impact performance.
+   * Higher values reduce blank flashes during fast scrolling but can lower performance.
    */
   overScan: number;
   /**
-   * Estimated item size in pixels used before an item is measured in the DOM.
-   * The engine replaces this with the actual measured size after the first render of each item.
+   * Estimated item size in pixels, used before an item is measured in the DOM.
+   * After the first render of an item, the engine replaces the estimate with the measured size.
    */
   estimatedItemSize: number;
 }


### PR DESCRIPTION
## Description

**Carousel:** stop the rotation timer on disconnect and start it again on reconnect, keep the playing and paused states consistent through interval changes, drop the timer that stayed behind at the `disableLoop` end stop, and start the rotation again only after a pause that an interaction caused. Map projected indicators to the slides by position in either direction, move the active state when the active slide leaves the DOM, and set `aria-controls` on each indicator instead of the host.

**Rating:** normalize the value once in its setter, thus `aria-valuenow`, `aria-valuetext` and the `igcChange` payload agree. `stepUp(n)` and `stepDown(n)` move by `n` steps. A non-numeric `max` or `step` falls back to a valid number. The slider takes its name from the host `aria-label` without a `label`, and exposes `aria-readonly` and `aria-disabled`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Refactoring (code improvements without functional changes)

## Testing

Adds 24 tests. No existing test changed.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
