### PR TITLE
fix(textarea): repair auto-resize teardown and projected default value

### DIFF
--- a/src/components/textarea/textarea.spec.ts
+++ b/src/components/textarea/textarea.spec.ts
@@ -72,6 +72,22 @@ describe('Textarea component', () => {
       expect(finalHeight).lessThan(intermediateHeight);
       expect(finalHeight).to.equal(initialHeight);
     });
+
+    it('auto sizing height is released when resize changes away from `auto`', async () => {
+      await createFixture(
+        html`<igc-textarea resize="auto" rows="1"></igc-textarea>`
+      );
+
+      simulateInput(textArea, { value: [1, 2, 3, 4, 5, 6].join('\n') });
+      await elementUpdated(element);
+
+      expect(textArea.style.height).to.not.be.empty;
+
+      element.resize = 'vertical';
+      await elementUpdated(element);
+
+      expect(textArea.style.height).to.be.empty;
+    });
   });
 
   describe('Setting value through attribute and projection', () => {
@@ -380,6 +396,39 @@ describe('Textarea component', () => {
         spec.reset();
 
         expect(spec.element.value).to.equal('Hello');
+      });
+    });
+
+    describe('Projected content', () => {
+      const projected = 'Hello';
+      const spec = createFormAssociatedTestBed<IgcTextareaComponent>(
+        html`<igc-textarea name="textarea">${projected}</igc-textarea>`
+      );
+
+      beforeEach(async () => {
+        await spec.setup(IgcTextareaComponent.tagName);
+      });
+
+      it('is treated as the default value', () => {
+        spec.assertIsPristine();
+
+        expect(spec.element.value).to.equal(projected);
+        expect(spec.element.defaultValue).to.equal(projected);
+      });
+
+      it('is restored on form reset', () => {
+        spec.setProperties({ value: 'World' });
+        spec.reset();
+
+        expect(spec.element.value).to.equal(projected);
+        spec.assertSubmitHasValue(projected);
+      });
+
+      it('does not shadow a later defaultValue assignment', () => {
+        spec.setProperties({ defaultValue: 'World' });
+
+        spec.assertIsPristine();
+        expect(spec.element.value).to.equal('World');
       });
     });
 

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, nothing, type PropertyValues } from 'lit';
+import { html, LitElement, type PropertyValues } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -21,7 +21,10 @@ import type { Constructor } from '#internals/mixins/constructor.js';
 import { EventEmitterMixin } from '#internals/mixins/event-emitter.js';
 import { FormAssociatedRequiredMixin } from '#internals/mixins/forms/associated-required.js';
 import { createFormValueState } from '#internals/mixins/forms/form-value.js';
-import { partMap } from '#internals/part-map.js';
+import {
+  renderInputShell,
+  resolveInputPartNames,
+} from '#internals/templates/input-shell.js';
 import { addSafeEventListener } from '#internals/utils/events.js';
 import { asNumber } from '#internals/utils/math.js';
 import { createIdGenerator } from '#internals/utils/strings.js';
@@ -124,7 +127,7 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   });
 
   @query('textarea')
-  private readonly _input!: HTMLTextAreaElement;
+  private readonly _input?: HTMLTextAreaElement;
 
   protected override get __validators() {
     return textAreaValidators;
@@ -307,35 +310,27 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
 
   //#region Internal methods
 
-  private _setAutoHeight(): number {
-    const { borderTopWidth, borderBottomWidth } = getComputedStyle(this._input);
-    return (
-      this._input.scrollHeight +
-      asNumber(borderTopWidth) +
-      asNumber(borderBottomWidth)
-    );
-  }
-
   protected _setAreaHeight(): void {
-    if (this.resize === 'auto') {
-      this._input.style.height = 'auto';
-      this._input.style.height = `${this._setAutoHeight()}px`;
-    } else {
-      Object.assign(this._input.style, { height: undefined });
-    }
-  }
+    const input = this._input;
 
-  protected _resolvePartNames() {
-    return {
-      container: true,
-      prefixed: this._slots.hasAssignedElements('prefix', {
-        selector: ':not([hidden])',
-      }),
-      suffixed: this._slots.hasAssignedElements('suffix', {
-        selector: ':not([hidden])',
-      }),
-      filled: !!this.value,
-    };
+    if (!input) {
+      return;
+    }
+
+    if (this.resize !== 'auto') {
+      input.style.removeProperty('height');
+      return;
+    }
+
+    input.style.height = 'auto';
+
+    const { borderTopWidth, borderBottomWidth } = getComputedStyle(input);
+    const height =
+      input.scrollHeight +
+      asNumber(borderTopWidth) +
+      asNumber(borderBottomWidth);
+
+    input.style.height = `${height}px`;
   }
 
   //#endregion
@@ -345,25 +340,33 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   private _handleSlotChange({
     isDefault,
   }: SlotChangeCallbackParameters<InferSlotNames<typeof Slots>>): void {
-    if (isDefault) {
-      const value = this._slots
-        .getAssignedNodes('[default]', true)
-        .map((node) => node.textContent?.trim())
-        .filter((node) => Boolean(node))
-        .join('\r\n');
+    if (!isDefault) {
+      return;
+    }
 
-      if (value !== this.value) {
-        this.value = value;
-      }
+    const value = this._slots
+      .getAssignedNodes('[default]', true)
+      .map((node) => node.textContent?.trim())
+      .filter(Boolean)
+      .join('\r\n');
+
+    if (value === this.value) {
+      return;
+    }
+
+    if (this._pristine) {
+      this.defaultValue = value;
+    } else {
+      this.value = value;
     }
   }
 
   protected _handleInput(): void {
-    this._commitValue(this._input.value, 'igcInput');
+    this._commitValue(this._input?.value ?? '', 'igcInput');
   }
 
   protected _handleChange(): void {
-    this._commitValue(this._input.value, 'igcChange');
+    this._commitValue(this._input?.value ?? '', 'igcChange');
   }
 
   //#endregion
@@ -372,7 +375,7 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
 
   /** Selects all text within the control. */
   public select(): void {
-    this._input.select();
+    this._input?.select();
   }
 
   /* blazorSuppress */
@@ -382,7 +385,7 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
     end: number,
     direction: SelectionRangeDirection = 'none'
   ): void {
-    this._input.setSelectionRange(start, end, direction);
+    this._input?.setSelectionRange(start, end, direction);
   }
 
   /* blazorSuppress */
@@ -393,8 +396,8 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
     end: number,
     selectMode: RangeTextSelectMode = 'preserve'
   ): void {
-    this._input.setRangeText(replacement, start, end, selectMode);
-    this.value = this._input.value;
+    this._input?.setRangeText(replacement, start, end, selectMode);
+    this.value = this._input?.value ?? '';
   }
 
   /* blazorSuppress */
@@ -403,72 +406,20 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
   public override scrollTo(x: number, y: number): void;
   public override scrollTo(x?: unknown, y?: unknown): void {
     x != null && y != null
-      ? this._input.scrollTo(x as number, y as number)
-      : this._input.scrollTo(x as ScrollToOptions);
+      ? this._input?.scrollTo(x as number, y as number)
+      : this._input?.scrollTo(x as ScrollToOptions);
   }
 
   //#endregion
 
   //#region Renderers
 
-  protected _renderSlot(name: InferSlotNames<typeof Slots>) {
-    const isHidden = !this._slots.hasAssignedElements(name, {
-      selector: ':not([hidden])',
-    });
-
-    return html`
-      <div part=${name} ?hidden=${isHidden}>
-        <slot name=${name}></slot>
-      </div>
-    `;
-  }
-
-  protected _renderLabel() {
-    return this.label
-      ? html`
-          <label part="label" for=${this.id || this._inputId}>
-            ${this.label}
-          </label>
-        `
-      : nothing;
-  }
-
-  protected _renderStandard() {
-    return html`
-      ${this._renderLabel()}
-      <div part=${partMap(this._resolvePartNames())}>
-        ${this._renderSlot('prefix')} ${this._renderInput()}
-        ${this._renderSlot('suffix')}
-      </div>
-      ${this._renderValidationContainer()}
-    `;
-  }
-
-  protected _renderMaterial() {
-    return html`
-      <div
-        part=${partMap({
-          ...this._resolvePartNames(),
-          labelled: !!this.label,
-          placeholder: !!this.placeholder,
-        })}
-      >
-        <div part="start">${this._renderSlot('prefix')}</div>
-        ${this._renderInput()}
-        <div part="notch">${this._renderLabel()}</div>
-        <div part="filler"></div>
-        <div part="end">${this._renderSlot('suffix')}</div>
-      </div>
-      ${this._renderValidationContainer()}
-    `;
-  }
-
   protected _renderInput() {
     return html`
       <slot style="display: none"></slot>
       <textarea
         ${ariaBindings(this._ariaTarget.resolveBindings())}
-        id=${this.id || this._inputId}
+        id=${this._inputId}
         part="input"
         style=${styleMap({
           resize: this.resize === 'auto' ? 'none' : this.resize,
@@ -494,9 +445,19 @@ export default class IgcTextareaComponent extends FormAssociatedRequiredMixin(
 
   protected override render() {
     return cache(
-      this._themes.theme === 'material'
-        ? this._renderMaterial()
-        : this._renderStandard()
+      renderInputShell(this, {
+        theme: this._themes.theme,
+        label: this.label,
+        labelId: this._inputId,
+        containerParts: resolveInputPartNames(
+          this._slots,
+          'container',
+          !!this.value
+        ),
+        materialParts: { placeholder: !!this.placeholder },
+        hideEmptyAffixes: true,
+        renderInput: this._renderInput,
+      })
     );
   }
 

--- a/src/internals/templates/input-shell.ts
+++ b/src/internals/templates/input-shell.ts
@@ -43,6 +43,17 @@ export interface InputShellOptions {
   renderInput: () => TemplateResult;
   /** Optional renderer for components that need extra parts inside the container (e.g. file-input). */
   renderFileParts?: () => TemplateResult | typeof nothing;
+  /**
+   * Container part names contributed only by the material notch layout
+   * (e.g. the `placeholder` part of `igc-textarea`).
+   */
+  materialParts?: Record<string, boolean>;
+  /**
+   * Whether the prefix/suffix wrappers are hidden while their slot has no
+   * visible assigned elements, driven by the `prefixed` and `suffixed` entries
+   * of `containerParts`. Off by default, so the wrappers always render.
+   */
+  hideEmptyAffixes?: boolean;
 }
 
 function renderLabel(forId: string, label: string) {
@@ -51,12 +62,10 @@ function renderLabel(forId: string, label: string) {
     : nothing;
 }
 
-function renderPrefix() {
-  return html`<div part="prefix"><slot name="prefix"></slot></div>`;
-}
-
-function renderSuffix() {
-  return html`<div part="suffix"><slot name="suffix"></slot></div>`;
+function renderAffix(name: 'prefix' | 'suffix', hidden: boolean) {
+  return html`<div part=${name} ?hidden=${hidden}>
+    <slot name=${name}></slot>
+  </div>`;
 }
 
 /**
@@ -68,6 +77,8 @@ export function renderInputShell(
   host: IgcFormControl,
   {
     containerParts,
+    materialParts,
+    hideEmptyAffixes = false,
     renderFileParts,
     renderInput,
     theme,
@@ -78,15 +89,29 @@ export function renderInputShell(
   const validator = IgcValidationContainerComponent.create(host);
   const input = renderInput.call(host);
   const fileParts = renderFileParts?.call(host) ?? nothing;
+  const prefix = renderAffix(
+    'prefix',
+    hideEmptyAffixes && !containerParts.prefixed
+  );
+  const suffix = renderAffix(
+    'suffix',
+    hideEmptyAffixes && !containerParts.suffixed
+  );
 
   if (theme === 'material') {
     return html`
-      <div part=${partMap({ ...containerParts, labelled: !!label })}>
-        <div part="start">${renderPrefix()}</div>
+      <div
+        part=${partMap({
+          ...containerParts,
+          ...materialParts,
+          labelled: !!label,
+        })}
+      >
+        <div part="start">${prefix}</div>
         ${input}${fileParts}
         <div part="notch">${renderLabel(labelId, label)}</div>
         <div part="filler"></div>
-        <div part="end">${renderSuffix()}</div>
+        <div part="end">${suffix}</div>
       </div>
       ${validator}
     `;
@@ -95,7 +120,7 @@ export function renderInputShell(
   return html`
     ${renderLabel(labelId, label)}
     <div part=${partMap(containerParts)}>
-      ${renderPrefix()}${fileParts}${input}${renderSuffix()}
+      ${prefix}${fileParts}${input}${suffix}
     </div>
     ${validator}
   `;


### PR DESCRIPTION
## Description

Leaving `resize="auto"` never released the inline height, because `Object.assign(style, { height: undefined })` stringifies to `"undefined"` and the CSS parser drops it, so the control stayed frozen at its last auto height. Projected text content was also assigned to `value` rather than `defaultValue`, unlike the native `<textarea>`, which left the control non-pristine and cleared the visible text on a form reset while the light DOM still held it.

- `resize` moving away from `auto` removes the inline height.
- Default-slot content becomes the default value while the control is pristine, so a form reset restores it and a later `defaultValue` assignment still applies.
- The render layer moves onto the shared `input-shell` template, which grows a `hideEmptyAffixes` flag for the hidden prefix/suffix wrappers and a `materialParts` option for the material-only `placeholder` part. Both default off, so `igc-input` and `igc-date-time-input` render unchanged.
- The inner textarea id and label `for` use the generated id alone, and `_input` is optional so the resize observer cannot outrun the first render.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
