### PR TITLE
feat(calendar, date-picker, date-range-picker): derive week start and header order from locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - #### Calendar, Date picker, Date range picker
   - When `week-start` is not set, the week starts on the first day of the week of the `locale`, as reported by `Intl.Locale.prototype.getWeekInfo()`. For example, `bg` starts on Monday and `en` stays on Sunday. An explicit `week-start` has priority. Set `weekStart` to `undefined` to return to the locale value. Browsers without `getWeekInfo()` keep the Sunday default. [#1020](https://github.com/IgniteUI/igniteui-webcomponents/issues/1020)
-  - The header date and the month/year navigation follow the field order of the `locale`. The header renders the weekday, month and day with one `Intl.DateTimeFormat` call. For `ja`, the header shows `7月15日(火)`, and the year button precedes the month button and shows `2025年`. The years view keeps plain numbers. In vertical header orientation, the weekday line has no trailing comma. [#1712](https://github.com/IgniteUI/igniteui-webcomponents/issues/1712)
+  - The header date and the month/year navigation follow the field order of the `locale`. For `ja`, the header shows `7月15日(火)`, and the year button precedes the month button and shows `2025年`. The years view keeps plain numbers. In vertical header orientation, the weekday line has no trailing comma. [#1712](https://github.com/IgniteUI/igniteui-webcomponents/issues/1712)
 
 ## [7.3.1] - 2026-09-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,46 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
-## [7.3.1] - 2026-09-01
-### Added
-- #### Color picker
-  - `IgcColorPickerComponentEventMap` is now exported from the package entry point. [#2360](https://github.com/IgniteUI/igniteui-webcomponents/pull/2360)
-
 ### Changed
-- #### Avatar
-  - The component now exposes `role="img"`. Before, it declared `image`, which is an ARIA 1.3 token that current tools do not know. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
-  - The accessible name now comes from `alt`, and then from `initials`. The role description is the static string `avatar`. Before, the two were inverted: the name was always the literal "avatar", and `alt` or `initials` became the role description.
-- #### Badge
-  - The role description is the static string `badge`. The visual `variant` no longer reaches assistive technology. `role="status"` is unchanged. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
-  - The `icon` CSS part now applies only when an `igc-icon` is the only content of the badge, as the documentation already stated.
-- #### Chip
-  - **Breaking for custom styles:** `part="base"` is now a plain wrapper. The selection control moved to the new `action` part, and the remove control to the new `remove` part. Move rules that target `::part(base)` for the interactive surface to `::part(action)`. [#2362](https://github.com/IgniteUI/igniteui-webcomponents/pull/2362)
-  - `igcRemove` is typed `CustomEvent<void>`. The type declared a boolean detail that the event never carried.
-  - The `start` and `end` slots, and the `action` and `remove` parts, are documented. Thus they reach the custom elements manifest.
-- #### Tile manager
-  - `igc-tile` renders its resize handles directly. Before, an internal element rendered them and exported the parts. The `trigger-side`, `trigger` and `trigger-bottom` parts keep their names, and the new `tile-container` part wraps the tile content together with the handles. [#2359](https://github.com/IgniteUI/igniteui-webcomponents/pull/2359)
-
-### Fixed
-- #### Avatar
-  - The `<img>` element carried no `alt` attribute when you set no alt text. This is an `image-alt` violation in the page of the consumer. The component now renders `alt=""`, thus the image counts as decorative. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
-  - Removed the documented `icon` CSS part. The component never rendered it.
-- #### Badge
-  - A badge that holds an `igc-icon` together with text lost its inline padding and clipped the text under `overflow: hidden`. The `icon` part became active for any slotted icon, but the padding rule matched `[part='base']` exactly and thus did not apply. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
-- #### Chip
-  - A removable chip failed the `nested-interactive` accessibility audit. The chip rendered its full surface as a button, and the remove icon inside it declared `role="button"` and `tabindex="0"`. The two controls are now siblings. [#2362](https://github.com/IgniteUI/igniteui-webcomponents/pull/2362)
-  - The accessible name of the chip read "Chip remove chip" or "select chip Chip", because the labels of the remove icon and of the selection icon became part of it. The name is now the content of the chip.
-  - `Space` did not toggle the selection, and `igcRemove` fired on chips that are not removable. The remove keybindings applied to the host and cancelled the activation keys of the chip. They now apply to the remove control only.
-  - Focus on the remove control now also shows the focus state of the chip.
-  - The prefix wrapper hides only when the chip is selectable and selected, and the suffix wrapper no longer hides because of `removable`.
-- #### Color picker
-  - The picker canvas did not respond to touch input. [#2357](https://github.com/IgniteUI/igniteui-webcomponents/pull/2357)
-- #### Textarea
-  - A change of `resize` away from `auto` did not release the inline height. Thus the control stayed at its last automatic height. [#2361](https://github.com/IgniteUI/igniteui-webcomponents/pull/2361)
-  - Text that you project into the default slot now becomes the default value, as with a native `<textarea>`. Before, it became the value. Thus the control was not pristine, and a form reset cleared the visible text while the light DOM still held it.
-- #### Tile manager
-  - A swap of two positioned tiles wrote a column value into `rowStart`. Thus the tiles moved to the wrong row. [#2359](https://github.com/IgniteUI/igniteui-webcomponents/pull/2359)
-  - A tile that you add next to a single positioned tile collided with it at position 0.
+- #### Calendar, Date picker, Date range picker
+  - When `week-start` is not set, the week starts on the first day of the week of the `locale`, as reported by `Intl.Locale.prototype.getWeekInfo()`. For example, `bg` starts on Monday and `en` stays on Sunday. An explicit `week-start` has priority. Set `weekStart` to `undefined` to return to the locale value. Browsers without `getWeekInfo()` keep the Sunday default. [#1020](https://github.com/IgniteUI/igniteui-webcomponents/issues/1020)
+  - The header date and the month/year navigation follow the field order of the `locale`. The header renders the weekday, month and day with one `Intl.DateTimeFormat` call. For `ja`, the header shows `7月15日(火)`, and the year button precedes the month button and shows `2025年`. The years view keeps plain numbers. In vertical header orientation, the weekday line has no trailing comma. [#1712](https://github.com/IgniteUI/igniteui-webcomponents/issues/1712)
 
 ## [7.3.0] - 2026-08-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - When `week-start` is not set, the week starts on the first day of the week of the `locale`, as reported by `Intl.Locale.prototype.getWeekInfo()`. For example, `bg` starts on Monday and `en` stays on Sunday. An explicit `week-start` has priority. Set `weekStart` to `undefined` to return to the locale value. Browsers without `getWeekInfo()` keep the Sunday default. [#1020](https://github.com/IgniteUI/igniteui-webcomponents/issues/1020)
   - The header date and the month/year navigation follow the field order of the `locale`. The header renders the weekday, month and day with one `Intl.DateTimeFormat` call. For `ja`, the header shows `7月15日(火)`, and the year button precedes the month button and shows `2025年`. The years view keeps plain numbers. In vertical header orientation, the weekday line has no trailing comma. [#1712](https://github.com/IgniteUI/igniteui-webcomponents/issues/1712)
 
+## [7.3.1] - 2026-09-01
+### Added
+- #### Color picker
+  - `IgcColorPickerComponentEventMap` is now exported from the package entry point. [#2360](https://github.com/IgniteUI/igniteui-webcomponents/pull/2360)
+
+### Changed
+- #### Avatar
+  - The component now exposes `role="img"`. Before, it declared `image`, which is an ARIA 1.3 token that current tools do not know. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
+  - The accessible name now comes from `alt`, and then from `initials`. The role description is the static string `avatar`. Before, the two were inverted: the name was always the literal "avatar", and `alt` or `initials` became the role description.
+- #### Badge
+  - The role description is the static string `badge`. The visual `variant` no longer reaches assistive technology. `role="status"` is unchanged. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
+  - The `icon` CSS part now applies only when an `igc-icon` is the only content of the badge, as the documentation already stated.
+- #### Chip
+  - **Breaking for custom styles:** `part="base"` is now a plain wrapper. The selection control moved to the new `action` part, and the remove control to the new `remove` part. Move rules that target `::part(base)` for the interactive surface to `::part(action)`. [#2362](https://github.com/IgniteUI/igniteui-webcomponents/pull/2362)
+  - `igcRemove` is typed `CustomEvent<void>`. The type declared a boolean detail that the event never carried.
+  - The `start` and `end` slots, and the `action` and `remove` parts, are documented. Thus they reach the custom elements manifest.
+- #### Tile manager
+  - `igc-tile` renders its resize handles directly. Before, an internal element rendered them and exported the parts. The `trigger-side`, `trigger` and `trigger-bottom` parts keep their names, and the new `tile-container` part wraps the tile content together with the handles. [#2359](https://github.com/IgniteUI/igniteui-webcomponents/pull/2359)
+
+### Fixed
+- #### Avatar
+  - The `<img>` element carried no `alt` attribute when you set no alt text. This is an `image-alt` violation in the page of the consumer. The component now renders `alt=""`, thus the image counts as decorative. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
+  - Removed the documented `icon` CSS part. The component never rendered it.
+- #### Badge
+  - A badge that holds an `igc-icon` together with text lost its inline padding and clipped the text under `overflow: hidden`. The `icon` part became active for any slotted icon, but the padding rule matched `[part='base']` exactly and thus did not apply. [#2363](https://github.com/IgniteUI/igniteui-webcomponents/pull/2363)
+- #### Chip
+  - A removable chip failed the `nested-interactive` accessibility audit. The chip rendered its full surface as a button, and the remove icon inside it declared `role="button"` and `tabindex="0"`. The two controls are now siblings. [#2362](https://github.com/IgniteUI/igniteui-webcomponents/pull/2362)
+  - The accessible name of the chip read "Chip remove chip" or "select chip Chip", because the labels of the remove icon and of the selection icon became part of it. The name is now the content of the chip.
+  - `Space` did not toggle the selection, and `igcRemove` fired on chips that are not removable. The remove keybindings applied to the host and cancelled the activation keys of the chip. They now apply to the remove control only.
+  - Focus on the remove control now also shows the focus state of the chip.
+  - The prefix wrapper hides only when the chip is selectable and selected, and the suffix wrapper no longer hides because of `removable`.
+- #### Color picker
+  - The picker canvas did not respond to touch input. [#2357](https://github.com/IgniteUI/igniteui-webcomponents/pull/2357)
+- #### Textarea
+  - A change of `resize` away from `auto` did not release the inline height. Thus the control stayed at its last automatic height. [#2361](https://github.com/IgniteUI/igniteui-webcomponents/pull/2361)
+  - Text that you project into the default slot now becomes the default value, as with a native `<textarea>`. Before, it became the value. Thus the control was not pristine, and a form reset cleared the visible text while the light DOM still held it.
+- #### Tile manager
+  - A swap of two positioned tiles wrote a column value into `rowStart`. Thus the tiles moved to the wrong row. [#2359](https://github.com/IgniteUI/igniteui-webcomponents/pull/2359)
+  - A tile that you add next to a single positioned tile collided with it at position 0.
+
 ## [7.3.0] - 2026-08-26
 ### Added
 - #### Calendar

--- a/src/components/calendar/base.ts
+++ b/src/components/calendar/base.ts
@@ -12,7 +12,7 @@ import type { IgcCalendarResourceStrings } from '#internals/i18n/EN/calendar.res
 import type { I18nControllerConfig } from '#internals/i18n/i18n-controller.js';
 import { I18nMixin } from '#internals/mixins/i18n.js';
 import { firstOf } from '#internals/utils/arrays.js';
-import { getWeekDayNumber } from './helpers.js';
+import { getLocaleWeekStart, getWeekDayNumber } from './helpers.js';
 import type {
   CalendarSelection,
   DateRangeDescriptor,
@@ -34,6 +34,7 @@ export class IgcCalendarBaseComponent extends I18nMixin<
   IgcCalendarResourceStrings & ICalendarResourceStrings
 >(LitElement, i18n) {
   private _initialActiveDateSet = false;
+  private _weekStart?: WeekDays;
 
   protected get _hasValues(): boolean {
     return this._values.length > 0;
@@ -144,11 +145,20 @@ export class IgcCalendarBaseComponent extends I18nMixin<
 
   /**
    * Gets/Sets the first day of the week.
+   *
+   * @remarks
+   * When not set, the week starts on the first day of the week of the current {@link locale}.
+   * Setting `undefined` returns to the locale value.
    * @attr week-start
-   * @default sunday
    */
   @property({ attribute: 'week-start' })
-  public weekStart: WeekDays = 'sunday';
+  public set weekStart(value: WeekDays | undefined) {
+    this._weekStart = value ?? undefined;
+  }
+
+  public get weekStart(): WeekDays {
+    return this._weekStart ?? getLocaleWeekStart(this.locale);
+  }
 
   /**
    * Gets/Sets the special dates for the component.

--- a/src/components/calendar/calendar-rendering.spec.ts
+++ b/src/components/calendar/calendar-rendering.spec.ts
@@ -574,6 +574,146 @@ describe('Calendar Rendering', () => {
       expect(lastWeekNumber.innerText).to.equal('1');
     });
   });
+
+  describe('Locale', () => {
+    // July 2025 starts on a Tuesday
+    const july = new CalendarDay({ year: 2025, month: 6, date: 15 });
+    const sunday = new CalendarDay({ year: 2025, month: 5, date: 29 });
+    const monday = new CalendarDay({ year: 2025, month: 5, date: 30 });
+    const saturday = new CalendarDay({ year: 2025, month: 5, date: 28 });
+
+    const daysViewDOM = () =>
+      getDayViewDOM(getCalendarDOM(calendar).views.days);
+    const firstDateValue = () =>
+      firstOf(daysViewDOM().dates.all).dataset.value!;
+    const firstLabel = () =>
+      firstOf(daysViewDOM().weekLabels).getAttribute('aria-label');
+
+    it('derives the week start from the locale when `week-start` is not set', async () => {
+      calendar = await createCalendarElement(
+        html`<igc-calendar
+          locale="bg"
+          .activeDate=${july.native}
+        ></igc-calendar>`
+      );
+
+      expect(calendar.weekStart).to.equal('monday');
+      expect(firstLabel()).to.equal('понеделник');
+      expect(firstDateValue()).to.equal(`${monday.timestamp}`);
+    });
+
+    it('re-aligns the days grid when the locale changes at runtime', async () => {
+      calendar = await createCalendarElement(
+        html`<igc-calendar .activeDate=${july.native}></igc-calendar>`
+      );
+
+      expect(calendar.weekStart).to.equal('sunday');
+      expect(firstDateValue()).to.equal(`${sunday.timestamp}`);
+
+      calendar.locale = 'de';
+      await elementUpdated(calendar);
+
+      expect(calendar.weekStart).to.equal('monday');
+      expect(firstDateValue()).to.equal(`${monday.timestamp}`);
+
+      calendar.locale = 'ar-EG';
+      await elementUpdated(calendar);
+
+      expect(calendar.weekStart).to.equal('saturday');
+      expect(firstLabel()).to.equal('السبت');
+      expect(firstDateValue()).to.equal(`${saturday.timestamp}`);
+    });
+
+    it('prefers an explicit `week-start` over the locale', async () => {
+      calendar = await createCalendarElement(
+        html`<igc-calendar
+          locale="bg"
+          week-start="sunday"
+          .activeDate=${july.native}
+        ></igc-calendar>`
+      );
+
+      expect(calendar.weekStart).to.equal('sunday');
+      expect(firstDateValue()).to.equal(`${sunday.timestamp}`);
+
+      // Returns to the locale value
+      calendar.weekStart = undefined;
+      await elementUpdated(calendar);
+
+      expect(calendar.weekStart).to.equal('monday');
+      expect(firstDateValue()).to.equal(`${monday.timestamp}`);
+    });
+
+    it('falls back to sunday in engines without `Intl.Locale.prototype.getWeekInfo()`', async () => {
+      const prototype = Intl.Locale.prototype as unknown as Record<
+        string,
+        unknown
+      >;
+      const getWeekInfo = prototype.getWeekInfo;
+
+      Reflect.deleteProperty(prototype, 'getWeekInfo');
+
+      try {
+        calendar = await createCalendarElement(
+          html`<igc-calendar locale="bg"></igc-calendar>`
+        );
+        expect(calendar.weekStart).to.equal('sunday');
+      } finally {
+        prototype.getWeekInfo = getWeekInfo;
+      }
+    });
+
+    it('renders the header date in the field order of the locale', async () => {
+      calendar = await createCalendarElement(
+        html`<igc-calendar locale="ja" .value=${july.native}></igc-calendar>`
+      );
+      const dom = getCalendarDOM(calendar);
+      const lines = () =>
+        Array.from(dom.header.date.querySelector('slot')!.childNodes)
+          .filter((node) => node.nodeType === Node.TEXT_NODE)
+          .map((node) => node.textContent!.trim())
+          .filter(Boolean);
+
+      expect(dom.header.date.textContent!.trim()).to.equal('7月15日(火)');
+
+      // The month/day line precedes the weekday line
+      calendar.headerOrientation = 'vertical';
+      await elementUpdated(calendar);
+
+      expect(dom.header.date.querySelector('br')).to.exist;
+      expect(lines()).to.eql(['7月15日', '火']);
+
+      calendar.locale = 'en';
+      await elementUpdated(calendar);
+
+      expect(lines()).to.eql(['Tue', 'Jul 15']);
+    });
+
+    it('orders the month and year navigation buttons per locale', async () => {
+      calendar = await createCalendarElement(
+        html`<igc-calendar
+          locale="ja"
+          .activeDate=${july.native}
+        ></igc-calendar>`
+      );
+      const dom = getCalendarDOM(calendar);
+      const pickers = () =>
+        Array.from(dom.navigation.months.parentElement!.children).map(
+          (element) => element.getAttribute('part')
+        );
+
+      expect(pickers()).to.eql(['years-navigation', 'months-navigation']);
+      expect(dom.navigation.months.textContent!.trim()).to.equal('7月');
+      expect(dom.navigation.years.textContent!.trim()).to.equal('2025年');
+
+      calendar.locale = 'en';
+      await elementUpdated(calendar);
+
+      expect(pickers()).to.eql(['months-navigation', 'years-navigation']);
+      expect(dom.navigation.months.textContent!.trim()).to.equal('July');
+      expect(dom.navigation.years.textContent!.trim()).to.equal('2025');
+    });
+  });
 });
 
 function createCalendarElement(template?: TemplateResult) {

--- a/src/components/calendar/calendar-rendering.spec.ts
+++ b/src/components/calendar/calendar-rendering.spec.ts
@@ -645,13 +645,13 @@ describe('Calendar Rendering', () => {
     });
 
     it('falls back to sunday in engines without `Intl.Locale.prototype.getWeekInfo()`', async () => {
-      const prototype = Intl.Locale.prototype as unknown as Record<
-        string,
-        unknown
-      >;
-      const getWeekInfo = prototype.getWeekInfo;
+      const prototype = Intl.Locale.prototype;
+      const descriptor = Object.getOwnPropertyDescriptor(
+        prototype,
+        'getWeekInfo'
+      );
 
-      Reflect.deleteProperty(prototype, 'getWeekInfo');
+      expect(Reflect.deleteProperty(prototype, 'getWeekInfo')).to.be.true;
 
       try {
         calendar = await createCalendarElement(
@@ -659,7 +659,9 @@ describe('Calendar Rendering', () => {
         );
         expect(calendar.weekStart).to.equal('sunday');
       } finally {
-        prototype.getWeekInfo = getWeekInfo;
+        if (descriptor) {
+          Object.defineProperty(prototype, 'getWeekInfo', descriptor);
+        }
       }
     });
 

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -33,6 +33,7 @@ import {
   areSameMonth,
   getYearRange,
   isDateInRanges,
+  isDatePartBefore,
   MONTHS_PER_ROW,
   YEARS_PER_PAGE,
   YEARS_PER_ROW,
@@ -618,11 +619,19 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
     `;
   }
 
+  /** The year with the unit of the locale - `2025年` for `ja`, `2025 г.` for `bg`. */
+  protected _formatYear(day: CalendarDay): string {
+    return getDateFormatter().formatDateTime(day.native, this.locale, {
+      year: 'numeric',
+    });
+  }
+
   protected _renderYearButtonNavigation(
     active: CalendarDay,
     viewIndex: number
   ): TemplateResult {
-    const ariaLabel = `${active.year}, ${this.resourceStrings.calendar_select_year}`;
+    const year = this._formatYear(active);
+    const ariaLabel = `${year}, ${this.resourceStrings.calendar_select_year}`;
 
     return html`
       <button
@@ -630,7 +639,7 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
         aria-label=${ariaLabel}
         @click=${() => this._navigateToYearView(viewIndex)}
       >
-        ${active.year}
+        ${year}
       </button>
     `;
   }
@@ -655,7 +664,7 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
 
     return html`
       <span class="aria-off-screen" aria-live="polite">
-        ${this._isDayView ? format(this._activeDate.native) : this._activeDate.year}
+        ${this._isDayView ? format(this._activeDate.native) : this._formatYear(this._activeDate)}
       </span>
     `;
   }
@@ -666,6 +675,24 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
     return html`
       <span part="years-range" aria-live="polite"> ${start} - ${end} </span>
     `;
+  }
+
+  /** Renders the month and year buttons of the days view in the field order of the locale. */
+  protected _renderDayViewNavigation(
+    active: CalendarDay,
+    viewIndex: number
+  ): TemplateResult[] {
+    const parts = getDateFormatter().formatDateTimeToParts(
+      active.native,
+      this.locale,
+      { year: 'numeric', month: this.formatOptions.month }
+    );
+    const yearFirst = isDatePartBefore(parts, 'year', 'month');
+
+    const month = this._renderMonthButtonNavigation(active, viewIndex);
+    const year = this._renderYearButtonNavigation(active, viewIndex);
+
+    return yearFirst ? [year, month] : [month, year];
   }
 
   protected _renderNavigation(
@@ -680,11 +707,11 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
         <div part="picker-dates">
           ${
             this._isDayView
-              ? this._renderMonthButtonNavigation(activeDate, viewIndex)
+              ? this._renderDayViewNavigation(activeDate, viewIndex)
               : nothing
           }
           ${
-            this._isDayView || this._isMonthView
+            this._isMonthView
               ? this._renderYearButtonNavigation(activeDate, viewIndex)
               : nothing
           }
@@ -723,20 +750,34 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
 
   protected _renderHeaderDateSingle(): TemplateResult {
     const date = this.value ?? CalendarDay.today.native;
+    const { locale } = this;
     const formatter = getDateFormatter();
-    const weekday = formatter.formatDateTime(date, this.locale, {
-      weekday: 'short',
-    });
-    const monthDay = formatter.formatDateTime(date, this.locale, {
+    const weekdayOptions: Intl.DateTimeFormatOptions = { weekday: 'short' };
+    const dateOptions: Intl.DateTimeFormatOptions = {
       month: 'short',
       day: 'numeric',
+    };
+
+    if (this.headerOrientation !== 'vertical') {
+      const formatted = formatter.formatDateTime(date, locale, {
+        ...weekdayOptions,
+        ...dateOptions,
+      });
+      return html`<slot name="header-date">${formatted}</slot>`;
+    }
+
+    // The weekday and the month/day on separate lines, in the field order of the locale
+    const parts = formatter.formatDateTimeToParts(date, locale, {
+      ...weekdayOptions,
+      ...dateOptions,
     });
-    const separator =
-      this.headerOrientation === 'vertical' ? html`<br />` : ' ';
+    const weekday = formatter.formatDateTime(date, locale, weekdayOptions);
+    const monthDay = formatter.formatDateTime(date, locale, dateOptions);
+    const [first, second] = isDatePartBefore(parts, 'weekday', 'month')
+      ? [weekday, monthDay]
+      : [monthDay, weekday];
 
-    const formatted = html`${weekday},${separator}${monthDay}`;
-
-    return html`<slot name="header-date">${formatted}</slot>`;
+    return html`<slot name="header-date">${first}<br />${second}</slot>`;
   }
 
   protected _renderHeaderDateRange(): TemplateResult {
@@ -777,6 +818,7 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
     const length = activeDates.length - 1;
     const format = this.formatOptions
       .weekday as Intl.DateTimeFormatOptions['weekday'];
+    const weekStart = this.weekStart;
 
     return html`${activeDates.map(
       (date, idx) => html`
@@ -806,7 +848,7 @@ export default class IgcCalendarComponent extends EventEmitterMixin<
             .value=${this.value}
             .values=${this.values}
             .weekDayFormat=${format!}
-            .weekStart=${this.weekStart}
+            .weekStart=${weekStart}
           ></igc-days-view>
         </div>
       `

--- a/src/components/calendar/days-view/days-view.ts
+++ b/src/components/calendar/days-view/days-view.ts
@@ -1,6 +1,6 @@
 import { getDateFormatter, getDisplayNamesFormatter } from 'igniteui-i18n-core';
-import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { property, query } from 'lit/decorators.js';
 import { addInternalsController } from '#internals/controllers/internals.js';
 import { addKeybindings } from '#internals/controllers/key-bindings.js';
 import { CalendarDay, DAYS_IN_WEEK } from '#internals/date/model.js';
@@ -113,9 +113,6 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
 
   //#region Internal properties and state
 
-  @state()
-  private _dates: CalendarDay[] = [];
-
   @query('[tabindex="0"]')
   private _activeDay?: HTMLElement;
 
@@ -194,17 +191,6 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
     addThemingController(this, all);
     addKeybindings(this).setActivateHandler(this._handleInteraction);
     addSafeEventListener(this, 'click', this._handleInteraction);
-  }
-
-  /** @internal */
-  protected override update(props: PropertyValues): void {
-    if (props.has('_activeDate') || props.has('weekStart')) {
-      this._dates = Array.from(
-        generateMonth(this._activeDate, this._firstDayOfWeek)
-      );
-    }
-
-    super.update(props);
   }
 
   //#endregion
@@ -467,7 +453,7 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
     `;
   }
 
-  protected _renderHeaders() {
+  protected _renderHeaders(dates: CalendarDay[]) {
     const label = getDateFormatter().getIntlFormatter(this.locale, {
       weekday: this.weekDayFormat,
     });
@@ -480,7 +466,7 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
       : nothing;
 
     // The first week of the grid, so that the labels cannot disagree with it
-    const headers = this._dates.slice(0, DAYS_IN_WEEK).map(
+    const headers = dates.slice(0, DAYS_IN_WEEK).map(
       (day) => html`
         <span
           role="columnheader"
@@ -497,9 +483,9 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
     `;
   }
 
-  protected *_renderWeeks(): Generator<TemplateResult> {
+  protected *_renderWeeks(dates: CalendarDay[]): Generator<TemplateResult> {
     const context = this._createRenderContext();
-    const weeks = Array.from(chunk(this._dates, DAYS_IN_WEEK));
+    const weeks = Array.from(chunk(dates, DAYS_IN_WEEK));
     const lastIndex = weeks.length - 1;
 
     for (const [idx, week] of weeks.entries()) {
@@ -525,7 +511,12 @@ export default class IgcDaysViewComponent extends EventEmitterMixin<
   }
 
   protected override render() {
-    return html`${this._renderHeaders()}${this._renderWeeks()}`;
+    // Derived per render - it depends on the active date, `weekStart` and the `locale`
+    const dates = Array.from(
+      generateMonth(this._activeDate, this._firstDayOfWeek)
+    );
+
+    return html`${this._renderHeaders(dates)}${this._renderWeeks(dates)}`;
   }
 }
 

--- a/src/components/calendar/helpers.ts
+++ b/src/components/calendar/helpers.ts
@@ -1,3 +1,4 @@
+import { getDateFormatter } from 'igniteui-i18n-core';
 import {
   CalendarDay,
   calendarRange,
@@ -30,6 +31,7 @@ const WEEK_DAYS_MAP = {
   friday: 5,
   saturday: 6,
 } as const;
+const WEEK_DAY_NAMES = Object.keys(WEEK_DAYS_MAP) as WeekDays[];
 
 /** The value of the activated day/month/year element of a calendar view, or -1. */
 export function getViewElement(event: Event): number {
@@ -39,6 +41,39 @@ export function getViewElement(event: Event): number {
 
 export function getWeekDayNumber(value: WeekDays): number {
   return WEEK_DAYS_MAP[value];
+}
+
+/**
+ * The first day of the week of `locale`, as reported by `Intl.Locale.prototype.getWeekInfo()`.
+ *
+ * @remarks
+ * igniteui-i18n-core falls back to Monday in engines without the API. This overrides
+ * that with `sunday`, the documented default of the components.
+ */
+export function getLocaleWeekStart(locale: string): WeekDays {
+  if (!('getWeekInfo' in Intl.Locale.prototype)) {
+    return 'sunday';
+  }
+
+  // igniteui-i18n-core numbers the days 1 (Monday) - 7 (Sunday)
+  return WEEK_DAY_NAMES[getDateFormatter().getFirstDayOfWeek(locale) % 7];
+}
+
+/**
+ * Whether the `first` field precedes the `second` one in the formatted `parts`.
+ * A missing field counts as last.
+ */
+export function isDatePartBefore(
+  parts: Intl.DateTimeFormatPart[],
+  first: Intl.DateTimeFormatPartTypes,
+  second: Intl.DateTimeFormatPartTypes
+): boolean {
+  const indexOf = (type: Intl.DateTimeFormatPartTypes) => {
+    const index = parts.findIndex((part) => part.type === type);
+    return index < 0 ? Number.POSITIVE_INFINITY : index;
+  };
+
+  return indexOf(first) < indexOf(second);
 }
 
 export function areSameMonth(

--- a/src/components/date-picker/date-picker.base.ts
+++ b/src/components/date-picker/date-picker.base.ts
@@ -27,7 +27,10 @@ import { bindIf } from '#internals/utils/lit.js';
 import { equal } from '#internals/utils/objects.js';
 import type { ThemingController } from '#theming/theming-controller.js';
 import IgcCalendarComponent, { focusActiveDate } from '../calendar/calendar.js';
-import { createDateConstraints } from '../calendar/helpers.js';
+import {
+  createDateConstraints,
+  getLocaleWeekStart,
+} from '../calendar/helpers.js';
 import type {
   CalendarHeaderOrientation,
   CalendarSelection,
@@ -117,6 +120,7 @@ export abstract class IgcDatePickerBaseComponent<
   protected _displayFormat?: string;
   protected _inputFormat?: string;
   protected _visibleMonths = 1;
+  private _weekStart?: WeekDays;
 
   protected override readonly _rootClickController = addRootClickController(
     this,
@@ -470,9 +474,22 @@ export abstract class IgcDatePickerBaseComponent<
   @property({ type: Boolean, reflect: true, attribute: 'show-week-numbers' })
   public showWeekNumbers = false;
 
-  /** Sets the start day of the week for the calendar. */
+  /**
+   * Sets the start day of the week for the calendar.
+   *
+   * @remarks
+   * When not set, the week starts on the first day of the week of the current {@link locale}.
+   * Setting `undefined` returns to the locale value.
+   * @attr week-start
+   */
   @property({ attribute: 'week-start' })
-  public weekStart: WeekDays = 'sunday';
+  public set weekStart(value: WeekDays | undefined) {
+    this._weekStart = value ?? undefined;
+  }
+
+  public get weekStart(): WeekDays {
+    return this._weekStart ?? getLocaleWeekStart(this.locale);
+  }
 
   //#endregion
 

--- a/src/components/date-picker/date-picker.spec.ts
+++ b/src/components/date-picker/date-picker.spec.ts
@@ -1189,4 +1189,25 @@ describe('Date picker', () => {
       });
     });
   });
+  describe('Locale week start', () => {
+    it('derives the calendar week start from the locale when `week-start` is not set', async () => {
+      picker = await fixture<IgcDatePickerComponent>(
+        html`<igc-date-picker locale="bg"></igc-date-picker>`
+      );
+      calendar = picker.renderRoot.querySelector(IgcCalendarComponent.tagName)!;
+
+      expect(picker.weekStart).to.equal('monday');
+      expect(calendar.weekStart).to.equal('monday');
+
+      picker.weekStart = 'friday';
+      await elementUpdated(picker);
+
+      expect(calendar.weekStart).to.equal('friday');
+
+      picker.weekStart = undefined;
+      await elementUpdated(picker);
+
+      expect(calendar.weekStart).to.equal('monday');
+    });
+  });
 });

--- a/src/components/date-range-picker/date-range-picker.common.spec.ts
+++ b/src/components/date-range-picker/date-range-picker.common.spec.ts
@@ -876,4 +876,25 @@ describe('Date range picker - common tests for single and two inputs mode', () =
       });
     });
   });
+  describe('Locale week start', () => {
+    it('derives the calendar week start from the locale when `week-start` is not set', async () => {
+      picker = await fixture<IgcDateRangePickerComponent>(
+        html`<igc-date-range-picker locale="bg"></igc-date-range-picker>`
+      );
+      calendar = picker.renderRoot.querySelector(IgcCalendarComponent.tagName)!;
+
+      expect(picker.weekStart).to.equal('monday');
+      expect(calendar.weekStart).to.equal('monday');
+
+      picker.weekStart = 'friday';
+      await elementUpdated(picker);
+
+      expect(calendar.weekStart).to.equal('friday');
+
+      picker.weekStart = undefined;
+      await elementUpdated(picker);
+
+      expect(calendar.weekStart).to.equal('monday');
+    });
+  });
 });

--- a/stories/calendar.stories.ts
+++ b/stories/calendar.stories.ts
@@ -123,7 +123,6 @@ const metadata: Meta<IgcCalendarComponent> = {
         'saturday',
       ],
       control: { type: 'select' },
-      table: { defaultValue: { summary: 'sunday' } },
     },
   },
   args: {
@@ -135,7 +134,6 @@ const metadata: Meta<IgcCalendarComponent> = {
     activeView: 'days',
     selection: 'single',
     showWeekNumbers: false,
-    weekStart: 'sunday',
   },
 };
 

--- a/stories/date-picker.stories.ts
+++ b/stories/date-picker.stories.ts
@@ -209,7 +209,6 @@ const metadata: Meta<IgcDatePickerComponent> = {
         'saturday',
       ],
       control: { type: 'select' },
-      table: { defaultValue: { summary: 'sunday' } },
     },
     keepOpenOnSelect: {
       type: 'boolean',
@@ -247,7 +246,6 @@ const metadata: Meta<IgcDatePickerComponent> = {
     hideHeader: false,
     hideOutsideDays: false,
     showWeekNumbers: false,
-    weekStart: 'sunday',
     keepOpenOnSelect: false,
     keepOpenOnOutsideClick: false,
     open: false,

--- a/stories/date-range-picker.stories.ts
+++ b/stories/date-range-picker.stories.ts
@@ -250,7 +250,6 @@ const metadata: Meta<IgcDateRangePickerComponent> = {
         'saturday',
       ],
       control: { type: 'select' },
-      table: { defaultValue: { summary: 'sunday' } },
     },
     keepOpenOnSelect: {
       type: 'boolean',
@@ -294,7 +293,6 @@ const metadata: Meta<IgcDateRangePickerComponent> = {
     hideHeader: false,
     hideOutsideDays: false,
     showWeekNumbers: false,
-    weekStart: 'sunday',
     keepOpenOnSelect: false,
     keepOpenOnOutsideClick: false,
     open: false,


### PR DESCRIPTION
## Description

- `weekStart` defaults to the first day of the week of the current `locale` (`Intl.Locale.prototype.getWeekInfo()`); an explicit value still wins and `undefined` returns to the locale value.
- The header date is formatted in one `Intl.DateTimeFormat` call and the month/year navigation buttons follow the field order of the locale (`7月15日(火)`, `2025年` then `7月` for `ja`). The years grid stays bare numbers.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Behavioral change (fix or feature that causes existing functionality to change)


## Related Issues

Closes #1020
Closes #1712

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
