### PR TITLE
fix(avatar, badge): repair icon-only badge padding and ARIA semantics

### DIFF
--- a/src/components/avatar/avatar.spec.ts
+++ b/src/components/avatar/avatar.spec.ts
@@ -1,5 +1,12 @@
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import {
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+  waitUntil,
+} from '@open-wc/testing';
 
+import { internalsOf } from '#internals/controllers/internals.js';
 import { defineComponents } from '#internals/definitions/defineComponents.js';
 import IgcAvatarComponent from './avatar.js';
 
@@ -7,6 +14,17 @@ describe('Avatar', () => {
   const DIFF_OPTIONS = {
     ignoreAttributes: ['style'],
   };
+
+  /** A 1x1 transparent GIF. Data URIs keep the network out of these tests. */
+  const ValidImage =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+  /** Undecodable payload - errors locally, without a 404 in the test log. */
+  const BrokenImage = 'data:image/gif;base64,bm90LWFuLWltYWdl';
+
+  function getImage(element: IgcAvatarComponent): HTMLImageElement | null {
+    return element.renderRoot.querySelector('img');
+  }
 
   before(() => {
     defineComponents(IgcAvatarComponent);
@@ -50,7 +68,7 @@ describe('Avatar', () => {
     );
   });
 
-  it('should fallback to initials avatar when no image or wrong image source is provided', async () => {
+  it('should fallback to initials avatar when no image is provided', async () => {
     const el = await fixture<IgcAvatarComponent>(
       html`<igc-avatar initials="ab"></igc-avatar>`
     );
@@ -61,12 +79,88 @@ describe('Avatar', () => {
       <span part="initials">ab</span>
       </div>`
     );
+  });
 
-    el.setAttribute('src', 'abs');
+  it('should render the image alongside the initials until it fails to load', async () => {
+    const el = await fixture<IgcAvatarComponent>(
+      html`<igc-avatar initials="ab" src=${BrokenImage}></igc-avatar>`
+    );
+
+    expect(getImage(el)).to.exist;
+
+    await waitUntil(
+      () => getImage(el) === null,
+      'The avatar did not drop the image after a load error'
+    );
+
     expect(el).shadowDom.to.equal(
       `<div part="base">
       <span part="initials">ab</span>
       </div>`
     );
+  });
+
+  it('should retry rendering the image when the source changes after an error', async () => {
+    const el = await fixture<IgcAvatarComponent>(
+      html`<igc-avatar src=${BrokenImage}></igc-avatar>`
+    );
+
+    await waitUntil(() => getImage(el) === null);
+
+    el.src = ValidImage;
+    await elementUpdated(el);
+
+    expect(getImage(el)?.src).to.equal(ValidImage);
+  });
+
+  it('should mark the image as decorative when no alt text is provided', async () => {
+    const el = await fixture<IgcAvatarComponent>(
+      html`<igc-avatar src=${ValidImage}></igc-avatar>`
+    );
+
+    expect(getImage(el)!.getAttribute('alt')).to.equal('');
+
+    el.alt = 'John Doe';
+    await elementUpdated(el);
+    expect(getImage(el)!.getAttribute('alt')).to.equal('John Doe');
+  });
+
+  describe('ARIA', () => {
+    function ariaOf(element: IgcAvatarComponent) {
+      const internals = internalsOf(element)!;
+      return {
+        role: internals.getARIA('role'),
+        label: internals.getARIA('ariaLabel'),
+        roleDescription: internals.getARIA('ariaRoleDescription'),
+      };
+    }
+
+    it('should expose an image role, a role description and no name of its own', async () => {
+      const el = await fixture<IgcAvatarComponent>(
+        html`<igc-avatar></igc-avatar>`
+      );
+
+      expect(ariaOf(el)).to.eql({
+        role: 'img',
+        roleDescription: 'avatar',
+        label: null,
+      });
+    });
+
+    it('should derive the accessible name from alt, then initials', async () => {
+      const el = await fixture<IgcAvatarComponent>(
+        html`<igc-avatar initials="ab"></igc-avatar>`
+      );
+
+      expect(ariaOf(el).label).to.equal('ab');
+
+      el.alt = 'John Doe';
+      await elementUpdated(el);
+      expect(ariaOf(el).label).to.equal('John Doe');
+
+      el.alt = undefined;
+      await elementUpdated(el);
+      expect(ariaOf(el).label).to.equal('ab');
+    });
   });
 });

--- a/src/components/avatar/avatar.ts
+++ b/src/components/avatar/avatar.ts
@@ -1,6 +1,5 @@
 import { html, LitElement, nothing, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { addInternalsController } from '#internals/controllers/internals.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import { addThemingController } from '#theming/theming-controller.js';
@@ -15,12 +14,11 @@ import { all } from './themes/themes.js';
  *
  * @element igc-avatar
  *
- * @slot - Renders an icon inside the default slot.
+ * @slot - Renders an icon inside the default slot. Ignored when `initials` is set.
  *
  * @csspart base - The base wrapper of the avatar.
  * @csspart initials - The initials wrapper of the avatar.
  * @csspart image - The image wrapper of the avatar.
- * @csspart icon - The icon wrapper of the avatar.
  */
 export default class IgcAvatarComponent extends LitElement {
   public static readonly tagName = 'igc-avatar';
@@ -67,11 +65,8 @@ export default class IgcAvatarComponent extends LitElement {
     addThemingController(this, all);
 
     addInternalsController(this, {
-      initialARIA: {
-        role: 'image',
-        ariaLabel: 'avatar',
-      },
-      aria: () => ({ ariaRoleDescription: this.alt ?? this.initials ?? null }),
+      initialARIA: { role: 'img', ariaRoleDescription: 'avatar' },
+      aria: () => ({ ariaLabel: this.alt ?? this.initials ?? null }),
     });
   }
 
@@ -98,8 +93,8 @@ export default class IgcAvatarComponent extends LitElement {
             ? html`
                 <img
                   part="image"
-                  alt=${ifDefined(this.alt)}
-                  src=${ifDefined(this.src)}
+                  alt=${this.alt ?? ''}
+                  src=${this.src}
                   @error=${this._handleError}
                 />
               `

--- a/src/components/badge/badge.spec.ts
+++ b/src/components/badge/badge.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { internalsOf } from '#internals/controllers/internals.js';
 import { defineComponents } from '#internals/definitions/defineComponents.js';
 import IgcIconComponent from '../icon/icon.js';
 import IgcBadgeComponent from './badge.js';
@@ -96,11 +97,83 @@ describe('Badge', () => {
     expect(el.variant).to.equal('success');
   });
 
-  it('should apply correct part for slotted igc-icon', async () => {
-    const el = await fixture<IgcBadgeComponent>(
-      html`<igc-badge><igc-icon name="home"></igc-icon></igc-badge>`
-    );
+  describe('Icon part', () => {
+    function hasIconPart(element: IgcBadgeComponent): boolean {
+      return element.renderRoot.querySelector('[part~="icon"]') !== null;
+    }
 
-    expect(el.renderRoot.querySelector('[part~="icon"]')).to.exist;
+    it('should apply the icon part when an igc-icon is the only slotted element', async () => {
+      const el = await fixture<IgcBadgeComponent>(
+        html`<igc-badge><igc-icon name="home"></igc-icon></igc-badge>`
+      );
+
+      expect(hasIconPart(el)).to.be.true;
+    });
+
+    it('should not apply the icon part when the icon is accompanied by text', async () => {
+      const el = await fixture<IgcBadgeComponent>(
+        html`<igc-badge><igc-icon name="home"></igc-icon>12</igc-badge>`
+      );
+
+      expect(hasIconPart(el)).to.be.false;
+    });
+
+    it('should not apply the icon part for text-only content', async () => {
+      const el = await fixture<IgcBadgeComponent>(
+        html`<igc-badge>12</igc-badge>`
+      );
+
+      expect(hasIconPart(el)).to.be.false;
+    });
+
+    it('should clear the icon part when the icon is removed', async () => {
+      const el = await fixture<IgcBadgeComponent>(
+        html`<igc-badge><igc-icon name="home"></igc-icon></igc-badge>`
+      );
+
+      expect(hasIconPart(el)).to.be.true;
+
+      el.querySelector('igc-icon')!.remove();
+      await elementUpdated(el);
+
+      expect(hasIconPart(el)).to.be.false;
+    });
+
+    it('should keep the inline padding of a badge that is not icon-only', async () => {
+      const el = await fixture<HTMLElement>(
+        html`<div style="--ig-spacing: 1; --ig-spacing-inline: 1">
+          <igc-badge id="icon"><igc-icon name="home"></igc-icon></igc-badge>
+          <igc-badge id="mixed"><igc-icon name="home"></igc-icon>12</igc-badge>
+          <igc-badge id="text">12</igc-badge>
+        </div>`
+      );
+
+      const paddingOf = (id: string) => {
+        const badge = el.querySelector<IgcBadgeComponent>(`#${id}`)!;
+        const base = badge.renderRoot.querySelector('[part~="base"]')!;
+        return getComputedStyle(base).paddingInline;
+      };
+
+      // An icon-only badge renders as a circle.
+      expect(paddingOf('icon')).to.equal('0px');
+      expect(paddingOf('mixed')).to.not.equal('0px');
+      expect(paddingOf('text')).to.equal(paddingOf('mixed'));
+    });
+  });
+
+  describe('ARIA', () => {
+    it('should expose a static role description that ignores the variant', async () => {
+      const el = await fixture<IgcBadgeComponent>(
+        html`<igc-badge variant="success">1</igc-badge>`
+      );
+      const internals = internalsOf(el)!;
+
+      expect(internals.getARIA('role')).to.equal('status');
+      expect(internals.getARIA('ariaRoleDescription')).to.equal('badge');
+
+      el.variant = 'danger';
+      await elementUpdated(el);
+      expect(internals.getARIA('ariaRoleDescription')).to.equal('badge');
+    });
   });
 });

--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -4,6 +4,8 @@ import { addInternalsController } from '#internals/controllers/internals.js';
 import { addSlotController, setSlots } from '#internals/controllers/slot.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import { partMap } from '#internals/part-map.js';
+import { isEmpty } from '#internals/utils/arrays.js';
+import { isElement } from '#internals/utils/dom.js';
 import { addThemingController } from '#theming/theming-controller.js';
 import type { BadgeShape, StyleVariant } from '../types.js';
 import { styles } from './themes/badge.base.css.js';
@@ -19,7 +21,7 @@ import { all } from './themes/themes.js';
  * @slot - Default slot for the badge content.
  *
  * @csspart base - The base wrapper of the badge.
- * @csspart icon - The icon container, present when an icon element is slotted.
+ * @csspart icon - The icon container, present when an `igc-icon` is the only slotted element.
  *
  * @example
  * ```html
@@ -87,15 +89,22 @@ export default class IgcBadgeComponent extends LitElement {
     addThemingController(this, all);
 
     addInternalsController(this, {
-      initialARIA: { role: 'status' },
-      aria: () => ({ ariaRoleDescription: `badge ${this.variant}` }),
+      initialARIA: { role: 'status', ariaRoleDescription: 'badge' },
     });
   }
 
+  /**
+   * The `icon` part is reserved for a badge whose only content is a single
+   * `igc-icon`, which renders as a circle rather than a padded pill. The filter
+   * discards the whitespace text nodes that formatted markup leaves around it.
+   */
   protected _handleSlotChange(): void {
-    this._hasIcon = this._slots.hasAssignedElements('[default]', {
-      selector: 'igc-icon',
-    });
+    const [content, ...rest] = this._slots
+      .getAssignedNodes('[default]')
+      .filter((node) => isElement(node) || node.textContent?.trim());
+
+    this._hasIcon =
+      isEmpty(rest) && isElement(content) && content.matches('igc-icon');
   }
 
   protected override render() {

--- a/src/components/badge/themes/badge.base.scss
+++ b/src/components/badge/themes/badge.base.scss
@@ -23,7 +23,9 @@
     text-transform: sizable(var(--ig-caption-text-transform), var(--ig-body-2-text-transform), var(--ig-body-2-text-transform));
 }
 
-:host(:not(:empty, [dot])) [part='base'] {
+// Excluded for an icon-only badge, which renders as a circle. Match the part
+// token, not the whole attribute, so that adding a part cannot drop the padding.
+:host(:not(:empty, [dot])) [part~='base']:not([part~='icon']) {
     padding-inline: pad-inline(rem(4px), rem(6px), rem(8px));
 }
 


### PR DESCRIPTION
## Description

The badge `icon` part activated for any slotted `igc-icon`, while the padding rule matched `[part='base']` exactly - so an icon badge that also had text lost its inline padding and clipped the text under `overflow: hidden`. Avatar exposed the invalid role `image` and inverted its ARIA: `alt`/`initials` became the role description, while the accessible name was pinned to the literal "avatar".

- The `icon` part now requires the icon to be the badge's only content, as the documentation already claimed, and the padding rule excludes that part explicitly instead of relying on an exact attribute match.
- Badge reports a static `badge` role description, so the visual `variant` no longer reaches assistive technology. `role="status"` is unchanged.
- Avatar uses `role="img"`, derives its accessible name from `alt` then `initials`, and keeps `avatar` as the role description.
- Avatar renders `alt=""` when no alt text is given, rather than an `<img>` carrying no `alt` attribute at all.
- Removed the avatar `icon` part, documented but never rendered.
- The avatar fallback test asserted pre-update DOM and passed for the wrong reason; it now exercises the load error, next to new coverage for the image alt, both components' ARIA and the badge icon part.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code improvements without functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
