### PR TITLE
feat(breadcrumbs): add component styles

### DIFF
--- a/src/components/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb.ts
@@ -7,6 +7,7 @@ import { addInternalsController } from '../common/controllers/internals.js';
 import { registerComponent } from '../common/definitions/register.js';
 import IgcIconComponent from '../icon/icon.js';
 import { styles } from './themes/breadcrumb.base.css.js';
+import { styles as shared } from './themes/shared/breadcrumb.common.css.js';
 import { all } from './themes/themes.js';
 
 /**
@@ -21,11 +22,6 @@ import { all } from './themes/themes.js';
  *
  * @csspart label - The container wrapping the prefix, default, and suffix slots.
  * @csspart separator - The container wrapping the separator slot content.
- *
- * @cssproperty --ig-breadcrumb-link-color - The color of the breadcrumb link. Defaults to `--ig-primary-500`.
- * @cssproperty --ig-breadcrumb-link-color-hover - The hover color of the breadcrumb link. Defaults to `--ig-primary-700`.
- * @cssproperty --ig-breadcrumb-current-color - The color of the active (current) breadcrumb link. Defaults to `--ig-gray-900`.
- * @cssproperty --ig-breadcrumb-separator-color - The color of the separator. Defaults to `--ig-gray-500`.
  *
  * @example
  * ```html
@@ -44,7 +40,7 @@ import { all } from './themes/themes.js';
  */
 export default class IgcBreadcrumbComponent extends LitElement {
   public static readonly tagName = 'igc-breadcrumb';
-  public static override styles = [styles];
+  public static override styles = [styles, shared];
 
   /* blazorSuppress */
   public static register(): void {
@@ -84,6 +80,13 @@ export default class IgcBreadcrumbComponent extends LitElement {
    */
   @property({ type: Boolean, reflect: true })
   public current = false;
+
+  /**
+   * Sets the disabled state of the breadcrumb.
+   * @attr
+   */
+  @property({ type: Boolean, reflect: true })
+  public disabled = false;
 
   //#endregion
 

--- a/src/components/breadcrumb/breadcrumbs.spec.ts
+++ b/src/components/breadcrumb/breadcrumbs.spec.ts
@@ -150,6 +150,20 @@ describe('Breadcrumbs', () => {
     });
   });
 
+  describe('disabled property', () => {
+    it('reflects the disabled attribute', async () => {
+      const item = await fixture<IgcBreadcrumbComponent>(
+        html`<igc-breadcrumb><a href="#">Home</a></igc-breadcrumb>`
+      );
+
+      item.disabled = true;
+      await elementUpdated(item);
+
+      expect(item.disabled).to.be.true;
+      expect(item.hasAttribute('disabled')).to.be.true;
+    });
+  });
+
   describe('Separator property', () => {
     it('defaults to tree_expand separator icon', async () => {
       const el = await fixture<IgcBreadcrumbsComponent>(

--- a/src/components/breadcrumb/themes/breadcrumb.base.scss
+++ b/src/components/breadcrumb/themes/breadcrumb.base.scss
@@ -2,40 +2,30 @@
 @use 'styles/utilities' as *;
 
 :host {
-    --_link-color: var(--ig-breadcrumb-link-color, var(--ig-primary-500));
-    --_link-color-hover: var(
-        --ig-breadcrumb-link-color-hover,
-        var(--ig-primary-700)
-    );
-    --_current-color: var(--ig-breadcrumb-current-color, var(--ig-gray-900));
-    --_separator-color: var(
-        --ig-breadcrumb-separator-color,
-        var(--ig-gray-500)
-    );
-
     display: inline-flex;
     flex: 0 0 auto;
-    gap: 0.5rem;
+    align-items: center;
 
     ::slotted(a) {
-        color: var(--_link-color);
         text-decoration: none;
 
         &:hover {
-            color: var(--_link-color-hover);
             text-decoration: underline;
         }
+    }
 
-        &:focus-visible {
-            outline: 2px solid var(--_link-color);
-            outline-offset: 2px;
-            border-radius: 2px;
-        }
+    ::slotted(a:focus-visible) {
+        outline: none;
     }
 }
 
 [part='separator'] {
-    color: var(--_separator-color);
+    display: inline-flex;
+    align-items: center;
+
+    igc-icon {
+        --component-size: var(--ig-size, var(--ig-size-medium));
+    }
 
     &:dir(rtl) igc-icon,
     &:dir(rtl) ::slotted(igc-icon) {
@@ -43,10 +33,25 @@
     }
 }
 
-:host([current]) {
-    ::slotted(a) {
-        color: var(--_current-color);
-        pointer-events: none;
+[part='label'] {
+    display: inline-flex;
+    align-items: center;
+    padding-inline: pad-inline(rem(2px), rem(4px), rem(8px));
+
+    ::slotted(a){
+        padding-inline: pad-inline(rem(2px), rem(4px), rem(8px));
+        font-size: sizable(var(--ig-detail-1-font-size), var(--ig-body-2-font-size), var(--ig-body-1-font-size));
+        font-weight: sizable(var(--ig-detail-1-font-weight), var(--ig-body-2-font-weight), var(--ig-body-1-font-weight));
+        line-height: sizable(var(--ig-detail-1-line-height), var(--ig-body-2-line-height), var(--ig-body-1-line-height));
+        letter-spacing: sizable(var(--ig-detail-1-letter-spacing), var(--ig-body-2-letter-spacing), var(--ig-body-1-letter-spacing));
+        text-transform: sizable(var(--ig-detail-1-text-transform), var(--ig-body-2-text-transform), var(--ig-body-1-text-transform));
+    }
+
+    ::slotted([slot='prefix']),
+    ::slotted([slot='suffix']) {
+        --component-size: var(--ig-size, var(--ig-size-medium));
+        
+        font-size: sizable(rem(14px), rem(16px), rem(24px));
     }
 }
 

--- a/src/components/breadcrumb/themes/breadcrumbs.base.scss
+++ b/src/components/breadcrumb/themes/breadcrumbs.base.scss
@@ -2,10 +2,10 @@
 @use 'styles/utilities' as *;
 
 :host {
-    --_gap: var(--ig-breadcrumbs-gap, 0.5rem);
+    --component-size: var(--ig-size, var(--ig-size-medium));
 
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: var(--_gap);
+    row-gap: rem(4px);
 }

--- a/src/components/breadcrumb/themes/dark/_themes.scss
+++ b/src/components/breadcrumb/themes/dark/_themes.scss
@@ -1,0 +1,8 @@
+@use 'styles/utilities' as *;
+@use 'igniteui-theming/sass/themes/schemas/components/dark/breadcrumb' as *;
+
+$base: digest-schema($dark-base-breadcrumb);
+$material: digest-schema($dark-material-breadcrumb);
+$bootstrap: digest-schema($dark-bootstrap-breadcrumb);
+$fluent: digest-schema($dark-fluent-breadcrumb);
+$indigo: digest-schema($dark-indigo-breadcrumb);

--- a/src/components/breadcrumb/themes/dark/breadcrumb.bootstrap.scss
+++ b/src/components/breadcrumb/themes/dark/breadcrumb.bootstrap.scss
@@ -1,0 +1,9 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+@use '../light/themes' as light;
+
+$theme: $bootstrap;
+
+:host {
+    @include css-vars-from-theme(diff(light.$base, $theme));
+}

--- a/src/components/breadcrumb/themes/dark/breadcrumb.fluent.scss
+++ b/src/components/breadcrumb/themes/dark/breadcrumb.fluent.scss
@@ -1,0 +1,9 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+@use '../light/themes' as light;
+
+$theme: $fluent;
+
+:host {
+    @include css-vars-from-theme(diff(light.$base, $theme));
+}

--- a/src/components/breadcrumb/themes/dark/breadcrumb.indigo.scss
+++ b/src/components/breadcrumb/themes/dark/breadcrumb.indigo.scss
@@ -1,0 +1,9 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+@use '../light/themes' as light;
+
+$theme: $indigo;
+
+:host {
+    @include css-vars-from-theme(diff(light.$base, $theme));
+}

--- a/src/components/breadcrumb/themes/dark/breadcrumb.material.scss
+++ b/src/components/breadcrumb/themes/dark/breadcrumb.material.scss
@@ -1,0 +1,9 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+@use '../light/themes' as light;
+
+$theme: $material;
+
+:host {
+    @include css-vars-from-theme(diff(light.$base, $theme));
+}

--- a/src/components/breadcrumb/themes/light/_themes.scss
+++ b/src/components/breadcrumb/themes/light/_themes.scss
@@ -1,0 +1,8 @@
+@use 'styles/utilities' as *;
+@use 'igniteui-theming/sass/themes/schemas/components/light/breadcrumb' as *;
+
+$base: digest-schema($light-breadcrumb);
+$material: digest-schema($material-breadcrumb);
+$bootstrap: digest-schema($bootstrap-breadcrumb);
+$fluent: digest-schema($fluent-breadcrumb);
+$indigo: digest-schema($indigo-breadcrumb);

--- a/src/components/breadcrumb/themes/light/breadcrumb.bootstrap.scss
+++ b/src/components/breadcrumb/themes/light/breadcrumb.bootstrap.scss
@@ -1,0 +1,8 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+
+$theme: $bootstrap;
+
+:host {
+    @include css-vars-from-theme(diff($base, $theme));
+}

--- a/src/components/breadcrumb/themes/light/breadcrumb.fluent.scss
+++ b/src/components/breadcrumb/themes/light/breadcrumb.fluent.scss
@@ -1,0 +1,8 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+
+$theme: $fluent;
+
+:host {
+    @include css-vars-from-theme(diff($base, $theme));
+}

--- a/src/components/breadcrumb/themes/light/breadcrumb.indigo.scss
+++ b/src/components/breadcrumb/themes/light/breadcrumb.indigo.scss
@@ -1,0 +1,8 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+
+$theme: $indigo;
+
+:host {
+    @include css-vars-from-theme(diff($base, $theme));
+}

--- a/src/components/breadcrumb/themes/light/breadcrumb.material.scss
+++ b/src/components/breadcrumb/themes/light/breadcrumb.material.scss
@@ -1,0 +1,8 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+
+$theme: $material;
+
+:host {
+    @include css-vars-from-theme(diff($base, $theme));
+}

--- a/src/components/breadcrumb/themes/light/breadcrumb.shared.scss
+++ b/src/components/breadcrumb/themes/light/breadcrumb.shared.scss
@@ -1,0 +1,6 @@
+@use 'styles/utilities' as *;
+@use 'themes' as *;
+
+:host {
+    @include css-vars-from-theme($base);
+}

--- a/src/components/breadcrumb/themes/shared/breadcrumb.bootstrap.scss
+++ b/src/components/breadcrumb/themes/shared/breadcrumb.bootstrap.scss
@@ -1,0 +1,11 @@
+@use 'styles/utilities' as *;
+@use '../light/themes' as *;
+
+$theme: $bootstrap;
+
+:host(:not([current])) {
+    [part~='label']:focus-within {
+        outline: rem(4px) solid var-get($theme, 'focus-border-color');
+        border-radius: rem(4px);
+    }
+}

--- a/src/components/breadcrumb/themes/shared/breadcrumb.common.scss
+++ b/src/components/breadcrumb/themes/shared/breadcrumb.common.scss
@@ -1,0 +1,98 @@
+@use 'styles/utilities' as *;
+@use '../light/themes' as *;
+
+$theme: $material;
+
+:host(:not([current], [disabled])) {
+    ::slotted(a){
+        color: var-get($theme, 'text-color');
+    }
+
+    ::slotted([slot='suffix']),
+    ::slotted([slot='prefix']) {
+        color: var-get($theme, 'icon-color');
+    }
+
+    [part~='label']:hover {
+        ::slotted(a){
+            color: var-get($theme, 'hover-text-color');
+        }
+
+        ::slotted([slot='suffix']),
+        ::slotted([slot='prefix']) {
+            color: var-get($theme, 'hover-icon-color');
+        } 
+    }
+
+    [part~='label']:focus-within {
+        ::slotted(a){
+            color: var-get($theme, 'focus-text-color');
+        }
+
+        ::slotted([slot='prefix']),
+        ::slotted([slot='suffix']) {
+            color: var-get($theme, 'focus-icon-color');
+        }
+    }
+
+    [part~='label']:active {
+        ::slotted(a){
+            color: var-get($theme, 'pressed-text-color');
+        }
+
+        ::slotted([slot='prefix']),
+        ::slotted([slot='suffix']) {
+            color: var-get($theme, 'pressed-icon-color');
+        }
+    }
+
+    [part~='label']:focus-within:hover {
+        ::slotted(a){
+            color: var-get($theme, 'focus-hover-text-color');
+        }
+
+        ::slotted([slot='prefix']),
+        ::slotted([slot='suffix']) {
+            color: var-get($theme, 'focus-hover-icon-color');
+        }
+    }
+
+    [part~='label']:focus-within:active {
+        ::slotted(a){
+            color: var-get($theme, 'focus-pressed-text-color');
+        }
+
+        ::slotted([slot='prefix']),
+        ::slotted([slot='suffix']) {
+            color: var-get($theme, 'focus-pressed-icon-color');
+        }
+    }
+}
+
+:host([current]) {
+    ::slotted(a) {
+        color: var-get($theme, 'current-text-color');
+        pointer-events: none;
+    }
+
+    ::slotted([slot='suffix']),
+    ::slotted([slot='prefix']) {
+        color: var-get($theme, 'current-icon-color');
+    }
+}
+
+:host([disabled]) {
+    ::slotted(a) {
+        color: var-get($theme, 'disabled-text-color');
+        pointer-events: none;
+    }
+
+    ::slotted([slot='suffix']),
+    ::slotted([slot='prefix']) {
+        color: var-get($theme, 'disabled-icon-color');
+    }
+}
+
+[part='separator'] {
+    color: var(--ig-breadcrumb-separator-color, var(--ig-gray-500));
+}

--- a/src/components/breadcrumb/themes/shared/breadcrumb.fluent.scss
+++ b/src/components/breadcrumb/themes/shared/breadcrumb.fluent.scss
@@ -1,0 +1,10 @@
+@use 'styles/utilities' as *;
+@use '../light/themes' as *;
+
+$theme: $fluent;
+
+:host(:not([current])) {
+    [part~='label']:focus-within {
+        outline: rem(1px) solid var-get($theme, 'focus-border-color');
+    }
+}

--- a/src/components/breadcrumb/themes/shared/breadcrumb.indigo.scss
+++ b/src/components/breadcrumb/themes/shared/breadcrumb.indigo.scss
@@ -1,0 +1,11 @@
+@use 'styles/utilities' as *;
+@use '../light/themes' as *;
+
+$theme: $indigo;
+
+:host(:not([current])) {
+    [part~='label']:focus-within {
+        outline: rem(3px) solid var-get($theme, 'focus-border-color');
+        border-radius: rem(32px);
+    }
+}

--- a/src/components/breadcrumb/themes/shared/breadcrumb.material.scss
+++ b/src/components/breadcrumb/themes/shared/breadcrumb.material.scss
@@ -1,0 +1,24 @@
+@use 'styles/utilities' as *;
+@use '../light/themes' as *;
+
+$theme: $material;
+
+:host(:not([current])) {
+    [part~='label']:focus-within {
+        ::slotted(a){
+            text-decoration: underline var-get($theme, 'focus-underline-color');
+        }
+    }
+
+    [part~='label']:focus-within:hover {
+        ::slotted(a){
+            text-decoration: underline var-get($theme, 'focus-hover-underline-color');
+        }
+    }
+
+    [part~='label']:focus-within:active {
+        ::slotted(a){
+            text-decoration: underline var-get($theme, 'focus-pressed-underline-color');
+        }
+    }
+}

--- a/src/components/breadcrumb/themes/themes.ts
+++ b/src/components/breadcrumb/themes/themes.ts
@@ -1,6 +1,57 @@
-import type { Themes } from '../../../theming/types.js';
+import { css } from 'lit';
 
-export const all: Themes = {
-  light: {},
-  dark: {},
+import type { Themes } from '../../../theming/types.js';
+// Dark Overrides
+import { styles as bootstrapDark } from './dark/breadcrumb.bootstrap.css.js';
+import { styles as fluentDark } from './dark/breadcrumb.fluent.css.js';
+import { styles as indigoDark } from './dark/breadcrumb.indigo.css.js';
+import { styles as materialDark } from './dark/breadcrumb.material.css.js';
+// Light Overrides
+import { styles as bootstrapLight } from './light/breadcrumb.bootstrap.css.js';
+import { styles as fluentLight } from './light/breadcrumb.fluent.css.js';
+import { styles as indigoLight } from './light/breadcrumb.indigo.css.js';
+import { styles as materialLight } from './light/breadcrumb.material.css.js';
+import { styles as shared } from './light/breadcrumb.shared.css.js';
+// Shared Styles
+import { styles as bootstrap } from './shared/breadcrumb.bootstrap.css.js';
+import { styles as fluent } from './shared/breadcrumb.fluent.css.js';
+import { styles as indigo } from './shared/breadcrumb.indigo.css.js';
+import { styles as material } from './shared/breadcrumb.material.css.js';
+
+const light = {
+  shared: css`
+    ${shared}
+  `,
+  bootstrap: css`
+    ${bootstrap} ${bootstrapLight}
+  `,
+  material: css`
+    ${material} ${materialLight}
+  `,
+  fluent: css`
+    ${fluent} ${fluentLight}
+  `,
+  indigo: css`
+    ${indigo} ${indigoLight}
+  `,
 };
+
+const dark = {
+  shared: css`
+    ${shared}
+  `,
+  bootstrap: css`
+    ${bootstrap} ${bootstrapDark}
+  `,
+  material: css`
+    ${material} ${materialDark}
+  `,
+  fluent: css`
+    ${fluent} ${fluentDark}
+  `,
+  indigo: css`
+    ${indigo} ${indigoDark}
+  `,
+};
+
+export const all: Themes = { light, dark };

--- a/stories/breadcrumbs.stories.ts
+++ b/stories/breadcrumbs.stories.ts
@@ -2,12 +2,21 @@ import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import {
   IgcBreadcrumbComponent,
   IgcBreadcrumbsComponent,
+  IgcIconComponent,
+  registerIconFromText,
   defineComponents,
 } from 'igniteui-webcomponents';
 import { html } from 'lit';
 
-defineComponents(IgcBreadcrumbsComponent);
-
+defineComponents(IgcBreadcrumbsComponent, IgcIconComponent);
+registerIconFromText(
+  'biking',
+  '<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="biking" class="svg-inline--fa fa-biking fa-w-20" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M400 96a48 48 0 1 0-48-48 48 48 0 0 0 48 48zm-4 121a31.9 31.9 0 0 0 20 7h64a32 32 0 0 0 0-64h-52.78L356 103a31.94 31.94 0 0 0-40.81.68l-112 96a32 32 0 0 0 3.08 50.92L288 305.12V416a32 32 0 0 0 64 0V288a32 32 0 0 0-14.25-26.62l-41.36-27.57 58.25-49.92zm116 39a128 128 0 1 0 128 128 128 128 0 0 0-128-128zm0 192a64 64 0 1 1 64-64 64 64 0 0 1-64 64zM128 256a128 128 0 1 0 128 128 128 128 0 0 0-128-128zm0 192a64 64 0 1 1 64-64 64 64 0 0 1-64 64z"/></svg>'
+);
+registerIconFromText(
+  'notification',
+  '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"> <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path> <path d="M13.73 21a2 2 0 0 1-3.46 0"></path> </svg>'
+);
 // region default
 const metadata: Meta<IgcBreadcrumbsComponent> = {
   title: 'Breadcrumbs',
@@ -136,7 +145,7 @@ export const WithPrefixAndSuffix: Story = {
     },
   },
   render: () => html`
-    <nav aria-label="Breadcrumb">
+    <nav aria-label="Breadcrumb with Emojis">
       <igc-breadcrumbs>
         <igc-breadcrumb>
           <span slot="prefix">🏠</span>
@@ -148,9 +157,30 @@ export const WithPrefixAndSuffix: Story = {
           <span slot="separator">/</span>
         </igc-breadcrumb>
         <igc-breadcrumb current>
-          <span slot="prefix">💻</span>
           <a href="#">Laptop</a>
           <span slot="separator">/</span>
+          <span slot="suffix">💻</span>
+        </igc-breadcrumb>
+      </igc-breadcrumbs>
+    </nav>
+    <br />
+    <nav aria-label="Breadcrumb with Icons">
+      <igc-breadcrumbs>
+        <igc-breadcrumb>
+          <igc-icon slot="prefix" name="biking"></igc-icon>
+          <a href="#">Home</a>
+          <span slot="separator">/</span>
+          <igc-icon slot="suffix" name="biking"></igc-icon>
+        </igc-breadcrumb>
+        <igc-breadcrumb current>
+          <a href="#">Products</a>
+          <span slot="separator">/</span>
+        </igc-breadcrumb>
+        <igc-breadcrumb disabled>
+          <igc-icon slot="prefix" name="notification"></igc-icon>
+          <a href="#">Messages</a>
+          <span slot="separator">/</span>
+          <igc-icon slot="suffix" name="notification"></igc-icon>
         </igc-breadcrumb>
       </igc-breadcrumbs>
     </nav>


### PR DESCRIPTION
## Description

Adding styles for the new Breadcrumbs component.

Needs to be tested together with this theming PR: [601](https://github.com/IgniteUI/igniteui-theming/pull/601)

Handoff: https://www.figma.com/design/B6BpAtRGepZS0t3bCExofc/Breadcrumbs-Handoff

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
