### PR TITLE
fix(chip): repair nested interactive controls and accessible name

### DIFF
--- a/src/components/chip/chip.spec.ts
+++ b/src/components/chip/chip.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { spy } from 'sinon';
 import { defineComponents } from '#internals/definitions/defineComponents.js';
 import IgcChipComponent from './chip.js';
 
@@ -127,5 +128,183 @@ describe('Chip', () => {
     await elementUpdated(chip);
 
     expect(chip).dom.to.equal('<igc-chip></igc-chip>', DIFF_OPTIONS);
+  });
+
+  describe('Accessibility', () => {
+    it('passes the a11y audit in every interactive state', async () => {
+      const states = [
+        html`<igc-chip removable>Chip</igc-chip>`,
+        html`<igc-chip selectable selected>Chip</igc-chip>`,
+        html`<igc-chip selectable selected removable outlined>Chip</igc-chip>`,
+        html`<igc-chip disabled selectable removable>Chip</igc-chip>`,
+      ];
+
+      for (const state of states) {
+        const chip = await fixture<IgcChipComponent>(state);
+
+        await expect(chip).shadowDom.to.be.accessible();
+        await expect(chip).to.be.accessible();
+      }
+    });
+
+    it('keeps the remove control out of the action control', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip removable>Chip</igc-chip>`
+      );
+
+      const action = chip.renderRoot.querySelector('[part="action"]')!;
+      const remove = chip.renderRoot.querySelector('[part="remove"]')!;
+
+      expect(action.contains(remove)).to.be.false;
+      expect(action.querySelector('[tabindex]')).to.be.null;
+    });
+
+    it('does not leak the state icon into the accessible name', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip selectable selected>Chip</igc-chip>`
+      );
+
+      const icon = chip.renderRoot.querySelector('igc-icon[name="selected"]')!;
+
+      expect(icon.getAttribute('aria-hidden')).to.equal('true');
+      expect(icon.hasAttribute('aria-label')).to.be.false;
+    });
+
+    it('exposes the selection state through aria-pressed', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip selectable>Chip</igc-chip>`
+      );
+      const action = chip.renderRoot.querySelector('[part="action"]')!;
+
+      expect(action.getAttribute('aria-pressed')).to.equal('false');
+
+      chip.selected = true;
+      await elementUpdated(chip);
+      expect(action.getAttribute('aria-pressed')).to.equal('true');
+
+      chip.selectable = false;
+      await elementUpdated(chip);
+      expect(action.hasAttribute('aria-pressed')).to.be.false;
+    });
+  });
+
+  describe('Rendering', () => {
+    it('keeps the prefix hidden when selected but not selectable', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip selected>Chip</igc-chip>`
+      );
+      const prefix = chip.renderRoot.querySelector('[part="prefix"]')!;
+
+      expect(prefix.hasAttribute('hidden')).to.be.true;
+
+      chip.selectable = true;
+      await elementUpdated(chip);
+      expect(prefix.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('keeps the suffix hidden when only the remove control is rendered', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip removable>Chip</igc-chip>`
+      );
+
+      expect(
+        chip.renderRoot.querySelector('[part="suffix"]')!.hasAttribute('hidden')
+      ).to.be.true;
+      expect(chip.renderRoot.querySelector('[part="remove"]')).to.not.be.null;
+    });
+
+    it('does not render the remove control for a disabled chip', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip disabled removable>Chip</igc-chip>`
+      );
+
+      expect(chip.renderRoot.querySelector('[part="remove"]')).to.be.null;
+    });
+  });
+
+  describe('Events', () => {
+    it('emits igcRemove when the remove control is activated', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip removable>Chip</igc-chip>`
+      );
+      const eventSpy = spy();
+      chip.addEventListener('igcRemove', eventSpy);
+
+      (
+        chip.renderRoot.querySelector('igc-icon[name="remove"]') as HTMLElement
+      ).click();
+
+      expect(eventSpy).calledOnce;
+    });
+
+    it('does not emit igcSelect when the remove control is activated', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip selectable removable>Chip</igc-chip>`
+      );
+      const removeSpy = spy();
+      const selectSpy = spy();
+      chip.addEventListener('igcRemove', removeSpy);
+      chip.addEventListener('igcSelect', selectSpy);
+
+      const icon = chip.renderRoot.querySelector(
+        'igc-icon[name="remove"]'
+      ) as HTMLElement;
+
+      icon.click();
+      icon.dispatchEvent(
+        new KeyboardEvent('keyup', {
+          key: 'Enter',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await elementUpdated(chip);
+
+      expect(removeSpy.callCount).to.equal(2);
+      expect(selectSpy).to.not.be.called;
+      expect(chip.selected).to.be.false;
+    });
+
+    it('does not intercept the activation keys of a non-removable chip', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip selectable>Chip</igc-chip>`
+      );
+      const eventSpy = spy();
+      chip.addEventListener('igcRemove', eventSpy);
+
+      const action = chip.renderRoot.querySelector('[part="action"]')!;
+
+      // The remove keybindings are scoped to the remove control. Left unscoped
+      // they fall back to the host and cancel the default action of the keys
+      // that activate the chip itself - `Space` selection among them.
+      for (const key of ['Enter', ' ']) {
+        const event = new KeyboardEvent('keyup', {
+          key,
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+        });
+        action.dispatchEvent(event);
+
+        expect(event.defaultPrevented).to.be.false;
+      }
+
+      expect(eventSpy).to.not.be.called;
+    });
+
+    it('emits igcSelect from the action control', async () => {
+      const chip = await fixture<IgcChipComponent>(
+        html`<igc-chip selectable>Chip</igc-chip>`
+      );
+      const eventSpy = spy();
+      chip.addEventListener('igcSelect', eventSpy);
+
+      (chip.renderRoot.querySelector('[part="action"]') as HTMLElement).click();
+      await elementUpdated(chip);
+
+      expect(chip.selected).to.be.true;
+      expect(eventSpy).calledOnce;
+      expect(eventSpy.firstCall.args[0].detail).to.be.true;
+    });
   });
 });

--- a/src/components/chip/chip.ts
+++ b/src/components/chip/chip.ts
@@ -6,7 +6,11 @@ import { html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { addKeybindings } from '#internals/controllers/key-bindings.js';
-import { addSlotController, setSlots } from '#internals/controllers/slot.js';
+import {
+  addSlotController,
+  type InferSlotNames,
+  setSlots,
+} from '#internals/controllers/slot.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import type { I18nControllerConfig } from '#internals/i18n/i18n-controller.js';
 import type { Constructor } from '#internals/mixins/constructor.js';
@@ -21,9 +25,11 @@ import { styles as shared } from './themes/shared/chip.common.css.js';
 import { all } from './themes/themes.js';
 
 export interface IgcChipComponentEventMap {
-  igcRemove: CustomEvent<boolean>;
+  igcRemove: CustomEvent<void>;
   igcSelect: CustomEvent<boolean>;
 }
+
+const Slots = setSlots('start', 'prefix', 'suffix', 'end');
 
 const i18n: I18nControllerConfig<IChipResourceStrings> = {
   defaultEN: ChipResourceStringsEN,
@@ -36,7 +42,9 @@ const i18n: I18nControllerConfig<IChipResourceStrings> = {
  *
  * @slot - Renders content in the default slot of the chip.
  * @slot prefix - Renders content at the start of the chip, before the default content.
+ * @slot start - Renders content at the start of the chip, before the prefix content.
  * @slot suffix - Renders content at the end of the chip after the default content.
+ * @slot end - Renders content at the end of the chip, before the suffix content.
  * @slot select - Content to render when the chip in selected state.
  * @slot remove - Content to override the default remove chip icon.
  *
@@ -44,9 +52,11 @@ const i18n: I18nControllerConfig<IChipResourceStrings> = {
  * @fires igcSelect - Emits event when the chip component is selected/deselected and any related animations and transitions also end.
  *
  * @csspart base - The base wrapper of the chip.
+ * @csspart action - The selection control of the chip, wrapping the chip content.
  * @csspart content - The wrapper element around the default slot of the chip.
  * @csspart prefix - The prefix container of the chip.
  * @csspart suffix - The suffix container of the chip.
+ * @csspart remove - The container of the remove control of the chip.
  */
 export default class IgcChipComponent extends I18nMixin(
   EventEmitterMixin<IgcChipComponentEventMap, Constructor<LitElement>>(
@@ -63,54 +73,61 @@ export default class IgcChipComponent extends I18nMixin(
   }
 
   private readonly _removePartRef = createRef<HTMLSlotElement>();
-
-  private readonly _slots = addSlotController(this, {
-    slots: setSlots('prefix', 'suffix', 'start', 'end', 'select', 'remove'),
-  });
+  private readonly _slots = addSlotController(this, { slots: Slots });
 
   /**
-   * Sets the disabled state for the chip.
-   * @attr
+   * Whether the chip is disabled or not.
+   *
+   * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public disabled = false;
 
   /**
-   * Defines if the chip is removable or not.
-   * @attr
+   * Whether the chip is removable or not.
+   *
+   * @attr removable
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public removable = false;
 
   /**
-   * Defines if the chip is outlined or not.
+   * Whether the chip is outlined or not.
    *
-   * @attr
+   * @attr outlined
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public outlined = false;
 
   /**
-   * Defines if the chip is selectable or not.
-   * @attr
+   * Whether the chip is selectable or not.
+   *
+   * @attr selectable
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public selectable = false;
 
   /* @tsTwoWayProperty(true, "igcSelect", "detail", false) */
   /**
-   * Defines if the chip is selected or not.
-   * @attr
+   * Whether the chip is selected or not.
+   *
+   * @attr selected
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   public selected = false;
 
   /**
    * A property that sets the color variant of the chip component.
-   * @attr
+   *
+   * @attr variant
    */
   @property({ reflect: true })
-  public variant!: StyleVariant;
+  public variant?: StyleVariant;
 
   constructor() {
     super();
@@ -119,8 +136,13 @@ export default class IgcChipComponent extends I18nMixin(
 
     addKeybindings(this, {
       ref: this._removePartRef,
+      skip: () => !this._removePartRef.value,
       bindingDefaults: { triggers: ['keyup'] },
     }).setActivateHandler(this._handleRemove);
+  }
+
+  private _hasSlotted(...slots: InferSlotNames<typeof Slots>[]): boolean {
+    return slots.some((slot) => this._slots.hasAssignedElements(slot));
   }
 
   protected _handleSelect(): void {
@@ -136,22 +158,18 @@ export default class IgcChipComponent extends I18nMixin(
   }
 
   protected _renderPrefix() {
-    const isVisible =
-      this._slots.hasAssignedElements('prefix') ||
-      this._slots.hasAssignedElements('start');
-
-    const selectSlot =
-      this.selectable && this.selected
-        ? renderSlottedIcon({
-            slot: 'select',
-            icon: 'selected',
-            label: this.resourceStrings.chip_select,
-          })
-        : nothing;
+    const showSelected = this.selectable && this.selected;
 
     return html`
-      <span part="prefix" ?hidden=${!isVisible && !this.selected}>
-        ${selectSlot}
+      <span
+        part="prefix"
+        ?hidden=${!showSelected && !this._hasSlotted('start', 'prefix')}
+      >
+        ${
+          showSelected
+            ? renderSlottedIcon({ slot: 'select', icon: 'selected' })
+            : nothing
+        }
         <slot name="start"></slot>
         <slot name="prefix"></slot>
       </span>
@@ -159,34 +177,34 @@ export default class IgcChipComponent extends I18nMixin(
   }
 
   protected _renderSuffix() {
-    const isVisible =
-      this._slots.hasAssignedElements('suffix') ||
-      this._slots.hasAssignedElements('end');
-
-    const removeSlot =
-      this.removable && !this.disabled
-        ? html`
-            <slot
-              ${ref(this._removePartRef)}
-              name="remove"
-              @click=${this._handleRemove}
-            >
-              <igc-icon
-                name="remove"
-                collection="default"
-                tabindex="0"
-                role="button"
-                aria-label=${this.resourceStrings.chip_remove}
-              ></igc-icon>
-            </slot>
-          `
-        : nothing;
-
     return html`
-      <span part="suffix" ?hidden=${!isVisible && !this.removable}>
+      <span part="suffix" ?hidden=${!this._hasSlotted('end', 'suffix')}>
         <slot name="end"></slot>
         <slot name="suffix"></slot>
-        ${removeSlot}
+      </span>
+    `;
+  }
+
+  protected _renderRemove() {
+    if (!this.removable || this.disabled) {
+      return nothing;
+    }
+
+    return html`
+      <span part="remove">
+        <slot
+          ${ref(this._removePartRef)}
+          name="remove"
+          @click=${this._handleRemove}
+        >
+          <igc-icon
+            name="remove"
+            collection="default"
+            tabindex="0"
+            role="button"
+            aria-label=${this.resourceStrings.chip_remove}
+          ></igc-icon>
+        </slot>
       </span>
     `;
   }
@@ -195,18 +213,22 @@ export default class IgcChipComponent extends I18nMixin(
     const ariaPressed = this.selectable ? this.selected.toString() : null;
 
     return html`
-      <button
-        part="base"
-        .ariaPressed=${ariaPressed}
-        ?disabled=${this.disabled}
-        @click=${this._handleSelect}
-      >
-        ${this._renderPrefix()}
-        <span part="content">
-          <slot></slot>
-        </span>
-        ${this._renderSuffix()}
-      </button>
+      <div part="base">
+        <button
+          part="action"
+          type="button"
+          .ariaPressed=${ariaPressed}
+          ?disabled=${this.disabled}
+          @click=${this._handleSelect}
+        >
+          ${this._renderPrefix()}
+          <span part="content">
+            <slot></slot>
+          </span>
+          ${this._renderSuffix()}
+        </button>
+        ${this._renderRemove()}
+      </div>
     `;
   }
 }

--- a/src/components/chip/themes/chip.base.scss
+++ b/src/components/chip/themes/chip.base.scss
@@ -2,11 +2,14 @@
 @use 'styles/utilities' as *;
 
 :host {
+    --chip-padding-inline: #{pad-inline(rem(2px), rem(6px), rem(12px))};
+    --chip-gap: #{sizable(rem(3px), rem(6px), rem(8px))};
+
     display: inline-block;
     vertical-align: top;
 }
 
-:host button {
+:host [part='base'] {
     @include type-style('body-2');
     @include ellipsis();
 
@@ -16,20 +19,60 @@
     border: none;
     box-shadow: none;
     cursor: pointer;
-    padding: 0 pad-inline(rem(2px), rem(6px), rem(12px));
+}
 
-    &[disabled] {
-        pointer-events: none;
+:host([disabled]) [part='base'] {
+    pointer-events: none;
+}
+
+/*
+ * The selection control. It carries the inline padding of the chip so that the
+ * padded area stays part of its hit target, and drops the button chrome so that
+ * every text and color declaration comes from the base.
+ */
+[part='action'] {
+    @include ellipsis();
+
+    display: inline-flex;
+    align-items: center;
+    align-self: stretch;
+    min-width: 0;
+    padding-inline: var(--chip-padding-inline);
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    cursor: inherit;
+    outline: none;
+}
+
+[part='remove'] {
+    display: inline-flex;
+    align-items: center;
+    align-self: stretch;
+    padding-inline-end: var(--chip-padding-inline);
+}
+
+/* The remove control owns the end padding and its distance from the suffix. */
+:host([removable]:not([disabled])) {
+    [part='action'] {
+        padding-inline-end: 0;
+    }
+
+    [part='suffix'] {
+        margin-inline-end: var(--chip-gap);
     }
 }
 
 @mixin chip-variants($variant, $variant-color) {
-    :host([variant='#{$variant}']) button,
-    :host([selected][variant='#{$variant}']) button:not([disabled]) {
+    :host([variant='#{$variant}']) [part='base'],
+    :host([selected][variant='#{$variant}']:not([disabled])) [part='base'] {
         background: color($variant-color, 500);
         color: contrast-color($variant-color, 500);
 
-        &:focus {
+        &:focus-within {
             background: color($variant-color, 800);
             color: contrast-color($variant-color, 800);
         }
@@ -40,8 +83,8 @@
         }
     }
 
-    :host([variant='#{$variant}']) button[disabled],
-    :host([selected][variant='#{$variant}']) button[disabled] {
+    :host([variant='#{$variant}'][disabled]) [part='base'],
+    :host([selected][variant='#{$variant}'][disabled]) [part='base'] {
         background: color(gray, 200);
         color: color(gray, 500);
     }
@@ -54,11 +97,11 @@
 @include chip-variants('danger', error);
 
 @mixin outlined-variant($variant, $variant-color) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         background: transparent;
 
-        &:focus {
+        &:focus-within {
             background: color($variant-color, 800, .30);
         }
 
@@ -67,8 +110,8 @@
         }
     }
 
-    :host([outlined][variant='#{$variant}']) button[disabled],
-    :host([selected][outlined][variant='#{$variant}']) button[disabled] {
+    :host([outlined][variant='#{$variant}'][disabled]) [part='base'],
+    :host([selected][outlined][variant='#{$variant}'][disabled]) [part='base'] {
         background: color(gray, 200, .30);
         color: color(gray, 500);
         border-color: color(gray, 500, .30);

--- a/src/components/chip/themes/dark/chip.bootstrap.scss
+++ b/src/components/chip/themes/dark/chip.bootstrap.scss
@@ -9,8 +9,8 @@ $theme: $bootstrap;
 }
 
 @mixin chip-outlined-variants-dark($variant, $variant-color, $border-shade) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         border-color: color($variant-color, $border-shade);
         color: contrast-color(gray, 100);
     }

--- a/src/components/chip/themes/dark/chip.fluent.scss
+++ b/src/components/chip/themes/dark/chip.fluent.scss
@@ -9,12 +9,12 @@ $theme: $fluent;
 }
 
 @mixin chip-outlined-variants-dark($variant, $variant-color, $border-shade, $color-shade) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         border-color: color($variant-color, $border-shade);
         color: contrast-color($variant-color, $color-shade);
 
-        &:focus {
+        &:focus-within {
             background: color($variant-color, 800, .50);
         }
 

--- a/src/components/chip/themes/dark/chip.indigo.scss
+++ b/src/components/chip/themes/dark/chip.indigo.scss
@@ -8,25 +8,25 @@ $theme: $indigo;
     @include css-vars-from-theme(diff(light.$base, $theme));
 }
 
-:host([variant='info']) button,
-:host([selected][variant='info']) button:not([disabled]) {
-    &:focus {
+:host([variant='info']) [part='base'],
+:host([selected][variant='info']:not([disabled])) [part='base'] {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) color(info, 800);
     }
 }
 
-:host([variant='success']) button,
-:host([selected][variant='success']) button:not([disabled]) {
-    &:focus {
+:host([variant='success']) [part='base'],
+:host([selected][variant='success']:not([disabled])) [part='base'] {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) color(success, 900);
     }
 }
 
-:host([variant='warning']) button,
-:host([selected][variant='warning']) button:not([disabled]) {
+:host([variant='warning']) [part='base'],
+:host([selected][variant='warning']:not([disabled])) [part='base'] {
     color: color(gray, 50);
 
-    &:focus {
+    &:focus-within {
         color: color(gray, 50);
         box-shadow: 0 0 0 rem(3px) color(warn, 900);
     }
@@ -36,26 +36,26 @@ $theme: $indigo;
     }
 }
 
-:host([variant='warning']) button[disabled],
-:host([selected][variant='warning']) button[disabled] {
+:host([variant='warning'][disabled]) [part='base'],
+:host([selected][variant='warning'][disabled]) [part='base'] {
     color: color(gray, 50);
 }
 
-:host([variant='danger']) button,
-:host([selected][variant='danger']) button:not([disabled]) {
-    &:focus {
+:host([variant='danger']) [part='base'],
+:host([selected][variant='danger']:not([disabled])) [part='base'] {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) color(error, 900);
     }
 }
 
-:host([variant='primary']) button[disabled],
-:host([selected][variant='primary']) button[disabled] {
+:host([variant='primary'][disabled]) [part='base'],
+:host([selected][variant='primary'][disabled]) [part='base'] {
     color: contrast-color(primary, 900, .2);
 }
 
 @mixin chip-outlined-variants-dark($variant, $variant-color, $border-shade) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         border-color: color($variant-color, $border-shade);
         color: contrast-color(gray, 100);
 
@@ -69,13 +69,13 @@ $theme: $indigo;
             }
         }
 
-        &:focus {
+        &:focus-within {
             background: transparent;
         }
     }
 
-    :host([outlined][variant='#{$variant}']) button[disabled],
-    :host([selected][outlined][variant='#{$variant}']) button[disabled] {
+    :host([outlined][variant='#{$variant}'][disabled]) [part='base'],
+    :host([selected][outlined][variant='#{$variant}'][disabled]) [part='base'] {
         background: transparent;
         border-color: color($variant-color, $border-shade);
         color: contrast-color(gray, 100);

--- a/src/components/chip/themes/dark/chip.material.scss
+++ b/src/components/chip/themes/dark/chip.material.scss
@@ -9,8 +9,8 @@ $theme: $material;
 }
 
 @mixin chip-outlined-variants-dark($variant, $variant-color, $border-shade) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         border-color: color($variant-color, $border-shade);
         color: contrast-color(gray, 100);
     }

--- a/src/components/chip/themes/light/chip.bootstrap.scss
+++ b/src/components/chip/themes/light/chip.bootstrap.scss
@@ -8,8 +8,8 @@ $theme: $bootstrap;
 }
 
 @mixin chip-outlined-variants-light($variant, $variant-color) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         color: contrast-color($variant-color, 100);
 
         @if $variant == 'warning' or $variant == 'info' {

--- a/src/components/chip/themes/light/chip.fluent.scss
+++ b/src/components/chip/themes/light/chip.fluent.scss
@@ -8,12 +8,12 @@ $theme: $fluent;
 }
 
 @mixin chip-outlined-variants-light($variant, $variant-color) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         border-color: color($variant-color, 600);
         color: contrast-color($variant-color, 100);
 
-        &:focus {
+        &:focus-within {
             background: color($variant-color, 800, .30);
         }
 

--- a/src/components/chip/themes/light/chip.indigo.scss
+++ b/src/components/chip/themes/light/chip.indigo.scss
@@ -7,25 +7,25 @@ $theme: $indigo;
     @include css-vars-from-theme(diff($base, $theme));
 }
 
-:host([variant='info']) button,
-:host([selected][variant='info']) button:not([disabled]) {
-    &:focus {
+:host([variant='info']) [part='base'],
+:host([selected][variant='info']:not([disabled])) [part='base'] {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) color(info, 100);
     }
 }
 
-:host([variant='success']) button,
-:host([selected][variant='success']) button:not([disabled]) {
-    &:focus {
+:host([variant='success']) [part='base'],
+:host([selected][variant='success']:not([disabled])) [part='base'] {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) color(success, 200);
     }
 }
 
-:host([variant='warning']) button,
-:host([selected][variant='warning']) button:not([disabled]) {
+:host([variant='warning']) [part='base'],
+:host([selected][variant='warning']:not([disabled])) [part='base'] {
     color: color(gray, 900);
 
-    &:focus {
+    &:focus-within {
         color: color(gray, 900);
         box-shadow: 0 0 0 rem(3px) color(warn, 100);
     }
@@ -35,26 +35,26 @@ $theme: $indigo;
     }
 }
 
-:host([variant='warning']) button[disabled],
-:host([selected][variant='warning']) button[disabled] {
+:host([variant='warning'][disabled]) [part='base'],
+:host([selected][variant='warning'][disabled]) [part='base'] {
     color: color(gray, 900);
 }
 
-:host([variant='danger']) button,
-:host([selected][variant='danger']) button:not([disabled]) {
-    &:focus {
+:host([variant='danger']) [part='base'],
+:host([selected][variant='danger']:not([disabled])) [part='base'] {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) color(error, 100);
     }
 }
 
-:host([variant='primary']) button[disabled],
-:host([selected][variant='primary']) button[disabled] {
+:host([variant='primary'][disabled]) [part='base'],
+:host([selected][variant='primary'][disabled]) [part='base'] {
     color: contrast-color(primary, 900, .4);
 }
 
 @mixin chip-outlined-variants-light($variant, $variant-color, $border-shade) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         border-color: color($variant-color, $border-shade);
         color: color(gray, 900);
 
@@ -66,13 +66,13 @@ $theme: $indigo;
             }
         }
 
-        &:focus {
+        &:focus-within {
             background: transparent;
         }
     }
 
-    :host([outlined][variant='#{$variant}']) button[disabled],
-    :host([selected][outlined][variant='#{$variant}']) button[disabled] {
+    :host([outlined][variant='#{$variant}'][disabled]) [part='base'],
+    :host([selected][outlined][variant='#{$variant}'][disabled]) [part='base'] {
         background: transparent;
         border-color: color($variant-color, $border-shade);
         color: color(gray, 900);

--- a/src/components/chip/themes/light/chip.material.scss
+++ b/src/components/chip/themes/light/chip.material.scss
@@ -8,8 +8,8 @@ $theme: $material;
 }
 
 @mixin chip-outlined-variants-light($variant, $variant-color) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         border-color: color($variant-color, 800);
         color: contrast-color($variant-color, 100);
     }

--- a/src/components/chip/themes/shared/chip.bootstrap.scss
+++ b/src/components/chip/themes/shared/chip.bootstrap.scss
@@ -7,24 +7,24 @@ $theme: $bootstrap;
     --component-size: var(--ig-size, #{var-get($theme, 'default-size')});
 }
 
-:host button {
-    &:focus {
+:host [part='base'] {
+    &:focus-within {
         outline: rem(4px) solid var-get($theme, 'focus-shadow-color');
     }
 }
 
-:host([selected]) button:not([disabled]) {
-    &:focus {
+:host([selected]:not([disabled])) [part='base'] {
+    &:focus-within {
         outline: rem(4px) solid var-get($theme, 'focus-selected-shadow-color');
     }
 }
 
 @mixin chip-variants($variant, $variant-color) {
-    :host([variant='#{$variant}']) button,
-    :host([selected][variant='#{$variant}']) button:not([disabled]) {
+    :host([variant='#{$variant}']) [part='base'],
+    :host([selected][variant='#{$variant}']:not([disabled])) [part='base'] {
         color: contrast-color($variant-color, 700);
 
-        &:focus {
+        &:focus-within {
             background: color($variant-color, 500);
             color: contrast-color($variant-color, 700);
             outline: rem(4px) solid color($variant-color, 500, 0.38);
@@ -44,15 +44,15 @@ $theme: $bootstrap;
 @include chip-variants('danger', error);
 
 @mixin chip-outlined-variants($variant, $variant-color) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         background: transparent;
 
         &:hover {
             background: color($variant-color, 600, .30);
         }
 
-        &:focus {
+        &:focus-within {
             background: transparent;
         }
     }

--- a/src/components/chip/themes/shared/chip.common.scss
+++ b/src/components/chip/themes/shared/chip.common.scss
@@ -8,7 +8,7 @@ $theme: $material;
     --chip-size: var(--component-size);
 }
 
-:host button {
+:host [part='base'] {
     border-radius: var-get($theme, 'border-radius');
     background: var-get($theme, 'background');
     color: var-get($theme, 'text-color');
@@ -19,7 +19,7 @@ $theme: $material;
         padding-inline: pad-inline(rem(3px), rem(6px), rem(8px));
     }
 
-    &:focus {
+    &:focus-within {
         background: var-get($theme, 'focus-background');
         color: var-get($theme, 'focus-text-color');
     }
@@ -27,11 +27,6 @@ $theme: $material;
     &:hover {
         background: var-get($theme, 'hover-background');
         color: var-get($theme, 'hover-text-color');
-    }
-
-    &[disabled] {
-        background: var-get($theme, 'disabled-background');
-        color: var-get($theme, 'disabled-text-color');
     }
 
     ::slotted([slot="remove"]) {
@@ -77,11 +72,16 @@ $theme: $material;
     }
 }
 
-:host([selected]) button:not([disabled]) {
+:host([disabled]) [part='base'] {
+    background: var-get($theme, 'disabled-background');
+    color: var-get($theme, 'disabled-text-color');
+}
+
+:host([selected]:not([disabled])) [part='base'] {
     background: var-get($theme, 'selected-background');
     color: var-get($theme, 'selected-text-color');
 
-    &:focus {
+    &:focus-within {
         background: var-get($theme, 'focus-selected-background');
         color: var-get($theme, 'focus-selected-text-color');
     }
@@ -92,17 +92,17 @@ $theme: $material;
     }
 }
 
-:host([selected]) button[disabled] {
+:host([selected][disabled]) [part='base'] {
     background: var-get($theme, 'disabled-selected-background');
     color: var-get($theme, 'disabled-selected-text-color');
 }
 
-:host([outlined]) button {
+:host([outlined]) [part='base'] {
     background: var-get($theme, 'outlined-background');
     color: var-get($theme, 'outlined-text-color');
     border: rem(1px) solid var-get($theme, 'border-color');
 
-    &:focus {
+    &:focus-within {
         background: var-get($theme, 'focus-outlined-background');
         color: var-get($theme, 'focus-outlined-text-color');
         border-color: var-get($theme, 'focus-border-color');
@@ -113,20 +113,20 @@ $theme: $material;
         color: var-get($theme, 'hover-outlined-text-color');
         border-color: var-get($theme, 'hover-border-color');
     }
-
-    &[disabled] {
-        background: var-get($theme, 'disabled-outlined-background');
-        color: var-get($theme, 'disabled-outlined-text-color');
-        border-color: var-get($theme, 'disabled-border-color');
-    }
 }
 
-:host([selected][outlined]) button:not([disabled]) {
+:host([outlined][disabled]) [part='base'] {
+    background: var-get($theme, 'disabled-outlined-background');
+    color: var-get($theme, 'disabled-outlined-text-color');
+    border-color: var-get($theme, 'disabled-border-color');
+}
+
+:host([selected][outlined]:not([disabled])) [part='base'] {
     background: var-get($theme, 'selected-outlined-background');
     color: var-get($theme, 'selected-outlined-text-color');
     border-color: var-get($theme, 'selected-border-color');
 
-    &:focus {
+    &:focus-within {
         background: var-get($theme, 'focus-selected-outlined-background');
         color: var-get($theme, 'focus-selected-outlined-text-color');
         border-color: var-get($theme, 'focus-selected-border-color');
@@ -139,7 +139,7 @@ $theme: $material;
     }
 }
 
-:host([selected][outlined]) button[disabled] {
+:host([selected][outlined][disabled]) [part='base'] {
     background: var-get($theme, 'disabled-selected-outlined-background');
     color: var-get($theme, 'disabled-selected-outlined-text-color');
     border-color: var-get($theme, 'disabled-selected-border-color');

--- a/src/components/chip/themes/shared/chip.fluent.scss
+++ b/src/components/chip/themes/shared/chip.fluent.scss
@@ -7,13 +7,13 @@ $theme: $fluent;
     --component-size: var(--ig-size, #{var-get($theme, 'default-size')});
 }
 
-:host button {
+:host [part='base'] {
     @include type-style('subtitle-2');
 }
 
 @mixin chip-outlined-variants($variant) {
-    :host([outlined][variant='#{$variant}']) button,
-    :host([selected][outlined][variant='#{$variant}']) button:not([disabled]) {
+    :host([outlined][variant='#{$variant}']) [part='base'],
+    :host([selected][outlined][variant='#{$variant}']:not([disabled])) [part='base'] {
         background: transparent;
     }
 }

--- a/src/components/chip/themes/shared/chip.indigo.scss
+++ b/src/components/chip/themes/shared/chip.indigo.scss
@@ -5,12 +5,11 @@ $theme: $indigo;
 
 :host {
     --component-size: var(--ig-size, #{var-get($theme, 'default-size')});
+    --chip-padding-inline: #{pad-inline(3px, 5px, 7px)};
 }
 
-:host button {
-    padding: 0 pad-inline(3px, 5px, 7px);
-
-    &:focus {
+:host [part='base'] {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) var-get($theme, 'focus-shadow-color');
     }
 
@@ -20,22 +19,22 @@ $theme: $indigo;
     }
 }
 
-:host([selected]) button:not([disabled]) {
+:host([selected]:not([disabled])) [part='base'] {
     color: var-get($theme, 'selected-text-color');
     background: var-get($theme, 'selected-background');
 
-    &:focus {
+    &:focus-within {
         box-shadow: 0 0 0 rem(3px) var-get($theme, 'focus-selected-shadow-color');
     }
 }
 
-:host([selected]) button[disabled] {
+:host([selected][disabled]) [part='base'] {
     opacity: .4;
 }
 
-:host([variant='primary']) button,
-:host([selected][variant='primary']) button:not([disabled]) {
-    &:focus {
+:host([variant='primary']) [part='base'],
+:host([selected][variant='primary']:not([disabled])) [part='base'] {
+    &:focus-within {
         color: contrast-color(primary, 900);
         background: color(primary, 500);
         box-shadow: 0 0 0 rem(3px) color(primary, 400, .5);
@@ -47,14 +46,14 @@ $theme: $indigo;
     }
 }
 
-:host([variant='primary']) button[disabled],
-:host([selected][variant='primary']) button[disabled] {
+:host([variant='primary'][disabled]) [part='base'],
+:host([selected][variant='primary'][disabled]) [part='base'] {
     background: color(primary, 400, .5);
 }
 
 @mixin chip-variants($variant, $variant-color) {
-    :host([variant='#{$variant}']) button,
-    :host([selected][variant='#{$variant}']) button:not([disabled]) {
+    :host([variant='#{$variant}']) [part='base'],
+    :host([selected][variant='#{$variant}']:not([disabled])) [part='base'] {
         @if $variant != 'warning' {
             color: contrast-color($variant-color, 900);
         }
@@ -65,7 +64,7 @@ $theme: $indigo;
             background: color(error, 600);
         }
 
-        &:focus {
+        &:focus-within {
             @if $variant == 'warning' or $variant == 'info' {
                 background: color($variant-color, 500);
             } @else if $variant == 'danger' {
@@ -92,8 +91,8 @@ $theme: $indigo;
         }
     }
 
-    :host([variant='#{$variant}']) button[disabled],
-    :host([selected][variant='#{$variant}']) button[disabled] {
+    :host([variant='#{$variant}'][disabled]) [part='base'],
+    :host([selected][variant='#{$variant}'][disabled]) [part='base'] {
         @if $variant != 'primary' {
             opacity: .4;
         }
@@ -119,6 +118,6 @@ $theme: $indigo;
 @include chip-variants('warning', warn);
 @include chip-variants('danger', error);
 
-:host([outlined][variant='primary']) button[disabled] {
+:host([outlined][variant='primary'][disabled]) [part='base'] {
     opacity: .4;
 }

--- a/stories/chip.stories.ts
+++ b/stories/chip.stories.ts
@@ -23,31 +23,31 @@ const metadata: Meta<IgcChipComponent> = {
   argTypes: {
     disabled: {
       type: 'boolean',
-      description: 'Sets the disabled state for the chip.',
+      description: 'Whether the chip is disabled or not.',
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
     removable: {
       type: 'boolean',
-      description: 'Defines if the chip is removable or not.',
+      description: 'Whether the chip is removable or not.',
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
     outlined: {
       type: 'boolean',
-      description: 'Defines if the chip is outlined or not.',
+      description: 'Whether the chip is outlined or not.',
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
     selectable: {
       type: 'boolean',
-      description: 'Defines if the chip is selectable or not.',
+      description: 'Whether the chip is selectable or not.',
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
     selected: {
       type: 'boolean',
-      description: 'Defines if the chip is selected or not.',
+      description: 'Whether the chip is selected or not.',
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
@@ -80,15 +80,15 @@ const metadata: Meta<IgcChipComponent> = {
 export default metadata;
 
 interface IgcChipArgs {
-  /** Sets the disabled state for the chip. */
+  /** Whether the chip is disabled or not. */
   disabled: boolean;
-  /** Defines if the chip is removable or not. */
+  /** Whether the chip is removable or not. */
   removable: boolean;
-  /** Defines if the chip is outlined or not. */
+  /** Whether the chip is outlined or not. */
   outlined: boolean;
-  /** Defines if the chip is selectable or not. */
+  /** Whether the chip is selectable or not. */
   selectable: boolean;
-  /** Defines if the chip is selected or not. */
+  /** Whether the chip is selected or not. */
   selected: boolean;
   /** A property that sets the color variant of the chip component. */
   variant: 'primary' | 'info' | 'success' | 'warning' | 'danger';


### PR DESCRIPTION
## Description

The chip rendered its whole surface as a `<button part="base">` while the remove icon inside it carried `role="button"` and `tabindex="0"`, so every removable chip failed the `nested-interactive` audit. The `aria-label` of that icon and of the selection icon also fed the base button's accessible name, which read "Chip remove chip" and "select chip Chip" instead of the chip content.

- `part="base"` is now a plain wrapper holding two siblings - `part="action"` for selection and `part="remove"` for removal - so neither control nests inside the other.
- The selection icon is decorative again, since `aria-pressed` on the action control already conveys the state.
- `igcRemove` is typed `CustomEvent<void>`; it never carried the boolean detail its type promised.
- The prefix wrapper hides on `selectable && selected` rather than on `selected` alone, and the suffix wrapper no longer tracks `removable`.
- The `start` and `end` slots and the new `action` and `remove` parts are documented, so they reach the manifest.
- Theme selectors move from `button` to `[part='base']`, with the disabled and enabled qualifiers folded into `:host(...)` and `:focus` widened to `:focus-within`, so focusing the remove control now also shows the chip focus state. Geometry is unchanged across every theme, variant and size.
- The remove keybindings are scoped to the remove control. Falling back to the host cancelled the chip's own activation keys, so `Space` never toggled selection and `igcRemove` fired on chips that are not removable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
