### PR TITLE
deps(theming): bump to version 28.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "husky": "^9.1.7",
         "ig-typedoc-theme": "^7.0.1",
         "igniteui-i18n-resources": "^1.0.5",
-        "igniteui-theming": "^28.0.0-beta.5",
+        "igniteui-theming": "^28.0.0",
         "keep-a-changelog": "^3.1.0",
         "lint-staged": "^17.3.0",
         "lit-analyzer": "^2.0.3",
@@ -8125,9 +8125,9 @@
       }
     },
     "node_modules/igniteui-theming": {
-      "version": "28.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-28.0.0-beta.5.tgz",
-      "integrity": "sha512-VoHzBo01Zzaq2++1pC8w7A6gUGvI+nPbF3jRyJbNY/q2N7qvtDv2oP7eytYQdOTzlCqRZIxe+8rqvxvgPCy7jw==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-28.0.0.tgz",
+      "integrity": "sha512-IpsVKR2THbKa7dLNJqFhDn8HJ7t6VSYc0/jm54JX1Ce5s7zZtWNtNIQQ7OPxIu/YNRad5MAAP9uG3hV6QzM89A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "husky": "^9.1.7",
     "ig-typedoc-theme": "^7.0.1",
     "igniteui-i18n-resources": "^1.0.5",
-    "igniteui-theming": "^28.0.0-beta.5",
+    "igniteui-theming": "^28.0.0",
     "keep-a-changelog": "^3.1.0",
     "lint-staged": "^17.3.0",
     "lit-analyzer": "^2.0.3",


### PR DESCRIPTION
## Description

Bumps Ignite UI Theming to version 28.0.0 that contains all tokens and themes for the QR Code and Color Picker components. 

## Checklist

<!-- Remove items that don't apply -->

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [ ] Breaking changes are documented in the description
