### PR TITLE
feat(qr-code): add toBlob() and toImage() export methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- #### QR code
+  - `toBlob()` serializes the rendered code to an `image/svg+xml` blob. Theme colors become plain `fill` attributes and a logo that is not a data URI is fetched and inlined, so the output renders the same outside the component.
+  - `toImage(options)` exports the code as a `File` in `svg`, `png`, `jpeg` or `webp` format. The `scale` option multiplies the component `size`, thus a 256px code with `scale: 2` gives a 512x512 image. Set `download: true` to open the browser download dialog. The `QrCodeExportFormat` and `QrCodeExportOptions` types are exported from the package entry point.
+
 ### Changed
 - #### Calendar, Date picker, Date range picker
   - When `week-start` is not set, the week starts on the first day of the week of the `locale`, as reported by `Intl.Locale.prototype.getWeekInfo()`. For example, `bg` starts on Monday and `en` stays on Sunday. An explicit `week-start` has priority. Set `weekStart` to `undefined` to return to the locale value. Browsers without `getWeekInfo()` keep the Sunday default. [#1020](https://github.com/IgniteUI/igniteui-webcomponents/issues/1020)

--- a/src/components/qr-code/qr-code.spec.ts
+++ b/src/components/qr-code/qr-code.spec.ts
@@ -1,4 +1,5 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { restore, stub } from 'sinon';
 import { defineComponents } from '#internals/definitions/defineComponents.js';
 import { asNumber } from '#internals/utils/math.js';
 import { configureTheme } from '#theming/config.js';
@@ -597,6 +598,265 @@ describe('IgcQrCodeComponent', () => {
         await elementUpdated(el);
 
         expect(el.renderRoot.querySelector('image')).to.be.null;
+      });
+    });
+  });
+
+  describe('Export', () => {
+    const LOGO =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    let logoUrl: string | undefined;
+
+    /** Serves the logo through an object URL so the export has to fetch and inline it. */
+    function createLogoUrl(): string {
+      const bytes = Uint8Array.from(atob(LOGO.split(',')[1]), (c) =>
+        c.charCodeAt(0)
+      );
+      logoUrl = URL.createObjectURL(new Blob([bytes], { type: 'image/png' }));
+      return logoUrl;
+    }
+
+    async function parseSvg(blob: Blob): Promise<SVGSVGElement> {
+      const doc = new DOMParser().parseFromString(
+        await blob.text(),
+        'image/svg+xml'
+      );
+      return doc.documentElement as unknown as SVGSVGElement;
+    }
+
+    async function expectRejection(
+      promise: Promise<unknown>,
+      type: new (...args: never[]) => Error
+    ): Promise<void> {
+      let error: unknown;
+      try {
+        await promise;
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.be.instanceOf(type);
+    }
+
+    afterEach(() => {
+      restore();
+      if (logoUrl) {
+        URL.revokeObjectURL(logoUrl);
+        logoUrl = undefined;
+      }
+    });
+
+    describe('toBlob()', () => {
+      it('returns an SVG blob', async () => {
+        const el = await fixture<IgcQrCodeComponent>(
+          html`<igc-qr-code value="https://example.com"></igc-qr-code>`
+        );
+
+        const blob = await el.toBlob();
+        expect(blob.type).to.include('image/svg+xml');
+
+        const svg = await parseSvg(blob);
+        expect(svg.tagName).to.equal('svg');
+        expect(svg.getAttribute('width')).to.equal('128');
+        expect(svg.querySelector('title')?.textContent).to.include(
+          'https://example.com'
+        );
+      });
+
+      it('resolves theme colors to fill attributes and strips parts', async () => {
+        const el = await fixture<IgcQrCodeComponent>(
+          html`<igc-qr-code
+            value="https://example.com"
+            style="--ig-qr-code-dark-color: rgb(10, 20, 30); --ig-qr-code-background: rgb(200, 210, 220)"
+          ></igc-qr-code>`
+        );
+
+        const blob = await el.toBlob();
+        const markup = await blob.text();
+        expect(markup).not.to.include('part=');
+        expect(markup).not.to.include('var(');
+
+        const svg = await parseSvg(blob);
+        expect(svg.querySelector('rect')?.getAttribute('fill')).to.equal(
+          'rgb(200, 210, 220)'
+        );
+        expect(
+          svg.querySelectorAll('path[fill="rgb(10, 20, 30)"]').length
+        ).to.be.greaterThan(0);
+        for (const shape of svg.querySelectorAll('rect, path')) {
+          expect(shape.getAttribute('fill')).to.match(/^rgb/);
+        }
+      });
+
+      it('keeps a data URI logo as is', async () => {
+        const el = await fixture<IgcQrCodeComponent>(
+          html`<igc-qr-code
+            value="https://example.com"
+            logo-src=${LOGO}
+          ></igc-qr-code>`
+        );
+
+        const svg = await parseSvg(await el.toBlob());
+        expect(svg.querySelector('image')?.getAttribute('href')).to.equal(LOGO);
+        expect(svg.querySelector('mask')).to.exist;
+      });
+
+      it('inlines a fetched logo as a data URI', async () => {
+        const el = await fixture<IgcQrCodeComponent>(
+          html`<igc-qr-code
+            value="https://example.com"
+            logo-src=${createLogoUrl()}
+          ></igc-qr-code>`
+        );
+
+        const svg = await parseSvg(await el.toBlob());
+        const href = svg.querySelector('image')?.getAttribute('href');
+        expect(href).to.match(/^data:image\/png/);
+        expect(svg.querySelector('g')?.getAttribute('mask')).to.match(
+          /^url\(#/
+        );
+      });
+
+      it('drops the logo and its mask when the logo cannot be fetched', async () => {
+        const fetchStub = stub(window, 'fetch').rejects(new TypeError('CORS'));
+        const el = await fixture<IgcQrCodeComponent>(
+          html`<igc-qr-code
+            value="https://example.com"
+            logo-src=${createLogoUrl()}
+          ></igc-qr-code>`
+        );
+
+        const svg = await parseSvg(await el.toBlob());
+        expect(fetchStub.calledOnce).to.be.true;
+        expect(svg.querySelector('image')).to.be.null;
+        expect(svg.querySelector('mask')).to.be.null;
+        expect(svg.querySelector('[mask]')).to.be.null;
+      });
+
+      it('rejects when there is no value', async () => {
+        const el = await fixture<IgcQrCodeComponent>(
+          html`<igc-qr-code></igc-qr-code>`
+        );
+        await expectRejection(el.toBlob(), Error);
+      });
+    });
+
+    describe('toImage()', () => {
+      let el: IgcQrCodeComponent;
+
+      beforeEach(async () => {
+        el = await fixture(
+          html`<igc-qr-code
+            value="https://example.com"
+            size="256"
+          ></igc-qr-code>`
+        );
+      });
+
+      it('exports a PNG file at the component size by default', async () => {
+        const file = await el.toImage();
+        expect(file).to.be.instanceOf(File);
+        expect(file.name).to.equal('qr-code.png');
+        expect(file.type).to.equal('image/png');
+
+        const bitmap = await createImageBitmap(file);
+        expect(bitmap.width).to.equal(256);
+        expect(bitmap.height).to.equal(256);
+        bitmap.close();
+      });
+
+      it('scales the raster output', async () => {
+        const file = await el.toImage({ scale: 2 });
+        const bitmap = await createImageBitmap(file);
+        expect(bitmap.width).to.equal(512);
+        expect(bitmap.height).to.equal(512);
+        bitmap.close();
+      });
+
+      it('exports an opaque JPEG', async () => {
+        const file = await el.toImage({ format: 'jpeg', fileName: 'code' });
+        expect(file.name).to.equal('code.jpeg');
+        expect(file.type).to.equal('image/jpeg');
+
+        const bitmap = await createImageBitmap(file);
+        const canvas = document.createElement('canvas');
+        canvas.width = bitmap.width;
+        canvas.height = bitmap.height;
+        const context = canvas.getContext('2d')!;
+        context.drawImage(bitmap, 0, 0);
+        bitmap.close();
+
+        const [, , , alpha] = context.getImageData(0, 0, 1, 1).data;
+        expect(alpha).to.equal(255);
+      });
+
+      it('exports a WebP file', async () => {
+        const file = await el.toImage({ format: 'webp' });
+        expect(file.name).to.equal('qr-code.webp');
+        expect(file.type).to.equal('image/webp');
+      });
+
+      it('exports an SVG file with scaled dimensions', async () => {
+        const file = await el.toImage({ format: 'svg', scale: 2 });
+        expect(file.name).to.equal('qr-code.svg');
+        expect(file.type).to.equal('image/svg+xml');
+
+        const svg = await parseSvg(file);
+        expect(svg.getAttribute('width')).to.equal('512');
+        expect(svg.getAttribute('height')).to.equal('512');
+        expect(svg.getAttribute('viewBox')).to.equal(
+          getSvg(el)!.getAttribute('viewBox')
+        );
+      });
+
+      it('keeps an existing matching extension in the file name', async () => {
+        expect((await el.toImage({ fileName: 'My Code.PNG' })).name).to.equal(
+          'My Code.PNG'
+        );
+        expect(
+          (await el.toImage({ fileName: 'photo.jpg', format: 'jpeg' })).name
+        ).to.equal('photo.jpg');
+        expect((await el.toImage({ fileName: 'code.svg' })).name).to.equal(
+          'code.svg.png'
+        );
+        expect((await el.toImage({ fileName: '  ' })).name).to.equal(
+          'qr-code.png'
+        );
+      });
+
+      it('triggers a download when requested', async () => {
+        const click = stub(HTMLAnchorElement.prototype, 'click');
+
+        await el.toImage({ fileName: 'ticket', download: true });
+        expect(click.calledOnce).to.be.true;
+
+        const anchor = click.thisValues[0] as HTMLAnchorElement;
+        expect(anchor.download).to.equal('ticket.png');
+        expect(anchor.href).to.match(/^blob:/);
+      });
+
+      it('does not trigger a download by default', async () => {
+        const click = stub(HTMLAnchorElement.prototype, 'click');
+
+        await el.toImage();
+        expect(click.called).to.be.false;
+      });
+
+      it('rejects invalid options', async () => {
+        await expectRejection(el.toImage({ scale: 0 }), RangeError);
+        await expectRejection(el.toImage({ scale: -1 }), RangeError);
+        await expectRejection(el.toImage({ scale: Number.NaN }), RangeError);
+        await expectRejection(el.toImage({ scale: 1000 }), RangeError);
+        await expectRejection(
+          el.toImage({ format: 'gif' as unknown as 'png' }),
+          TypeError
+        );
+      });
+
+      it('rejects when there is no value', async () => {
+        el.value = undefined;
+        await elementUpdated(el);
+        await expectRejection(el.toImage(), Error);
       });
     });
   });

--- a/src/components/qr-code/qr-code.spec.ts
+++ b/src/components/qr-code/qr-code.spec.ts
@@ -717,6 +717,20 @@ describe('IgcQrCodeComponent', () => {
         );
       });
 
+      it('waits for a logo assigned right before the export to settle', async () => {
+        const el = await fixture<IgcQrCodeComponent>(
+          html`<igc-qr-code value="https://example.com"></igc-qr-code>`
+        );
+
+        // The broken logo only drops out of the render once its load fails,
+        // which happens after the update that `logoSrc` schedules.
+        el.logoSrc = 'data:image/png;base64,not-a-real-png';
+        const svg = await parseSvg(await el.toBlob());
+
+        expect(svg.querySelector('image')).to.be.null;
+        expect(svg.querySelector('mask')).to.be.null;
+      });
+
       it('drops the logo and its mask when the logo cannot be fetched', async () => {
         const fetchStub = stub(window, 'fetch').rejects(new TypeError('CORS'));
         const el = await fixture<IgcQrCodeComponent>(

--- a/src/components/qr-code/qr-code.ts
+++ b/src/components/qr-code/qr-code.ts
@@ -3,7 +3,7 @@ import { property, state } from 'lit/decorators.js';
 import { createAbortHandle } from '#internals/abort-handler.js';
 import { registerComponent } from '#internals/definitions/register.js';
 import { bindIf } from '#internals/utils/lit.js';
-import { clamp } from '#internals/utils/math.js';
+import { clamp, numberInRangeInclusive } from '#internals/utils/math.js';
 import { createIdGenerator } from '#internals/utils/strings.js';
 import { addThemingController } from '#theming/theming-controller.js';
 import type { QRCodeMatrixResult } from './model/matrix.js';
@@ -15,11 +15,22 @@ import {
 } from './renderer/constants.js';
 import { renderQrFinders } from './renderer/corner.js';
 import { renderQrDots } from './renderer/dots.js';
+import {
+  createSvgSnapshot,
+  downloadFile,
+  ensureExtension,
+  isExportFormat,
+  MAX_EXPORT_DIMENSION,
+  MIME_TYPES,
+  rasterizeSvg,
+  serializeSvg,
+} from './renderer/export.js';
 import { renderQrMaskAndImage } from './renderer/image.js';
 import { styles } from './themes/qr-code.base.css.js';
 import { styles as shared } from './themes/shared/qr-code.common.css.js';
 import { all } from './themes/themes.js';
 import type {
+  QrCodeExportOptions,
   QrCornerSquareStyle,
   QrDotStyle,
   QrErrorCorrectionLevel,
@@ -57,6 +68,7 @@ export default class IgcQrCodeComponent extends LitElement {
   private readonly _abortHandle = createAbortHandle();
   private readonly _maskId = nextMaskId();
   private readonly _maskUrl = `url(#${this._maskId})`;
+  private _logoReady: Promise<void> = Promise.resolve();
   private _matrixCache?: {
     value: string;
     errorLevel: QrErrorCorrectionLevel;
@@ -191,6 +203,7 @@ export default class IgcQrCodeComponent extends LitElement {
     this._abortHandle.abort();
     this._logoLoadFailed = false;
     this._logoAspectRatio = 1;
+    this._logoReady = Promise.resolve();
 
     if (!this._hasValidLogoSrc()) {
       return;
@@ -200,34 +213,30 @@ export default class IgcQrCodeComponent extends LitElement {
     const img = new Image();
     img.src = this.logoSrc!;
 
-    if (img.complete) {
+    // On error the natural dimensions are 0, so one rule covers load and error.
+    const settle = () => {
       if (img.naturalWidth && img.naturalHeight) {
         this._logoAspectRatio = img.naturalWidth / img.naturalHeight;
       } else {
         this._logoLoadFailed = true;
       }
+    };
+
+    if (img.complete) {
+      settle();
       return;
     }
 
-    img.addEventListener(
-      'load',
-      () => {
-        if (img.naturalWidth && img.naturalHeight) {
-          this._logoAspectRatio = img.naturalWidth / img.naturalHeight;
-        } else {
-          this._logoLoadFailed = true;
-        }
-      },
-      { once: true, signal }
-    );
+    this._logoReady = new Promise<void>((resolve) => {
+      const done = () => {
+        settle();
+        resolve();
+      };
 
-    img.addEventListener(
-      'error',
-      () => {
-        this._logoLoadFailed = true;
-      },
-      { once: true, signal }
-    );
+      img.addEventListener('load', done, { once: true, signal });
+      img.addEventListener('error', done, { once: true, signal });
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
   }
 
   /**
@@ -292,6 +301,88 @@ export default class IgcQrCodeComponent extends LitElement {
     const result = generateQRCodeMatrix(value, errorLevel, this.version);
     this._matrixCache = { value, errorLevel, version: this.version, result };
     return result;
+  }
+
+  /**
+   * Returns a self-contained copy of the rendered SVG with theme colors resolved
+   * and the logo inlined. Waits for a pending logo load and render first.
+   */
+  private async _createSnapshot(): Promise<SVGSVGElement> {
+    await this._logoReady;
+    await this.updateComplete;
+
+    // The SVG is rendered only when there is a value.
+    const svg = this.renderRoot.querySelector('svg');
+    if (!svg) {
+      throw new Error('Cannot export an igc-qr-code without a value.');
+    }
+
+    return createSvgSnapshot(svg);
+  }
+
+  /* blazorSuppress */
+  /**
+   * Serializes the QR code to an `image/svg+xml` blob.
+   *
+   * Theme colors are resolved to plain `fill` attributes and a logo that is not a data URI
+   * is fetched and inlined, so the blob renders identically outside the component.
+   * A logo that cannot be fetched (for example a cross-origin URL without CORS headers) is omitted.
+   *
+   * Rejects when the component has no `value`.
+   */
+  public async toBlob(): Promise<Blob> {
+    return serializeSvg(await this._createSnapshot());
+  }
+
+  /* blazorSuppress */
+  /**
+   * Exports the QR code as an image file.
+   *
+   * The `scale` option multiplies the `size` of the component: a 256px QR code exported
+   * with `scale: 2` produces a 512x512 image. When `download` is `true` the browser
+   * download dialog opens for the file.
+   *
+   * Rejects when the component has no `value`, when `format` is not supported, when `scale`
+   * is not a positive finite number, or when the resulting image exceeds the maximum canvas size.
+   */
+  public async toImage(options?: QrCodeExportOptions): Promise<File> {
+    const { fileName, format = 'png', scale = 1, download } = options ?? {};
+
+    if (!isExportFormat(format)) {
+      throw new TypeError(`Unsupported export format: ${format}.`);
+    }
+
+    if (!Number.isFinite(scale) || scale <= 0) {
+      throw new RangeError(
+        'The export scale must be a positive finite number.'
+      );
+    }
+
+    const dimension = Math.round(this.size * scale);
+    if (!numberInRangeInclusive(dimension, 1, MAX_EXPORT_DIMENSION)) {
+      throw new RangeError(
+        `The exported image side must be between 1 and ${MAX_EXPORT_DIMENSION} pixels.`
+      );
+    }
+
+    const svg = await this._createSnapshot();
+    svg.setAttribute('width', `${dimension}`);
+    svg.setAttribute('height', `${dimension}`);
+
+    const svgBlob = serializeSvg(svg);
+    const blob =
+      format === 'svg'
+        ? svgBlob
+        : await rasterizeSvg(svgBlob, dimension, format);
+
+    const name = ensureExtension(fileName?.trim() || 'qr-code', format);
+    const file = new File([blob], name, { type: MIME_TYPES[format] });
+
+    if (download) {
+      downloadFile(file);
+    }
+
+    return file;
   }
 
   protected override render() {

--- a/src/components/qr-code/qr-code.ts
+++ b/src/components/qr-code/qr-code.ts
@@ -308,6 +308,9 @@ export default class IgcQrCodeComponent extends LitElement {
    * and the logo inlined. Waits for a pending logo load and render first.
    */
   private async _createSnapshot(): Promise<SVGSVGElement> {
+    // The logo load starts in `update()`, so flush a pending update before waiting
+    // on it and then let the settled aspect ratio render.
+    await this.updateComplete;
     await this._logoReady;
     await this.updateComplete;
 

--- a/src/components/qr-code/renderer/export.ts
+++ b/src/components/qr-code/renderer/export.ts
@@ -25,7 +25,7 @@ const EXTENSIONS: Readonly<Record<QrCodeExportFormat, RegExp>> = {
 
 /** Whether `format` is one of the supported export formats. */
 export function isExportFormat(format: string): format is QrCodeExportFormat {
-  return format in MIME_TYPES;
+  return Object.hasOwn(MIME_TYPES, format);
 }
 
 /** Appends the extension of `format` to `fileName` unless it already ends with a matching one. */

--- a/src/components/qr-code/renderer/export.ts
+++ b/src/components/qr-code/renderer/export.ts
@@ -1,0 +1,198 @@
+import type { QrCodeExportFormat } from '../types.js';
+
+type QrRasterFormat = Exclude<QrCodeExportFormat, 'svg'>;
+
+/** MIME type of each export format. */
+export const MIME_TYPES: Readonly<Record<QrCodeExportFormat, string>> = {
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+};
+
+/**
+ * Maximum side length in pixels of an exported raster image.
+ * Browsers fail to allocate or encode canvases past this bound.
+ */
+export const MAX_EXPORT_DIMENSION = 16384;
+
+const EXTENSIONS: Readonly<Record<QrCodeExportFormat, RegExp>> = {
+  svg: /\.svg$/i,
+  png: /\.png$/i,
+  jpeg: /\.jpe?g$/i,
+  webp: /\.webp$/i,
+};
+
+/** Whether `format` is one of the supported export formats. */
+export function isExportFormat(format: string): format is QrCodeExportFormat {
+  return format in MIME_TYPES;
+}
+
+/** Appends the extension of `format` to `fileName` unless it already ends with a matching one. */
+export function ensureExtension(
+  fileName: string,
+  format: QrCodeExportFormat
+): string {
+  return EXTENSIONS[format].test(fileName) ? fileName : `${fileName}.${format}`;
+}
+
+function readBlobAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => resolve(reader.result as string), {
+      once: true,
+    });
+    reader.addEventListener('error', () => reject(reader.error), {
+      once: true,
+    });
+    reader.readAsDataURL(blob);
+  });
+}
+
+/** Fetches an image URL and returns it as a data URI, or `null` when it cannot be fetched. */
+async function fetchImageAsDataUrl(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url);
+    const blob = response.ok ? await response.blob() : null;
+    return blob?.type.startsWith('image/') ? readBlobAsDataUrl(blob) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Copies the computed `fill` of every `part` element from the live SVG onto the
+ * matching element of the clone as a presentation attribute, and strips the `part`
+ * attributes. The clone renders identically outside the shadow root, where the
+ * component stylesheet and its CSS custom properties are not available.
+ *
+ * `fill` is the only property the component theme sets on its parts; extend this
+ * when `themes/shared/qr-code.common.scss` starts to style more.
+ */
+function resolveStyles(source: SVGSVGElement, clone: SVGSVGElement): void {
+  const liveParts = source.querySelectorAll<SVGElement>('[part]');
+  const cloneParts = clone.querySelectorAll<SVGElement>('[part]');
+
+  for (const [index, element] of liveParts.entries()) {
+    const target = cloneParts[index];
+    const { fill } = getComputedStyle(element);
+
+    if (fill) {
+      target.setAttribute('fill', fill);
+    }
+    target.removeAttribute('part');
+  }
+}
+
+/**
+ * Replaces a non data-URI logo `href` with an inlined data URI. An SVG loaded as an image
+ * cannot fetch external resources, so the logo must be embedded for the export to render it.
+ *
+ * When the logo cannot be fetched (for example, a cross-origin URL without CORS headers),
+ * the logo, its mask and the mask definition are removed so the exported code has no hole.
+ */
+async function inlineLogo(clone: SVGSVGElement): Promise<void> {
+  const image = clone.querySelector('image');
+  const href = image?.getAttribute('href');
+
+  if (!image || !href || href.startsWith('data:')) {
+    return;
+  }
+
+  const dataUrl = await fetchImageAsDataUrl(href);
+
+  if (dataUrl) {
+    image.setAttribute('href', dataUrl);
+  } else {
+    image.remove();
+    clone.querySelector('[mask]')?.removeAttribute('mask');
+    clone.querySelector('defs')?.remove();
+  }
+}
+
+/**
+ * Creates a self-contained copy of the component SVG: theme colors are resolved
+ * to presentation attributes and the logo is inlined as a data URI.
+ */
+export async function createSvgSnapshot(
+  source: SVGSVGElement
+): Promise<SVGSVGElement> {
+  const clone = source.cloneNode(true) as SVGSVGElement;
+  resolveStyles(source, clone);
+  await inlineLogo(clone);
+  return clone;
+}
+
+/** Serializes an SVG element into an `image/svg+xml` blob. */
+export function serializeSvg(svg: SVGSVGElement): Blob {
+  const markup = new XMLSerializer().serializeToString(svg);
+  return new Blob([markup], { type: `${MIME_TYPES.svg};charset=utf-8` });
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image), { once: true });
+    image.addEventListener(
+      'error',
+      () => reject(new Error('Failed to load the QR code SVG for export.')),
+      { once: true }
+    );
+    image.src = url;
+  });
+}
+
+/**
+ * Rasterize an SVG blob into a square bitmap of `dimension` pixels per side
+ * and encodes it in the requested format.
+ */
+export async function rasterizeSvg(
+  svgBlob: Blob,
+  dimension: number,
+  format: QrRasterFormat
+): Promise<Blob> {
+  const url = URL.createObjectURL(svgBlob);
+
+  try {
+    const image = await loadImage(url);
+    const canvas = document.createElement('canvas');
+    canvas.width = dimension;
+    canvas.height = dimension;
+
+    const context = canvas.getContext('2d')!;
+
+    if (format === 'jpeg') {
+      // JPEG has no alpha channel; paint white under transparent backgrounds.
+      context.fillStyle = '#fff';
+      context.fillRect(0, 0, dimension, dimension);
+    }
+
+    context.drawImage(image, 0, 0, dimension, dimension);
+
+    const type = MIME_TYPES[format];
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, type)
+    );
+
+    // Browsers that cannot encode a format silently fall back to PNG.
+    if (!blob || blob.type !== type) {
+      throw new Error(`The browser cannot encode ${type} images.`);
+    }
+
+    return blob;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/** Triggers the browser download dialog for the given file. */
+export function downloadFile(file: File): void {
+  const url = URL.createObjectURL(file);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = file.name;
+  anchor.click();
+
+  // Revoke after the current task so the navigation has captured the URL.
+  setTimeout(() => URL.revokeObjectURL(url));
+}

--- a/src/components/qr-code/types.ts
+++ b/src/components/qr-code/types.ts
@@ -18,3 +18,31 @@ export type QrErrorCorrectionLevel = 'L' | 'M' | 'Q' | 'H';
  * - `numeric` - digits only; `alphanumeric` - digits + uppercase letters + a few symbols; `byte` - arbitrary UTF-8.
  */
 export type QrEncodingMode = 'numeric' | 'alphanumeric' | 'byte';
+
+/** Output format of an exported QR code. */
+export type QrCodeExportFormat = 'svg' | 'png' | 'jpeg' | 'webp';
+
+/** Options for exporting the QR code to a file. */
+export interface QrCodeExportOptions {
+  /**
+   * The name of the exported file. The extension of the format is appended when the name does not end with it.
+   * @default 'qr-code'
+   */
+  fileName?: string;
+  /**
+   * The output format.
+   * @default 'png'
+   */
+  format?: QrCodeExportFormat;
+  /**
+   * Multiplier applied to the `size` of the component. A 256px QR code with a `scale` of 2 exports as a 512x512 image.
+   * For `svg`, the multiplier applies to the `width` and `height` attributes while the `viewBox` is unchanged.
+   * @default 1
+   */
+  scale?: number;
+  /**
+   * Whether to open the browser download dialog for the exported file.
+   * @default false
+   */
+  download?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,8 @@ export type {
   QrErrorCorrectionLevel,
   QrDotStyle,
   QrCornerSquareStyle,
+  QrCodeExportFormat,
+  QrCodeExportOptions,
 } from './components/qr-code/types.js';
 
 // Internal exports for other packages

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,11 +215,11 @@ export type {
 } from './components/icon/registry/types.js';
 export type * from './components/chat/types.js';
 export type {
-  QrErrorCorrectionLevel,
-  QrDotStyle,
-  QrCornerSquareStyle,
   QrCodeExportFormat,
   QrCodeExportOptions,
+  QrCornerSquareStyle,
+  QrDotStyle,
+  QrErrorCorrectionLevel,
 } from './components/qr-code/types.js';
 
 // Internal exports for other packages

--- a/stories/qr-code.stories.ts
+++ b/stories/qr-code.stories.ts
@@ -545,13 +545,22 @@ export const Sizes: Story = {
 export const Export: Story = {
   argTypes: disableStoryControls(metadata),
   render: () => {
-    const exportCode = (format: QrCodeExportFormat, scale: number) =>
-      document.querySelector<IgcQrCodeComponent>('#export-qr')!.toImage({
-        fileName: `ignite-ui-qr-${scale}x`,
-        format,
-        scale,
-        download: true,
-      });
+    const exportCode = async (format: QrCodeExportFormat, scale: number) => {
+      const qr = document.querySelector<IgcQrCodeComponent>('#export-qr')!;
+      const status = document.querySelector('#export-status')!;
+
+      try {
+        const file = await qr.toImage({
+          fileName: `ignite-ui-qr-${scale}x`,
+          format,
+          scale,
+          download: true,
+        });
+        status.textContent = `Exported ${file.name} (${file.type})`;
+      } catch (error) {
+        status.textContent = `Export failed: ${(error as Error).message}`;
+      }
+    };
 
     return html`
       <div
@@ -585,6 +594,7 @@ export const Export: Story = {
             Download WebP (4x)
           </igc-button>
         </div>
+        <span id="export-status"></span>
       </div>
     `;
   },

--- a/stories/qr-code.stories.ts
+++ b/stories/qr-code.stories.ts
@@ -1,9 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { defineComponents, IgcQrCodeComponent } from 'igniteui-webcomponents';
+import {
+  defineComponents,
+  IgcButtonComponent,
+  IgcQrCodeComponent,
+  type QrCodeExportFormat,
+} from 'igniteui-webcomponents';
 import { html } from 'lit';
 import { disableStoryControls } from './story.js';
 
-defineComponents(IgcQrCodeComponent);
+defineComponents(IgcButtonComponent, IgcQrCodeComponent);
 
 // region default
 const metadata: Meta<IgcQrCodeComponent> = {
@@ -535,4 +540,52 @@ export const Sizes: Story = {
       </div>
     </div>
   `,
+};
+
+export const Export: Story = {
+  argTypes: disableStoryControls(metadata),
+  render: () => {
+    const exportCode = (format: QrCodeExportFormat, scale: number) =>
+      document.querySelector<IgcQrCodeComponent>('#export-qr')!.toImage({
+        fileName: `ignite-ui-qr-${scale}x`,
+        format,
+        scale,
+        download: true,
+      });
+
+    return html`
+      <div
+        style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;"
+      >
+        <igc-qr-code
+          id="export-qr"
+          value="https://www.infragistics.com/products/ignite-ui-web-components"
+          size="256"
+          dot-style="rounded"
+          square-style="rounded"
+          error-level="H"
+          logo-src="https://static.infragistics.com/marketing/Website/products/ignite-ui/shared/ignite-ui-logo-light-background-horizontal.svg"
+          logo-size="0.75"
+          logo-margin="6"
+        ></igc-qr-code>
+        <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+          <igc-button @click=${() => exportCode('svg', 1)}
+            >Download SVG</igc-button
+          >
+          <igc-button @click=${() => exportCode('png', 1)}>
+            Download PNG (1x)
+          </igc-button>
+          <igc-button @click=${() => exportCode('png', 2)}>
+            Download PNG (2x)
+          </igc-button>
+          <igc-button @click=${() => exportCode('jpeg', 2)}>
+            Download JPEG (2x)
+          </igc-button>
+          <igc-button @click=${() => exportCode('webp', 4)}>
+            Download WebP (4x)
+          </igc-button>
+        </div>
+      </div>
+    `;
+  },
 };


### PR DESCRIPTION
## Description

- `toBlob()` serializes the rendered code to an `image/svg+xml` blob with theme colors resolved to fill attributes and a remote logo inlined as a data URI. A logo that cannot be fetched is dropped with its mask.
- `toImage(options)` exports a File in svg, png, jpeg or webp format. `scale` multiplies the component size, `download` opens the browser download dialog.
- Export QrCodeExportFormat and QrCodeExportOptions from the entry point.
- Add spec coverage, an Export story and a changelog entry.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
